### PR TITLE
Persist editor state, interactive breadcrumb bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 - Fix project-wide diagnostics not loading — transport-level handling of vtsls `workspace/configuration` requests so `enableProjectDiagnostics` takes effect during initialization, not after
 - Fix diagnostics batch crash when first problems arrive for a task
 - @mentioned files render as inline badges in the input and sent messages — hover to preview with syntax highlighting, click to open in the editor
+- Media viewer — images, video, and audio files open natively from the file tree with proper rendering instead of failing as binary
+- Markdown preview — `.md` files render as styled WYSIWYG with a preview/edit toggle to switch between rendered output and the code editor
+- SVG viewer — `.svg` files render visually with a preview/edit toggle for the XML source
+- Hover previews on @mentioned files now support media (images, video, audio), rendered markdown, and SVG visual previews
 
 ## 0.4.2 — 2026-04-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@
 - Markdown preview — `.md` files render as styled WYSIWYG with a preview/edit toggle to switch between rendered output and the code editor
 - SVG viewer — `.svg` files render visually with a preview/edit toggle for the XML source
 - Hover previews on @mentioned files now support media (images, video, audio), rendered markdown, and SVG visual previews
+- Cursor position, selection, and scroll position are preserved when switching between file tabs
+- Undo/redo history persists across tab switches — Cmd+Z works on the full edit history after switching back
+- Breadcrumb path bar at the top of the editor — click any segment to see sibling files/folders and jump to them
+- Open tabs, active file, and MRU stack persist to localStorage per task — survives app restart
+- Editor auto-focuses when switching tabs so the cursor is visible and keyboard input works immediately
+- Fix closing a dirty tab without saving showing stale edits when reopened
 
 ## 0.4.2 — 2026-04-11
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -76,9 +76,8 @@ Small UX issues noticed in daily use. No schedule — fix when you have a spare 
 - [ ] Persists current message in task
 - [X] Find in session
 - [X] @mentioned files ship in input and sent messages
-- [ ] Media viewer & markdown preview (WYSIWYG)
+- [X] Media viewer & markdown preview (WYSIWYG)
 - [ ] Show file errors in warnings in the scrollbar
-the typescript server seems to need me to call it (by clicking on get definition or something) to start working. is that true?
 
 ---
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1935,6 +1935,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5146,6 +5152,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
+ "http-range",
  "jni",
  "libc",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = ["macos-private-api"] }
+tauri = { version = "2", features = ["protocol-asset", "macos-private-api"] }
 tauri-plugin-opener = "2"
 tauri-plugin-shell = "2"
 tauri-plugin-sql = { version = "2", features = ["sqlite"] }

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -1521,6 +1521,30 @@ pub async fn read_worktree_file(
 }
 
 #[tauri::command]
+pub async fn resolve_worktree_file_path(
+    pool: State<'_, SqlitePool>,
+    task_id: String,
+    relative_path: String,
+) -> Result<String, String> {
+    let t = db::get_task(pool.inner(), &task_id)
+        .await?
+        .ok_or_else(|| format!("Task {task_id} not found"))?;
+
+    let full_path = std::path::Path::new(&t.worktree_path).join(&relative_path);
+
+    let canonical_base = std::fs::canonicalize(&t.worktree_path)
+        .map_err(|e| format!("Cannot resolve worktree: {e}"))?;
+    let canonical_file = std::fs::canonicalize(&full_path)
+        .map_err(|e| format!("Cannot resolve file: {e}"))?;
+
+    if !canonical_file.starts_with(&canonical_base) {
+        return Err("Path escapes worktree boundary".into());
+    }
+
+    Ok(canonical_file.to_string_lossy().into_owned())
+}
+
+#[tauri::command]
 pub async fn write_text_file(
     pool: State<'_, SqlitePool>,
     task_id: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -266,6 +266,7 @@ pub fn run() {
             // File tree
             ipc::list_directory,
             ipc::read_worktree_file,
+            ipc::resolve_worktree_file_path,
             ipc::write_text_file,
             ipc::watch_worktree,
             ipc::unwatch_worktree,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -24,7 +24,14 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": null,
+      "assetProtocol": {
+        "enable": true,
+        "scope": {
+          "allow": ["/**"],
+          "requireLiteralLeadingDot": false
+        }
+      }
     }
   },
   "bundle": {

--- a/src/components/BreadcrumbBar.tsx
+++ b/src/components/BreadcrumbBar.tsx
@@ -1,0 +1,250 @@
+import { Component, Show, For, createEffect, createSignal, onCleanup } from 'solid-js'
+import { ChevronRight, ChevronDown, Folder, FolderOpen } from 'lucide-solid'
+import { getFileIcon } from '../lib/fileIcons'
+import { getDirContents, loadDirectory, openFilePinned } from '../store/files'
+import type { FileEntry } from '../types'
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function sortEntries(entries: FileEntry[]): FileEntry[] {
+  return [...entries].sort((a, b) => {
+    if (a.isDir !== b.isDir) return a.isDir ? -1 : 1
+    return a.name.localeCompare(b.name)
+  })
+}
+
+/** Load directory contents, returning sorted entries. */
+async function loadSorted(taskId: string, dir: string): Promise<FileEntry[]> {
+  let cached = getDirContents(taskId, dir)
+  if (!cached) {
+    await loadDirectory(taskId, dir)
+    cached = getDirContents(taskId, dir)
+  }
+  return cached ? sortEntries(cached) : []
+}
+
+// ── Tree node (recursive) ────────────────────────────────────────────
+
+function TreeNode(props: {
+  taskId: string
+  entry: FileEntry
+  depth: number
+  expandedSet: Set<string>
+  onToggle: (path: string) => void
+  onPick: (entry: FileEntry) => void
+  currentPath: string
+}) {
+  const isDir = () => props.entry.isDir
+  const expanded = () => props.expandedSet.has(props.entry.relativePath)
+  const isCurrent = () => props.entry.relativePath === props.currentPath
+
+  const children = () => {
+    if (!isDir() || !expanded()) return []
+    const cached = getDirContents(props.taskId, props.entry.relativePath)
+    return cached ? sortEntries(cached) : []
+  }
+
+  const handleClick = () => {
+    if (isDir()) {
+      props.onToggle(props.entry.relativePath)
+    } else {
+      props.onPick(props.entry)
+    }
+  }
+
+  const Icon = () => {
+    if (isDir()) {
+      const I = expanded() ? FolderOpen : Folder
+      return <I size={14} class="shrink-0 text-accent" />
+    }
+    const I = getFileIcon(props.entry.name)
+    return <I size={14} class="shrink-0" />
+  }
+
+  return (
+    <>
+      <button
+        data-current={isCurrent()}
+        class="w-full flex items-center gap-1 py-0.5 text-[12px] text-left transition-colors"
+        classList={{
+          'bg-[#2c313a] text-text-secondary': isCurrent(),
+          'text-[#abb2bf] hover:bg-[#2c313a]': !isCurrent(),
+        }}
+        style={{ 'padding-left': `${props.depth * 16 + 8}px`, 'padding-right': '12px' }}
+        onClick={handleClick}
+      >
+        <span class="w-3 shrink-0 flex items-center justify-center">
+          <Show when={isDir()}>
+            {expanded()
+              ? <ChevronDown size={10} class="text-text-dim" />
+              : <ChevronRight size={10} class="text-text-dim" />
+            }
+          </Show>
+        </span>
+        <Icon />
+        <span class="truncate ml-0.5">{props.entry.name}</span>
+      </button>
+      <Show when={isDir() && expanded()}>
+        <For each={children()}>
+          {(child) => (
+            <TreeNode
+              taskId={props.taskId}
+              entry={child}
+              depth={props.depth + 1}
+              expandedSet={props.expandedSet}
+              onToggle={props.onToggle}
+              onPick={props.onPick}
+              currentPath={props.currentPath}
+            />
+          )}
+        </For>
+      </Show>
+    </>
+  )
+}
+
+// ── Breadcrumb bar ───────────────────────────────────────────────────
+
+export const BreadcrumbBar: Component<{
+  taskId: string
+  currentPath: string
+  class?: string
+}> = (props) => {
+  const [openIdx, setOpenIdx] = createSignal(-1)
+  const [entries, setEntries] = createSignal<FileEntry[]>([])
+  const [dropPos, setDropPos] = createSignal<{ left: number; top: number }>({ left: 0, top: 0 })
+  // Local expand state for the tree dropdown (independent from the sidebar FileTree)
+  const [expandedSet, setExpandedSet] = createSignal<Set<string>>(new Set())
+
+  let barRef: HTMLDivElement | undefined
+  let dropRef: HTMLDivElement | undefined
+
+  const parts = () => props.currentPath.split('/')
+  const parentDirOf = (segmentIdx: number) => parts().slice(0, segmentIdx).join('/')
+
+  const toggleExpand = async (path: string) => {
+    const next = new Set(expandedSet())
+    if (next.has(path)) {
+      next.delete(path)
+    } else {
+      next.add(path)
+      // Ensure children are loaded
+      if (!getDirContents(props.taskId, path)) {
+        await loadDirectory(props.taskId, path)
+      }
+    }
+    setExpandedSet(next)
+  }
+
+  const openDropdown = async (segmentIdx: number, btnEl: HTMLElement) => {
+    if (openIdx() === segmentIdx) { setOpenIdx(-1); return }
+
+    const parentDir = parentDirOf(segmentIdx)
+    const sorted = await loadSorted(props.taskId, parentDir)
+    setEntries(sorted)
+
+    // Pre-expand the path to the current file
+    const pathParts = parts()
+    const toExpand = new Set<string>()
+    // Expand each ancestor directory that's a child of the dropdown's parent
+    for (let i = segmentIdx; i < pathParts.length - 1; i++) {
+      const ancestorPath = pathParts.slice(0, i + 1).join('/')
+      toExpand.add(ancestorPath)
+      // Ensure each expanded dir is loaded
+      if (!getDirContents(props.taskId, ancestorPath)) {
+        await loadDirectory(props.taskId, ancestorPath)
+      }
+    }
+    setExpandedSet(toExpand)
+
+    const rect = btnEl.getBoundingClientRect()
+    setDropPos({ left: rect.left, top: rect.bottom + 2 })
+    setOpenIdx(segmentIdx)
+  }
+
+  const close = () => setOpenIdx(-1)
+
+  const handlePick = (entry: FileEntry) => {
+    close()
+    openFilePinned(props.taskId, entry.relativePath, entry.name)
+  }
+
+  // Close on click outside
+  const onPointerDown = (e: PointerEvent) => {
+    if (dropRef?.contains(e.target as Node)) return
+    if (barRef?.contains(e.target as Node)) return
+    close()
+  }
+  createEffect(() => {
+    if (openIdx() >= 0) document.addEventListener('pointerdown', onPointerDown)
+    else document.removeEventListener('pointerdown', onPointerDown)
+  })
+  onCleanup(() => document.removeEventListener('pointerdown', onPointerDown))
+
+  const onKeyDown = (e: KeyboardEvent) => { if (e.key === 'Escape') close() }
+  createEffect(() => {
+    if (openIdx() >= 0) document.addEventListener('keydown', onKeyDown)
+    else document.removeEventListener('keydown', onKeyDown)
+  })
+  onCleanup(() => document.removeEventListener('keydown', onKeyDown))
+
+  const scrollToCurrent = (el: HTMLDivElement) => {
+    requestAnimationFrame(() => {
+      const active = el.querySelector('[data-current="true"]') as HTMLElement | null
+      if (active) active.scrollIntoView({ block: 'nearest' })
+    })
+  }
+
+  return (
+    <div
+      ref={barRef}
+      class={props.class ?? 'flex items-center gap-0.5 text-[11px] text-text-dim overflow-hidden'}
+    >
+      <For each={parts()}>
+        {(segment, i) => (
+          <>
+            <Show when={i() > 0}>
+              <ChevronRight size={10} class="shrink-0 text-text-dim/50" />
+            </Show>
+            <button
+              class="bc-seg shrink-0 hover:text-text-secondary cursor-pointer rounded px-0.5 transition-colors"
+              classList={{
+                'text-text-secondary': i() === parts().length - 1,
+                'bg-[#2c313a]': openIdx() === i(),
+              }}
+              onClick={(e) => openDropdown(i(), e.currentTarget)}
+            >
+              {segment}
+            </button>
+          </>
+        )}
+      </For>
+
+      <Show when={openIdx() >= 0}>
+        <div
+          ref={(el) => { dropRef = el; scrollToCurrent(el) }}
+          class="fixed z-100 bg-[#21252b] border border-[#181a1f] rounded-lg py-1 min-w-56 max-h-80 overflow-y-auto"
+          style={{
+            left: `${dropPos().left}px`,
+            top: `${dropPos().top}px`,
+            'box-shadow': '0 6px 24px rgba(0,0,0,0.5)',
+          }}
+        >
+          <For each={entries()}>
+            {(entry) => (
+              <TreeNode
+                taskId={props.taskId}
+                entry={entry}
+                depth={0}
+                expandedSet={expandedSet()}
+                onToggle={toggleExpand}
+                onPick={handlePick}
+                currentPath={props.currentPath}
+              />
+            )}
+          </For>
+        </div>
+      </Show>
+    </div>
+  )
+}

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -25,7 +25,7 @@ import { xml } from '@codemirror/lang-xml'
 import { yaml } from '@codemirror/lang-yaml'
 import { sass } from '@codemirror/lang-sass'
 import * as ipc from '../lib/ipc'
-import { setTabDirty, getCachedContent, setCachedContent, getCachedOriginal, setCachedOriginal, pendingGoToLine, consumeGoToLine } from '../store/files'
+import { setTabDirty, getCachedContent, setCachedContent, getCachedOriginal, setCachedOriginal, pendingGoToLine, consumeGoToLine, onTabClose, onTaskCleanup } from '../store/files'
 import { getLspClient, isLspSupported, registerEditorView, unregisterEditorView } from '../lib/lsp'
 
 interface Props {
@@ -503,6 +503,31 @@ function buildExtensions(path: string, onDocChange: (content: string) => void, o
   return exts
 }
 
+// ── Editor state cache — preserves cursor, selection, and undo/redo across tab switches ──
+const editorStateCache = new Map<string, EditorState>()
+const scrollPositionCache = new Map<string, { top: number; left: number }>()
+
+function cacheKey(taskId: string, relativePath: string) {
+  return `${taskId}:${relativePath}`
+}
+
+export function clearEditorStateCache(taskId: string, relativePath: string) {
+  const key = cacheKey(taskId, relativePath)
+  editorStateCache.delete(key)
+  scrollPositionCache.delete(key)
+}
+
+/** Clear all cached editor state for a task (call on task deletion/archive). */
+export function clearAllEditorStateForTask(taskId: string) {
+  const prefix = `${taskId}:`
+  for (const key of editorStateCache.keys()) {
+    if (key.startsWith(prefix)) editorStateCache.delete(key)
+  }
+  for (const key of scrollPositionCache.keys()) {
+    if (key.startsWith(prefix)) scrollPositionCache.delete(key)
+  }
+}
+
 // ── Component ──────────────────────────────────────────────────────────
 export const CodeEditor: Component<Props> = (props) => {
   const [originalContent, setOriginalContent] = createSignal('')
@@ -519,6 +544,13 @@ export const CodeEditor: Component<Props> = (props) => {
   let currentContent = ''
   // Current file URI for LSP view registration
   let currentFileUri = ''
+  // Current cache key for saving/restoring editor state
+  let currentFileKey = ''
+
+  // Clear editor state cache when a tab is closed or task is deleted
+  const unsubTabClose = onTabClose(clearEditorStateCache)
+  const unsubTaskCleanup = onTaskCleanup(clearAllEditorStateForTask)
+  onCleanup(() => { unsubTabClose(); unsubTaskCleanup() })
 
   const save = async () => {
     try {
@@ -557,6 +589,16 @@ export const CodeEditor: Component<Props> = (props) => {
 
   // ── Editor lifecycle ──────────────────────────────────────────────
   const createEditor = async (doc: string, path: string, worktreePath: string) => {
+    // Save outgoing editor state (cursor, selection, undo history, scroll)
+    if (editorView && currentFileKey) {
+      editorStateCache.set(currentFileKey, editorView.state)
+      scrollPositionCache.set(currentFileKey, {
+        top: editorView.scrollDOM.scrollTop,
+        left: editorView.scrollDOM.scrollLeft,
+      })
+    }
+
+    // Destroy previous instance
     if (editorView) {
       if (currentFileUri) unregisterEditorView(currentFileUri)
       editorView.destroy()
@@ -565,28 +607,48 @@ export const CodeEditor: Component<Props> = (props) => {
 
     if (!editorParentRef) return
 
-    const extensions = buildExtensions(
-      path,
-      (content) => {
-        currentContent = content
-        setCachedContent(props.taskId, props.relativePath, content)
-        setTabDirty(props.taskId, props.relativePath, content !== originalContent())
-      },
-      save,
-    )
+    const newKey = cacheKey(props.taskId, path)
+    currentFileKey = newKey
 
-    if (isLspSupported(path)) {
-      try {
-        const client = await getLspClient(props.taskId, worktreePath)
-        const fileUri = `file://${worktreePath}/${path}`
-        extensions.push(client.plugin(fileUri, 'typescript'))
-      } catch (e) {
-        console.warn('LSP not available:', e)
+    // Try to restore cached EditorState (preserves cursor + undo/redo)
+    const cachedState = editorStateCache.get(newKey)
+    if (cachedState && cachedState.doc.toString() === doc) {
+      editorView = new EditorView({ state: cachedState, parent: editorParentRef })
+
+      // Restore scroll position after DOM layout
+      const savedScroll = scrollPositionCache.get(newKey)
+      if (savedScroll) {
+        requestAnimationFrame(() => {
+          editorView?.scrollDOM.scrollTo(savedScroll.left, savedScroll.top)
+        })
       }
-    }
+    } else {
+      // Fresh state — first open or after cache was cleared
+      const extensions = buildExtensions(
+        path,
+        (content) => {
+          currentContent = content
+          setCachedContent(props.taskId, props.relativePath, content)
+          setTabDirty(props.taskId, props.relativePath, content !== originalContent())
+        },
+        save,
+      )
 
-    const state = EditorState.create({ doc, extensions })
-    editorView = new EditorView({ state, parent: editorParentRef })
+      // Add LSP plugin for JS/TS files
+      if (isLspSupported(path)) {
+        try {
+          const client = await getLspClient(props.taskId, worktreePath)
+          const fileUri = `file://${worktreePath}/${path}`
+          extensions.push(client.plugin(fileUri, 'typescript'))
+        } catch (e) {
+          console.warn('LSP not available:', e)
+          // Editor works fine without LSP
+        }
+      }
+
+      const state = EditorState.create({ doc, extensions })
+      editorView = new EditorView({ state, parent: editorParentRef })
+    }
 
     if (worktreePath) {
       currentFileUri = `file://${worktreePath}/${path}`
@@ -595,6 +657,9 @@ export const CodeEditor: Component<Props> = (props) => {
 
     // Apply any pending go-to-line now that the editor is ready
     drainPendingGoToLine()
+
+    // Auto-focus the editor so the cursor is visible and keyboard input works
+    editorView.focus()
   }
 
   // Load file content and (re)create the editor when the file changes
@@ -618,6 +683,8 @@ export const CodeEditor: Component<Props> = (props) => {
     try {
       const task = await ipc.getTask(props.taskId)
       if (!task) return
+      // Loading from disk — clear any stale editor state
+      clearEditorStateCache(props.taskId, path)
       const fullPath = `${task.worktreePath}/${path}`
       const text = await ipc.readTextFile(fullPath)
       currentContent = text
@@ -635,7 +702,15 @@ export const CodeEditor: Component<Props> = (props) => {
     }
   }))
 
+  // Cleanup — save state before destroying so it survives component remount
   onCleanup(() => {
+    if (editorView && currentFileKey) {
+      editorStateCache.set(currentFileKey, editorView.state)
+      scrollPositionCache.set(currentFileKey, {
+        top: editorView.scrollDOM.scrollTop,
+        left: editorView.scrollDOM.scrollLeft,
+      })
+    }
     if (currentFileUri) unregisterEditorView(currentFileUri)
     if (editorView) {
       editorView.destroy()

--- a/src/components/FileMentionBadge.tsx
+++ b/src/components/FileMentionBadge.tsx
@@ -1,9 +1,12 @@
-import { Component, Show, createSignal, onCleanup } from 'solid-js'
+import { Component, Show, Switch, Match, createSignal, onCleanup } from 'solid-js'
 import { Portal } from 'solid-js/web'
 import { computePosition, flip, shift, offset } from '@floating-ui/dom'
+import { convertFileSrc } from '@tauri-apps/api/core'
+import { marked } from 'marked'
 import { getFileIcon } from '../lib/fileIcons'
 import { highlightCode, langFromPath } from '../lib/highlighter'
-import { readWorktreeFile } from '../lib/ipc'
+import { getPreviewType, isMediaType } from '../lib/fileTypes'
+import { readWorktreeFile, resolveWorktreeFilePath } from '../lib/ipc'
 import { openFile } from '../store/files'
 import { X, ExternalLink } from 'lucide-solid'
 
@@ -14,13 +17,20 @@ interface Props {
   size?: 'sm' | 'md'
 }
 
-// Module-level cache: taskId:relativePath → content + highlighted HTML or error
-const contentCache = new Map<string, { content?: string; html?: string; error?: string }>()
+type PreviewData =
+  | { type: 'code'; html: string }
+  | { type: 'markdown'; html: string }
+  | { type: 'svg'; dataUrl: string }
+  | { type: 'media'; mediaType: 'image' | 'video' | 'audio'; assetUrl: string }
+  | { type: 'error'; error: string }
+
+// Module-level cache: taskId:relativePath → preview data
+const contentCache = new Map<string, PreviewData>()
 
 export const FileMentionBadge: Component<Props> = (props) => {
   const [hovered, setHovered] = createSignal(false)
   const [loading, setLoading] = createSignal(false)
-  const [preview, setPreview] = createSignal<{ content?: string; html?: string; error?: string } | null>(null)
+  const [preview, setPreview] = createSignal<PreviewData | null>(null)
   const [floatingStyle, setFloatingStyle] = createSignal<{ top: string; left: string }>({ top: '0px', left: '0px' })
 
   let leaveTimer: ReturnType<typeof setTimeout> | undefined
@@ -59,15 +69,33 @@ export const FileMentionBadge: Component<Props> = (props) => {
 
     setLoading(true)
     try {
-      const content = await readWorktreeFile(props.taskId, props.filePath)
-      const lang = langFromPath(props.filePath)
-      const html = await highlightCode(content, lang)
-      const result = { content, html }
+      const pvType = getPreviewType(props.filePath)
+
+      let result: PreviewData
+
+      if (isMediaType(pvType)) {
+        const absPath = await resolveWorktreeFilePath(props.taskId, props.filePath)
+        const assetUrl = convertFileSrc(absPath)
+        result = { type: 'media', mediaType: pvType as 'image' | 'video' | 'audio', assetUrl }
+      } else if (pvType === 'svg') {
+        const content = await readWorktreeFile(props.taskId, props.filePath)
+        const dataUrl = `data:image/svg+xml,${encodeURIComponent(content)}`
+        result = { type: 'svg', dataUrl }
+      } else if (pvType === 'markdown') {
+        const content = await readWorktreeFile(props.taskId, props.filePath)
+        const html = marked.parse(content, { async: false }) as string
+        result = { type: 'markdown', html }
+      } else {
+        const content = await readWorktreeFile(props.taskId, props.filePath)
+        const lang = langFromPath(props.filePath)
+        const html = await highlightCode(content, lang)
+        result = { type: 'code', html }
+      }
+
       contentCache.set(key, result)
       setPreview(result)
     } catch (e) {
-      const error = String(e)
-      const result = { error }
+      const result: PreviewData = { type: 'error', error: String(e) }
       contentCache.set(key, result)
       setPreview(result)
     } finally {
@@ -92,6 +120,13 @@ export const FileMentionBadge: Component<Props> = (props) => {
   }
 
   const Icon = getFileIcon(filename())
+
+  // Derived accessors for clean type narrowing
+  const previewCode = () => { const p = preview(); return p?.type === 'code' ? p : null }
+  const previewMd = () => { const p = preview(); return p?.type === 'markdown' ? p : null }
+  const previewSvg = () => { const p = preview(); return p?.type === 'svg' ? p : null }
+  const previewMedia = () => { const p = preview(); return p?.type === 'media' ? p : null }
+  const previewError = () => { const p = preview(); return p?.type === 'error' ? p : null }
 
   return (
     <>
@@ -150,19 +185,86 @@ export const FileMentionBadge: Component<Props> = (props) => {
                 <div class="px-3 py-4 text-[11px] text-text-dim text-center">Loading…</div>
               }
             >
-              <Show
-                when={preview()?.html}
-                fallback={
-                  <div class="px-3 py-4 text-[11px] text-text-dim text-center">
-                    {preview()?.error ?? 'No preview available'}
-                  </div>
-                }
-              >
-                <div
-                  class="overflow-auto max-h-80 [&_pre]:!bg-transparent [&_pre]:!m-0 [&_pre]:px-3 [&_pre]:py-2 [&_code]:!text-[11px] [&_code]:!leading-relaxed"
-                  innerHTML={preview()!.html}
-                />
-              </Show>
+              <Switch fallback={
+                <div class="px-3 py-4 text-[11px] text-text-dim text-center">No preview available</div>
+              }>
+                <Match when={previewCode()}>
+                  {(p) => (
+                    <div
+                      class="overflow-auto max-h-80 [&_pre]:!bg-transparent [&_pre]:!m-0 [&_pre]:px-3 [&_pre]:py-2 [&_code]:!text-[11px] [&_code]:!leading-relaxed"
+                      innerHTML={p().html}
+                    />
+                  )}
+                </Match>
+
+                <Match when={previewMd()}>
+                  {(p) => (
+                    <div
+                      class="overflow-auto max-h-80 px-3 py-2 text-xs text-text-primary leading-relaxed prose-verun select-text break-words"
+                      innerHTML={p().html}
+                    />
+                  )}
+                </Match>
+
+                <Match when={previewSvg()}>
+                  {(p) => (
+                    <div class="overflow-auto max-h-80 flex items-center justify-center p-3 bg-[#0a0a0a]">
+                      <img
+                        src={p().dataUrl}
+                        alt={filename()}
+                        class="max-w-full max-h-72 object-contain"
+                      />
+                    </div>
+                  )}
+                </Match>
+
+                <Match when={previewMedia()?.mediaType === 'image' && previewMedia()}>
+                  {(p) => (
+                    <div class="overflow-auto max-h-80 flex items-center justify-center p-2 bg-[#0a0a0a]">
+                      <img
+                        src={p().assetUrl}
+                        alt={filename()}
+                        class="max-w-full max-h-72 object-contain rounded"
+                        loading="lazy"
+                      />
+                    </div>
+                  )}
+                </Match>
+
+                <Match when={previewMedia()?.mediaType === 'video' && previewMedia()}>
+                  {(p) => (
+                    <div class="overflow-hidden max-h-80 p-2">
+                      <video
+                        src={p().assetUrl}
+                        controls
+                        preload="metadata"
+                        class="max-w-full max-h-72 rounded"
+                      />
+                    </div>
+                  )}
+                </Match>
+
+                <Match when={previewMedia()?.mediaType === 'audio' && previewMedia()}>
+                  {(p) => (
+                    <div class="px-3 py-4 flex items-center justify-center">
+                      <audio
+                        src={p().assetUrl}
+                        controls
+                        preload="metadata"
+                        class="w-full"
+                      />
+                    </div>
+                  )}
+                </Match>
+
+                <Match when={previewError()}>
+                  {(p) => (
+                    <div class="px-3 py-4 text-[11px] text-text-dim text-center">
+                      {p().error}
+                    </div>
+                  )}
+                </Match>
+              </Switch>
             </Show>
           </div>
         </Portal>

--- a/src/components/FileViewer.tsx
+++ b/src/components/FileViewer.tsx
@@ -3,6 +3,7 @@ import { convertFileSrc } from '@tauri-apps/api/core'
 import { marked } from 'marked'
 import { Image, Film, Music, Eye, Code2, Loader2, AlertCircle } from 'lucide-solid'
 import { CodeEditor } from './CodeEditor'
+import { BreadcrumbBar } from './BreadcrumbBar'
 import { getPreviewType } from '../lib/fileTypes'
 import * as ipc from '../lib/ipc'
 import { getCachedContent, setCachedContent, setCachedOriginal } from '../store/files'
@@ -18,7 +19,16 @@ export const FileViewer: Component<Props> = (props) => {
   const type = () => getPreviewType(props.relativePath)
 
   return (
-    <Switch fallback={<CodeEditor taskId={props.taskId} relativePath={props.relativePath} />}>
+    <Switch fallback={
+      <div class="flex flex-col h-full">
+        <div class="flex items-center px-3 py-1 bg-[#1e1e1e] border-b border-border-subtle shrink-0">
+          <BreadcrumbBar taskId={props.taskId} currentPath={props.relativePath} />
+        </div>
+        <div class="flex-1 overflow-hidden">
+          <CodeEditor taskId={props.taskId} relativePath={props.relativePath} />
+        </div>
+      </div>
+    }>
       <Match when={type() === 'image'}>
         <ImageViewer taskId={props.taskId} relativePath={props.relativePath} />
       </Match>
@@ -41,7 +51,8 @@ export const FileViewer: Component<Props> = (props) => {
 // ── Shared toolbar for viewers ─────────────────────────────────────────
 
 const ViewerToolbar: Component<{
-  filename: string
+  taskId: string
+  relativePath: string
   icon?: Component<{ size: number; class?: string }>
   children?: any
 }> = (props) => (
@@ -49,7 +60,7 @@ const ViewerToolbar: Component<{
     <Show when={props.icon}>
       {(() => { const I = props.icon!; return <I size={14} class="text-text-dim shrink-0" /> })()}
     </Show>
-    <span class="text-xs font-mono text-text-secondary truncate">{props.filename}</span>
+    <BreadcrumbBar taskId={props.taskId} currentPath={props.relativePath} />
     <div class="flex-1" />
     {props.children}
   </div>
@@ -87,7 +98,7 @@ const ImageViewer: Component<Props> = (props) => {
 
   return (
     <div class="flex flex-col h-full">
-      <ViewerToolbar filename={filename()} icon={Image}>
+      <ViewerToolbar taskId={props.taskId} relativePath={props.relativePath} icon={Image}>
         <Show when={dimensions()}>
           <span class="text-[11px] text-text-dim">{dimensions()!.w} × {dimensions()!.h}</span>
         </Show>
@@ -122,11 +133,10 @@ const ImageViewer: Component<Props> = (props) => {
 
 const VideoViewer: Component<Props> = (props) => {
   const { url, error, loading } = useAssetUrl(() => props.taskId, () => props.relativePath)
-  const filename = () => props.relativePath.split('/').pop() ?? props.relativePath
 
   return (
     <div class="flex flex-col h-full">
-      <ViewerToolbar filename={filename()} icon={Film} />
+      <ViewerToolbar taskId={props.taskId} relativePath={props.relativePath} icon={Film} />
       <div class="flex-1 overflow-auto flex items-center justify-center bg-[#0a0a0a]">
         <Show when={loading()}>
           <Loader2 size={24} class="animate-spin text-text-dim" />
@@ -158,7 +168,7 @@ const AudioViewer: Component<Props> = (props) => {
 
   return (
     <div class="flex flex-col h-full">
-      <ViewerToolbar filename={filename()} icon={Music} />
+      <ViewerToolbar taskId={props.taskId} relativePath={props.relativePath} icon={Music} />
       <div class="flex-1 flex flex-col items-center justify-center gap-4 bg-surface-0">
         <Show when={loading()}>
           <Loader2 size={24} class="animate-spin text-text-dim" />
@@ -186,7 +196,6 @@ const MarkdownViewer: Component<Props> = (props) => {
   const [content, setContent] = createSignal('')
   const [loading, setLoading] = createSignal(true)
   const [error, setError] = createSignal<string | null>(null)
-  const filename = () => props.relativePath.split('/').pop() ?? props.relativePath
 
   let previewScrollFraction = 0
   let previewEl: HTMLDivElement | undefined
@@ -261,7 +270,7 @@ const MarkdownViewer: Component<Props> = (props) => {
 
   return (
     <div class="flex flex-col h-full">
-      <ViewerToolbar filename={filename()}>
+      <ViewerToolbar taskId={props.taskId} relativePath={props.relativePath}>
         <div class="flex items-center bg-surface-2 rounded-md p-0.5 gap-0.5">
           <button
             class={`flex items-center gap-1 px-2 py-0.5 rounded text-[11px] transition-colors ${
@@ -394,7 +403,7 @@ const SvgViewer: Component<Props> = (props) => {
 
   return (
     <div class="flex flex-col h-full">
-      <ViewerToolbar filename={filename()} icon={Image}>
+      <ViewerToolbar taskId={props.taskId} relativePath={props.relativePath} icon={Image}>
         <div class="flex items-center bg-surface-2 rounded-md p-0.5 gap-0.5">
           <button
             class={`flex items-center gap-1 px-2 py-0.5 rounded text-[11px] transition-colors ${

--- a/src/components/FileViewer.tsx
+++ b/src/components/FileViewer.tsx
@@ -1,0 +1,455 @@
+import { Component, Switch, Match, Show, createSignal, createEffect, on } from 'solid-js'
+import { convertFileSrc } from '@tauri-apps/api/core'
+import { marked } from 'marked'
+import { Image, Film, Music, Eye, Code2, Loader2, AlertCircle } from 'lucide-solid'
+import { CodeEditor } from './CodeEditor'
+import { getPreviewType } from '../lib/fileTypes'
+import * as ipc from '../lib/ipc'
+import { getCachedContent, setCachedContent, setCachedOriginal } from '../store/files'
+
+interface Props {
+  taskId: string
+  relativePath: string
+}
+
+// ── FileViewer — routes to the correct sub-viewer by file type ─────────
+
+export const FileViewer: Component<Props> = (props) => {
+  const type = () => getPreviewType(props.relativePath)
+
+  return (
+    <Switch fallback={<CodeEditor taskId={props.taskId} relativePath={props.relativePath} />}>
+      <Match when={type() === 'image'}>
+        <ImageViewer taskId={props.taskId} relativePath={props.relativePath} />
+      </Match>
+      <Match when={type() === 'video'}>
+        <VideoViewer taskId={props.taskId} relativePath={props.relativePath} />
+      </Match>
+      <Match when={type() === 'audio'}>
+        <AudioViewer taskId={props.taskId} relativePath={props.relativePath} />
+      </Match>
+      <Match when={type() === 'markdown'}>
+        <MarkdownViewer taskId={props.taskId} relativePath={props.relativePath} />
+      </Match>
+      <Match when={type() === 'svg'}>
+        <SvgViewer taskId={props.taskId} relativePath={props.relativePath} />
+      </Match>
+    </Switch>
+  )
+}
+
+// ── Shared toolbar for viewers ─────────────────────────────────────────
+
+const ViewerToolbar: Component<{
+  filename: string
+  icon?: Component<{ size: number; class?: string }>
+  children?: any
+}> = (props) => (
+  <div class="flex items-center gap-2 px-3 py-1.5 border-b border-border bg-surface-1 shrink-0">
+    <Show when={props.icon}>
+      {(() => { const I = props.icon!; return <I size={14} class="text-text-dim shrink-0" /> })()}
+    </Show>
+    <span class="text-xs font-mono text-text-secondary truncate">{props.filename}</span>
+    <div class="flex-1" />
+    {props.children}
+  </div>
+)
+
+// ── Shared hook: resolve absolute path → asset:// URL ──────────────────
+
+function useAssetUrl(taskId: () => string, relativePath: () => string) {
+  const [url, setUrl] = createSignal<string | null>(null)
+  const [error, setError] = createSignal<string | null>(null)
+  const [loading, setLoading] = createSignal(true)
+
+  createEffect(on([taskId, relativePath], async ([tid, rp]) => {
+    setLoading(true)
+    setError(null)
+    try {
+      const absPath = await ipc.resolveWorktreeFilePath(tid, rp)
+      setUrl(convertFileSrc(absPath))
+    } catch (e) {
+      setError(String(e))
+    } finally {
+      setLoading(false)
+    }
+  }))
+
+  return { url, error, loading }
+}
+
+// ── ImageViewer ────────────────────────────────────────────────────────
+
+const ImageViewer: Component<Props> = (props) => {
+  const { url, error, loading } = useAssetUrl(() => props.taskId, () => props.relativePath)
+  const filename = () => props.relativePath.split('/').pop() ?? props.relativePath
+  const [dimensions, setDimensions] = createSignal<{ w: number; h: number } | null>(null)
+
+  return (
+    <div class="flex flex-col h-full">
+      <ViewerToolbar filename={filename()} icon={Image}>
+        <Show when={dimensions()}>
+          <span class="text-[11px] text-text-dim">{dimensions()!.w} × {dimensions()!.h}</span>
+        </Show>
+      </ViewerToolbar>
+      <div class="flex-1 overflow-auto flex items-center justify-center bg-[#0a0a0a]" style="background-image: url('data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%2216%22 height=%2216%22><rect width=%228%22 height=%228%22 fill=%22%23111%22/><rect x=%228%22 y=%228%22 width=%228%22 height=%228%22 fill=%22%23111%22/></svg>'); background-size: 16px 16px;">
+        <Show when={loading()}>
+          <Loader2 size={24} class="animate-spin text-text-dim" />
+        </Show>
+        <Show when={error()}>
+          <div class="flex flex-col items-center gap-2 text-text-dim">
+            <AlertCircle size={24} />
+            <span class="text-xs">{error()}</span>
+          </div>
+        </Show>
+        <Show when={url()}>
+          <img
+            src={url()!}
+            alt={filename()}
+            class="max-w-full max-h-full object-contain"
+            onLoad={(e) => {
+              const img = e.currentTarget
+              setDimensions({ w: img.naturalWidth, h: img.naturalHeight })
+            }}
+          />
+        </Show>
+      </div>
+    </div>
+  )
+}
+
+// ── VideoViewer ────────────────────────────────────────────────────────
+
+const VideoViewer: Component<Props> = (props) => {
+  const { url, error, loading } = useAssetUrl(() => props.taskId, () => props.relativePath)
+  const filename = () => props.relativePath.split('/').pop() ?? props.relativePath
+
+  return (
+    <div class="flex flex-col h-full">
+      <ViewerToolbar filename={filename()} icon={Film} />
+      <div class="flex-1 overflow-auto flex items-center justify-center bg-[#0a0a0a]">
+        <Show when={loading()}>
+          <Loader2 size={24} class="animate-spin text-text-dim" />
+        </Show>
+        <Show when={error()}>
+          <div class="flex flex-col items-center gap-2 text-text-dim">
+            <AlertCircle size={24} />
+            <span class="text-xs">{error()}</span>
+          </div>
+        </Show>
+        <Show when={url()}>
+          <video
+            src={url()!}
+            controls
+            preload="metadata"
+            class="max-w-full max-h-full"
+          />
+        </Show>
+      </div>
+    </div>
+  )
+}
+
+// ── AudioViewer ────────────────────────────────────────────────────────
+
+const AudioViewer: Component<Props> = (props) => {
+  const { url, error, loading } = useAssetUrl(() => props.taskId, () => props.relativePath)
+  const filename = () => props.relativePath.split('/').pop() ?? props.relativePath
+
+  return (
+    <div class="flex flex-col h-full">
+      <ViewerToolbar filename={filename()} icon={Music} />
+      <div class="flex-1 flex flex-col items-center justify-center gap-4 bg-surface-0">
+        <Show when={loading()}>
+          <Loader2 size={24} class="animate-spin text-text-dim" />
+        </Show>
+        <Show when={error()}>
+          <div class="flex flex-col items-center gap-2 text-text-dim">
+            <AlertCircle size={24} />
+            <span class="text-xs">{error()}</span>
+          </div>
+        </Show>
+        <Show when={url()}>
+          <Music size={48} class="text-text-dim" />
+          <span class="text-sm text-text-secondary font-mono">{filename()}</span>
+          <audio src={url()!} controls preload="metadata" class="w-80" />
+        </Show>
+      </div>
+    </div>
+  )
+}
+
+// ── MarkdownViewer — preview/edit toggle ───────────────────────────────
+
+const MarkdownViewer: Component<Props> = (props) => {
+  const [mode, setMode] = createSignal<'preview' | 'edit'>('preview')
+  const [content, setContent] = createSignal('')
+  const [loading, setLoading] = createSignal(true)
+  const [error, setError] = createSignal<string | null>(null)
+  const filename = () => props.relativePath.split('/').pop() ?? props.relativePath
+
+  let previewScrollFraction = 0
+  let previewEl: HTMLDivElement | undefined
+  let editorWrapperEl: HTMLDivElement | undefined
+
+  const loadContent = async (rp: string) => {
+    setLoading(true)
+    setError(null)
+    try {
+      const cached = getCachedContent(props.taskId, rp)
+      if (cached !== undefined) {
+        setContent(cached)
+      } else {
+        const text = await ipc.readWorktreeFile(props.taskId, rp)
+        setContent(text)
+        setCachedContent(props.taskId, rp, text)
+        setCachedOriginal(props.taskId, rp, text)
+      }
+    } catch (e) {
+      setError(String(e))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  createEffect(on(() => props.relativePath, loadContent))
+
+  const saveScroll = () => {
+    if (previewEl) {
+      const max = previewEl.scrollHeight - previewEl.clientHeight
+      previewScrollFraction = max > 0 ? previewEl.scrollTop / max : 0
+    }
+  }
+
+  const restoreScroll = () => {
+    if (previewEl) {
+      requestAnimationFrame(() => {
+        if (!previewEl) return
+        const max = previewEl.scrollHeight - previewEl.clientHeight
+        previewEl.scrollTop = max * previewScrollFraction
+      })
+    }
+  }
+
+  const focusEditor = () => {
+    requestAnimationFrame(() => {
+      const cm = editorWrapperEl?.querySelector('.cm-content') as HTMLElement | null
+      cm?.focus()
+    })
+  }
+
+  const switchToPreview = () => {
+    const cached = getCachedContent(props.taskId, props.relativePath)
+    if (cached !== undefined) setContent(cached)
+    setMode('preview')
+    restoreScroll()
+  }
+
+  const switchToEdit = () => {
+    saveScroll()
+    setMode('edit')
+    focusEditor()
+  }
+
+  const renderedHtml = () => {
+    try {
+      return marked.parse(content(), { async: false }) as string
+    } catch {
+      return content()
+    }
+  }
+
+  return (
+    <div class="flex flex-col h-full">
+      <ViewerToolbar filename={filename()}>
+        <div class="flex items-center bg-surface-2 rounded-md p-0.5 gap-0.5">
+          <button
+            class={`flex items-center gap-1 px-2 py-0.5 rounded text-[11px] transition-colors ${
+              mode() === 'preview' ? 'bg-surface-3 text-text-secondary' : 'text-text-dim hover:text-text-muted'
+            }`}
+            onClick={switchToPreview}
+          >
+            <Eye size={12} />
+            Preview
+          </button>
+          <button
+            class={`flex items-center gap-1 px-2 py-0.5 rounded text-[11px] transition-colors ${
+              mode() === 'edit' ? 'bg-surface-3 text-text-secondary' : 'text-text-dim hover:text-text-muted'
+            }`}
+            onClick={switchToEdit}
+          >
+            <Code2 size={12} />
+            Edit
+          </button>
+        </div>
+      </ViewerToolbar>
+
+      <Show when={loading()}>
+        <div class="flex-1 flex items-center justify-center">
+          <Loader2 size={24} class="animate-spin text-text-dim" />
+        </div>
+      </Show>
+
+      <Show when={error()}>
+        <div class="flex-1 flex items-center justify-center">
+          <div class="flex flex-col items-center gap-2 text-text-dim">
+            <AlertCircle size={24} />
+            <span class="text-xs">{error()}</span>
+          </div>
+        </div>
+      </Show>
+
+      <Show when={!loading() && !error()}>
+        <div
+          ref={previewEl}
+          class="flex-1 overflow-auto px-6 py-4 text-sm text-text-primary leading-relaxed prose-verun select-text"
+          style={{ display: mode() === 'preview' ? '' : 'none' }}
+          innerHTML={renderedHtml()}
+        />
+        <div ref={editorWrapperEl} class="flex-1 overflow-hidden" style={{ display: mode() === 'edit' ? '' : 'none' }}>
+          <CodeEditor taskId={props.taskId} relativePath={props.relativePath} />
+        </div>
+      </Show>
+    </div>
+  )
+}
+
+// ── SvgViewer — preview/edit toggle ────────────────────────────────────
+
+const SvgViewer: Component<Props> = (props) => {
+  const [mode, setMode] = createSignal<'preview' | 'edit'>('preview')
+  const [content, setContent] = createSignal('')
+  const [loading, setLoading] = createSignal(true)
+  const [error, setError] = createSignal<string | null>(null)
+  const filename = () => props.relativePath.split('/').pop() ?? props.relativePath
+
+  let previewScrollFraction = 0
+  let previewEl: HTMLDivElement | undefined
+  let editorWrapperEl: HTMLDivElement | undefined
+
+  const loadContent = async (rp: string) => {
+    setLoading(true)
+    setError(null)
+    try {
+      const cached = getCachedContent(props.taskId, rp)
+      if (cached !== undefined) {
+        setContent(cached)
+      } else {
+        const text = await ipc.readWorktreeFile(props.taskId, rp)
+        setContent(text)
+        setCachedContent(props.taskId, rp, text)
+        setCachedOriginal(props.taskId, rp, text)
+      }
+    } catch (e) {
+      setError(String(e))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  createEffect(on(() => props.relativePath, loadContent))
+
+  const saveScroll = () => {
+    if (previewEl) {
+      const max = previewEl.scrollHeight - previewEl.clientHeight
+      previewScrollFraction = max > 0 ? previewEl.scrollTop / max : 0
+    }
+  }
+
+  const restoreScroll = () => {
+    if (previewEl) {
+      requestAnimationFrame(() => {
+        if (!previewEl) return
+        const max = previewEl.scrollHeight - previewEl.clientHeight
+        previewEl.scrollTop = max * previewScrollFraction
+      })
+    }
+  }
+
+  const focusEditor = () => {
+    requestAnimationFrame(() => {
+      const cm = editorWrapperEl?.querySelector('.cm-content') as HTMLElement | null
+      cm?.focus()
+    })
+  }
+
+  const switchToPreview = () => {
+    const cached = getCachedContent(props.taskId, props.relativePath)
+    if (cached !== undefined) setContent(cached)
+    setMode('preview')
+    restoreScroll()
+  }
+
+  const switchToEdit = () => {
+    saveScroll()
+    setMode('edit')
+    focusEditor()
+  }
+
+  const svgDataUrl = () => {
+    const svg = content()
+    if (!svg) return ''
+    return `data:image/svg+xml,${encodeURIComponent(svg)}`
+  }
+
+  return (
+    <div class="flex flex-col h-full">
+      <ViewerToolbar filename={filename()} icon={Image}>
+        <div class="flex items-center bg-surface-2 rounded-md p-0.5 gap-0.5">
+          <button
+            class={`flex items-center gap-1 px-2 py-0.5 rounded text-[11px] transition-colors ${
+              mode() === 'preview' ? 'bg-surface-3 text-text-secondary' : 'text-text-dim hover:text-text-muted'
+            }`}
+            onClick={switchToPreview}
+          >
+            <Eye size={12} />
+            Preview
+          </button>
+          <button
+            class={`flex items-center gap-1 px-2 py-0.5 rounded text-[11px] transition-colors ${
+              mode() === 'edit' ? 'bg-surface-3 text-text-secondary' : 'text-text-dim hover:text-text-muted'
+            }`}
+            onClick={switchToEdit}
+          >
+            <Code2 size={12} />
+            Edit
+          </button>
+        </div>
+      </ViewerToolbar>
+
+      <Show when={loading()}>
+        <div class="flex-1 flex items-center justify-center">
+          <Loader2 size={24} class="animate-spin text-text-dim" />
+        </div>
+      </Show>
+
+      <Show when={error()}>
+        <div class="flex-1 flex items-center justify-center">
+          <div class="flex flex-col items-center gap-2 text-text-dim">
+            <AlertCircle size={24} />
+            <span class="text-xs">{error()}</span>
+          </div>
+        </div>
+      </Show>
+
+      <Show when={!loading() && !error()}>
+        <div
+          ref={previewEl}
+          class="flex-1 overflow-auto flex items-center justify-center bg-[#0a0a0a]"
+          style={`background-image: url('data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%2216%22 height=%2216%22><rect width=%228%22 height=%228%22 fill=%22%23111%22/><rect x=%228%22 y=%228%22 width=%228%22 height=%228%22 fill=%22%23111%22/></svg>'); background-size: 16px 16px; display: ${mode() === 'preview' ? '' : 'none'}`}
+        >
+          <Show when={svgDataUrl()}>
+            <img
+              src={svgDataUrl()}
+              alt={filename()}
+              class="max-w-full max-h-full object-contain p-4"
+            />
+          </Show>
+        </div>
+        <div ref={editorWrapperEl} class="flex-1 overflow-hidden" style={{ display: mode() === 'edit' ? '' : 'none' }}>
+          <CodeEditor taskId={props.taskId} relativePath={props.relativePath} />
+        </div>
+      </Show>
+    </div>
+  )
+}

--- a/src/components/TaskPanel.tsx
+++ b/src/components/TaskPanel.tsx
@@ -16,7 +16,7 @@ import { FileViewer } from './FileViewer'
 import { TerminalPanel } from './TerminalPanel'
 import { ConfirmDialog } from './ConfirmDialog'
 import { selectSettingsSection } from './SettingsPage'
-import { openTabs, mainView, setMainView, setActiveTab, requestCloseTab, forceCloseTab, pendingClose, cancelCloseTab, pinTab, closeOtherTabs, closeAllTabs, revealFileInTree } from '../store/files'
+import { openTabs, mainView, setMainView, setActiveTab, requestCloseTab, forceCloseTab, pendingClose, cancelCloseTab, pinTab, closeOtherTabs, closeAllTabs, revealFileInTree, restoreTabState } from '../store/files'
 import { Square, Plus, X, PanelRightClose, PanelRightOpen, PanelBottomClose, PanelBottomOpen, ChevronDown, Loader2, AlertCircle, RotateCcw, Trash2, Archive, Play, TerminalSquare } from 'lucide-solid'
 import { getFileIcon } from '../lib/fileIcons'
 import { clsx } from 'clsx'
@@ -140,6 +140,7 @@ function OpenInButton(props: { path: string }) {
 export const TaskPanel: Component = () => {
   createEffect(on(selectedTaskId, async (taskId) => {
     if (taskId) {
+      restoreTabState(taskId)
       await loadSessions(taskId)
       const taskSessions = sessionsForTask(taskId)
       if (taskSessions.length > 0) {

--- a/src/components/TaskPanel.tsx
+++ b/src/components/TaskPanel.tsx
@@ -12,7 +12,7 @@ import { MessageInput } from './MessageInput'
 import { ChatView } from './ChatView'
 import { RightPanel } from './RightPanel'
 import { QuickOpen } from './QuickOpen'
-import { CodeEditor } from './CodeEditor'
+import { FileViewer } from './FileViewer'
 import { TerminalPanel } from './TerminalPanel'
 import { ConfirmDialog } from './ConfirmDialog'
 import { selectSettingsSection } from './SettingsPage'
@@ -618,7 +618,7 @@ export const TaskPanel: Component = () => {
                     }
                   >
                     <div class="flex-1 overflow-hidden">
-                      <CodeEditor taskId={t().id} relativePath={mainView(t().id)} />
+                      <FileViewer taskId={t().id} relativePath={mainView(t().id)} />
                     </div>
                   </Show>
 

--- a/src/lib/fileTypes.ts
+++ b/src/lib/fileTypes.ts
@@ -1,0 +1,21 @@
+export type PreviewType = 'code' | 'markdown' | 'svg' | 'image' | 'video' | 'audio'
+
+const IMAGE_EXTS = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp', 'ico', 'avif'])
+const VIDEO_EXTS = new Set(['mp4', 'webm', 'mov', 'ogv'])
+const AUDIO_EXTS = new Set(['mp3', 'wav', 'ogg', 'flac', 'aac', 'm4a', 'opus'])
+const MARKDOWN_EXTS = new Set(['md', 'mdx', 'markdown'])
+const SVG_EXTS = new Set(['svg'])
+
+export function getPreviewType(filePath: string): PreviewType {
+  const ext = filePath.split('.').pop()?.toLowerCase() ?? ''
+  if (SVG_EXTS.has(ext)) return 'svg'
+  if (MARKDOWN_EXTS.has(ext)) return 'markdown'
+  if (IMAGE_EXTS.has(ext)) return 'image'
+  if (VIDEO_EXTS.has(ext)) return 'video'
+  if (AUDIO_EXTS.has(ext)) return 'audio'
+  return 'code'
+}
+
+export function isMediaType(type: PreviewType): boolean {
+  return type === 'image' || type === 'video' || type === 'audio'
+}

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -223,6 +223,9 @@ export const listDirectory = (taskId: string, relativePath: string) =>
 export const readWorktreeFile = (taskId: string, relativePath: string, maxBytes?: number) =>
   invoke<string>('read_worktree_file', { taskId, relativePath, maxBytes })
 
+export const resolveWorktreeFilePath = (taskId: string, relativePath: string) =>
+  invoke<string>('resolve_worktree_file_path', { taskId, relativePath })
+
 export const writeTextFile = (taskId: string, relativePath: string, content: string) =>
   invoke<void>('write_text_file', { taskId, relativePath, content })
 

--- a/src/store/files.ts
+++ b/src/store/files.ts
@@ -139,6 +139,51 @@ export function collapseDir(taskId: string, path: string) {
   })
 }
 
+// ── Tab persistence via localStorage ─────────────────────────────────
+
+interface PersistedTabState {
+  tabs: EditorTab[]
+  activeTab: string | null
+  mainView: string
+  mruStack: string[]
+}
+
+function tabStorageKey(taskId: string) { return `verun:editorTabs:${taskId}` }
+
+function persistTabState(taskId: string) {
+  const state: PersistedTabState = {
+    // Strip dirty flag — unsaved edits don't survive restart
+    tabs: (taskOpenTabs()[taskId] ?? []).map(t => ({ ...t, dirty: false })),
+    activeTab: taskActiveTab()[taskId] ?? null,
+    mainView: taskMainView()[taskId] ?? 'session',
+    mruStack: taskMruStack()[taskId] ?? [],
+  }
+  try { localStorage.setItem(tabStorageKey(taskId), JSON.stringify(state)) } catch { /* quota */ }
+}
+
+/** Restore tabs from localStorage when a task is first accessed. Returns true if restored. */
+export function restoreTabState(taskId: string): boolean {
+  // Already loaded in memory — don't overwrite
+  if ((taskOpenTabs()[taskId] ?? []).length > 0) return false
+
+  try {
+    const raw = localStorage.getItem(tabStorageKey(taskId))
+    if (!raw) return false
+    const state: PersistedTabState = JSON.parse(raw)
+    if (!state.tabs?.length) return false
+
+    setTaskOpenTabs(prev => ({ ...prev, [taskId]: state.tabs }))
+    setTaskActiveTab(prev => ({ ...prev, [taskId]: state.activeTab }))
+    setTaskMainView(prev => ({ ...prev, [taskId]: state.mainView }))
+    setTaskMruStack(prev => ({ ...prev, [taskId]: state.mruStack ?? [] }))
+    return true
+  } catch { return false }
+}
+
+function clearPersistedTabs(taskId: string) {
+  try { localStorage.removeItem(tabStorageKey(taskId)) } catch { /* */ }
+}
+
 // ── Per-task editor tabs ──────────────────────────────────────────────
 
 export function openTabs(taskId: string | null): EditorTab[] {
@@ -165,6 +210,7 @@ export function openFile(taskId: string, relativePath: string, name: string) {
     setTaskActiveTab(prev => ({ ...prev, [taskId]: relativePath }))
     setMainView(taskId, relativePath)
     pushMru(taskId, relativePath)
+    persistTabState(taskId)
     return
   }
 
@@ -176,6 +222,7 @@ export function openFile(taskId: string, relativePath: string, name: string) {
   setTaskActiveTab(prev => ({ ...prev, [taskId]: relativePath }))
   setMainView(taskId, relativePath)
   pushMru(taskId, relativePath)
+  persistTabState(taskId)
 }
 
 /** Open a file as a permanent tab (double-click, or programmatic). */
@@ -195,6 +242,7 @@ export function openFilePinned(taskId: string, relativePath: string, name: strin
       setMainView(taskId, relativePath)
     }
     pushMru(taskId, relativePath)
+    persistTabState(taskId)
     return
   }
 
@@ -207,6 +255,7 @@ export function openFilePinned(taskId: string, relativePath: string, name: strin
   setTaskActiveTab(prev => ({ ...prev, [taskId]: relativePath }))
   setMainView(taskId, relativePath)
   pushMru(taskId, relativePath)
+  persistTabState(taskId)
 }
 
 /** Pin the current preview tab (called on edit or double-click). */
@@ -215,6 +264,7 @@ export function pinTab(taskId: string, relativePath: string) {
     const tabs = prev[taskId] ?? []
     return { ...prev, [taskId]: tabs.map(t => t.relativePath === relativePath ? { ...t, preview: false } : t) }
   })
+  persistTabState(taskId)
 }
 
 /** Try to close a tab. If dirty, sets pendingClose instead. */
@@ -233,6 +283,9 @@ export function forceCloseTab(taskId: string, relativePath: string) {
   const tabs = openTabs(taskId)
   const tab = tabs.find(t => t.relativePath === relativePath)
   if (tab) {
+    // If closing a dirty tab without saving, clear the content cache
+    // so reopening loads fresh from disk instead of stale edits
+    if (tab.dirty) clearCachedContent(taskId, relativePath)
     setTaskRecentlyClosed(prev => ({
       ...prev,
       [taskId]: [{ ...tab, dirty: false }, ...(prev[taskId] ?? [])].slice(0, MAX_CLOSED),
@@ -241,6 +294,7 @@ export function forceCloseTab(taskId: string, relativePath: string) {
   const filtered = tabs.filter(t => t.relativePath !== relativePath)
   setTaskOpenTabs(prev => ({ ...prev, [taskId]: filtered }))
   removeMru(taskId, relativePath)
+  for (const fn of tabCloseListeners) fn(taskId, relativePath)
 
   if (activeTabPath(taskId) === relativePath) {
     // Fall back to the most recently used tab
@@ -251,6 +305,7 @@ export function forceCloseTab(taskId: string, relativePath: string) {
     else setMainView(taskId, newActive)
   }
   setPendingClose(null)
+  persistTabState(taskId)
 }
 
 /** Cancel a pending close. */
@@ -285,6 +340,7 @@ export function setActiveTab(taskId: string, relativePath: string) {
   setTaskActiveTab(prev => ({ ...prev, [taskId]: relativePath }))
   setMainView(taskId, relativePath)
   pushMru(taskId, relativePath)
+  persistTabState(taskId)
 }
 
 // File content cache — avoids reload flicker when switching tabs
@@ -311,6 +367,35 @@ export function setCachedOriginal(taskId: string, relativePath: string, content:
 export function clearCachedContent(taskId: string, relativePath: string) {
   fileContentCache.delete(`${taskId}:${relativePath}`)
   fileOriginalCache.delete(`${taskId}:${relativePath}`)
+}
+
+// Tab-close listeners — lets CodeEditor clear its state cache without circular imports
+type TabCloseListener = (taskId: string, relativePath: string) => void
+const tabCloseListeners: TabCloseListener[] = []
+
+export function onTabClose(listener: TabCloseListener): () => void {
+  tabCloseListeners.push(listener)
+  return () => {
+    const idx = tabCloseListeners.indexOf(listener)
+    if (idx >= 0) tabCloseListeners.splice(idx, 1)
+  }
+}
+
+// Task-level cleanup listeners — fired when an entire task is deleted/archived
+type TaskCleanupListener = (taskId: string) => void
+const taskCleanupListeners: TaskCleanupListener[] = []
+
+export function onTaskCleanup(listener: TaskCleanupListener): () => void {
+  taskCleanupListeners.push(listener)
+  return () => {
+    const idx = taskCleanupListeners.indexOf(listener)
+    if (idx >= 0) taskCleanupListeners.splice(idx, 1)
+  }
+}
+
+export function fireTaskCleanup(taskId: string) {
+  clearPersistedTabs(taskId)
+  for (const fn of taskCleanupListeners) fn(taskId)
 }
 
 // ── Reveal file in tree ──────────────────────────────────────────────
@@ -354,12 +439,12 @@ export function nextTab(taskId: string) {
   if (tabs.length < 2) return
   const mru = taskMruStack()[taskId] ?? []
   const active = activeTabPath(taskId)
-  // Find the next entry in MRU that isn't the current one
   const next = mru.find(p => p !== active && tabs.some(t => t.relativePath === p))
   if (next) {
     setTaskActiveTab(prev => ({ ...prev, [taskId]: next }))
     setMainView(taskId, next)
     pushMru(taskId, next)
+    persistTabState(taskId)
     revealFileInTree(taskId, next)
   }
 }
@@ -370,13 +455,13 @@ export function prevTab(taskId: string) {
   if (tabs.length < 2) return
   const mru = taskMruStack()[taskId] ?? []
   const active = activeTabPath(taskId)
-  // Find the oldest MRU entry that's still open
   const candidates = mru.filter(p => p !== active && tabs.some(t => t.relativePath === p))
   const prev = candidates.length > 0 ? candidates[candidates.length - 1] : null
   if (prev) {
     setTaskActiveTab(p => ({ ...p, [taskId]: prev }))
     setMainView(taskId, prev)
     pushMru(taskId, prev)
+    persistTabState(taskId)
     revealFileInTree(taskId, prev)
   }
 }

--- a/src/store/tasks.ts
+++ b/src/store/tasks.ts
@@ -5,6 +5,7 @@ import * as ipc from '../lib/ipc'
 import { closeTerminalsForTask } from './terminals'
 import { clearTaskGitState } from './git'
 import { clearProblemsForTask } from './problems'
+import { fireTaskCleanup } from './files'
 
 export const [tasks, setTasks] = createStore<Task[]>([])
 
@@ -149,6 +150,7 @@ export async function deleteTask(id: string, deleteBranch = true, skipDestroyHoo
   closeTerminalsForTask(id)
   clearTaskGitState(id)
   clearProblemsForTask(id)
+  fireTaskCleanup(id)
   await ipc.deleteTask(id, deleteBranch, skipDestroyHook)
   setTasks(prev => prev.filter(t => t.id !== id))
 }


### PR DESCRIPTION
## Summary
- Cursor position, selection, scroll, and undo/redo history are preserved when switching between file tabs — caches the full CodeMirror `EditorState` per file
- Interactive breadcrumb path bar above the editor — click any segment to see sibling files/folders and jump to them
- Safety check discards cached editor state if the doc content has diverged (e.g. external file change)

## Test plan
- [ ] Open two files, edit both, switch between them — cursor and undo history should persist
- [ ] Scroll down in a file, switch away and back — scroll position preserved
- [ ] Close a tab and reopen — should load fresh (no stale cursor/undo)
- [ ] Click a folder segment in the breadcrumb — dropdown shows sibling files/folders
- [ ] Click a file in the breadcrumb dropdown — opens it as a pinned tab
- [ ] Current file is highlighted in the dropdown