### PR TITLE
fork a session from any past assistant message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fork a session from a past assistant message: hover any assistant reply to fork in this task (rewinds the chat, keeps current code), or fork to a new task with the worktree restored to the code as it was at that message (true counterfactual) or seeded from the parent's current code
+- Per-turn worktree snapshots taken at every assistant turn end via git plumbing (commit-tree against a temporary index), anchored under `refs/verun/snapshots/` so they survive `git gc`
 - Dev builds now use a separate bundle identifier (`com.softwaresavants.verun.dev`) and product name ("Verun Dev"), so dev and released apps have isolated SQLite databases and app data dirs — no more "migration N was previously applied but is missing" panics when running a released build after a newer dev session. Run dev with `pnpm tauri dev --config src-tauri/tauri.dev.conf.json` (or `make dev`).
 - Diffs now open exclusively as full-size tabs in the main editor panel — clicking a file in the Changes pane opens a side-by-side diff (backed by `@codemirror/merge`) with syntax highlighting, search, and folding, instead of expanding an inline diff in the sidebar. Double-click pins the tab. Works for both working-tree changes and files inside any branch commit; toggleable inline view; tabs persist across reloads. The old inline diff renderer (custom hunk view, expand-context buttons, word-wrap and hide-whitespace toggles) has been removed.
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Run multiple Claude Code sessions in parallel, each in its own isolated git work
 - **Inline diffs** — see exactly what Claude changed with syntax-highlighted diffs
 - **Git actions** — commit, push, create PR, merge — all without leaving the app
 - **Steps** — plan follow-up messages while Claude works; fire manually or arm for auto-send
+- **Fork from any message** — hover any past assistant reply to fork the conversation: rewind in place keeping the current code, or branch into a new task with the worktree restored to the code as it was at that exact turn
 - **Plan mode** — review implementation plans before Claude starts coding
 - **Desktop notifications** — get notified when tasks complete, fail, or need approval
 - **Tool approval** — configurable trust levels (Normal, Supervised, Full Auto)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -94,7 +94,7 @@ High-impact features that engineers are asking for most.
 ### Session & Workflow
 - [X] Refresh the state (github...) on app resume
 - [ ] Subagent / nested thread visualization
-- [ ] Fork task or session (branch a conversation into a new direction)
+- [X] Fork task or session (branch a conversation into a new direction)
 - [X] Steer & queue interaction modes (send follow-ups while the agent is working)
 - [X] Unread / attention-required indicator on tasks in sidebar
 - [X] OS notifications for task completion and approval prompts

--- a/src-tauri/src/claude_jsonl.rs
+++ b/src-tauri/src/claude_jsonl.rs
@@ -1,0 +1,208 @@
+// Knowledge of Claude Code's on-disk session JSONL format lives in this one file.
+//
+// Format (verified against Claude Code 2.1.101): one JSON object per line, with
+// a per-line `uuid` field on real message lines and a `sessionId` field that we
+// rewrite when forking. Other line types (e.g. `file-history-snapshot`,
+// `last-prompt`, internal markers) are passed through unchanged but their
+// `sessionId` is still rewritten if present.
+//
+// To fork a session at a given message UUID, we copy the source JSONL up to and
+// including the line whose `uuid` matches `last_kept_uuid`, drop everything
+// after, and rewrite `sessionId` on every kept line to point at the new id.
+//
+// Pinned to a known-good CLI version. Bumps to Claude Code that change this
+// format are expected to break here loudly rather than silently produce broken
+// forks; the constant below is the version we have validated.
+
+use std::fs::File;
+use std::io::{BufRead, BufReader, BufWriter, Write};
+use std::path::{Path, PathBuf};
+
+#[allow(dead_code)]
+pub const VERIFIED_CLAUDE_CODE_VERSION: &str = "2.1.101";
+
+#[derive(Debug)]
+pub enum JsonlError {
+    Io(String),
+    NotFound(PathBuf),
+    MessageUuidNotFound(String),
+    MalformedLine { line_no: usize, reason: String },
+}
+
+impl std::fmt::Display for JsonlError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            JsonlError::Io(s) => write!(f, "jsonl io error: {s}"),
+            JsonlError::NotFound(p) => write!(f, "jsonl file not found: {}", p.display()),
+            JsonlError::MessageUuidNotFound(u) => {
+                write!(f, "message uuid not found in transcript: {u}")
+            }
+            JsonlError::MalformedLine { line_no, reason } => {
+                write!(f, "malformed jsonl line {line_no}: {reason}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for JsonlError {}
+
+/// Compute the path of a Claude Code session transcript.
+///
+/// Claude stores transcripts at `~/.claude/projects/<encoded-cwd>/<id>.jsonl`
+/// where `<encoded-cwd>` is the absolute path of the cwd with all path
+/// separators replaced by `-`.
+pub fn session_path(cwd: &Path, session_id: &str) -> Option<PathBuf> {
+    let home = std::env::var_os("HOME").map(PathBuf::from)?;
+    let encoded = encode_cwd(cwd);
+    Some(
+        home.join(".claude")
+            .join("projects")
+            .join(encoded)
+            .join(format!("{session_id}.jsonl")),
+    )
+}
+
+fn encode_cwd(cwd: &Path) -> String {
+    let s = cwd.to_string_lossy();
+    let mut out = String::with_capacity(s.len() + 1);
+    if !s.starts_with('/') {
+        out.push('-');
+    }
+    for ch in s.chars() {
+        if ch == '/' || ch == '.' {
+            out.push('-');
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+/// Truncate a session JSONL to end at (and include) the line whose `uuid`
+/// equals `last_kept_uuid`, rewriting every kept line's `sessionId` to
+/// `new_session_id`. The result is written to `dest`.
+pub fn truncate_after_message(
+    src: &Path,
+    dest: &Path,
+    new_session_id: &str,
+    last_kept_uuid: &str,
+) -> Result<(), JsonlError> {
+    if !src.exists() {
+        return Err(JsonlError::NotFound(src.to_path_buf()));
+    }
+    let f = File::open(src).map_err(|e| JsonlError::Io(e.to_string()))?;
+    let reader = BufReader::new(f);
+
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| JsonlError::Io(e.to_string()))?;
+    }
+    let out_file = File::create(dest).map_err(|e| JsonlError::Io(e.to_string()))?;
+    let mut out = BufWriter::new(out_file);
+
+    let mut found = false;
+    for (idx, line_res) in reader.lines().enumerate() {
+        let line_no = idx + 1;
+        let line = line_res.map_err(|e| JsonlError::Io(e.to_string()))?;
+        if line.is_empty() {
+            continue;
+        }
+        let mut value: serde_json::Value =
+            serde_json::from_str(&line).map_err(|e| JsonlError::MalformedLine {
+                line_no,
+                reason: e.to_string(),
+            })?;
+
+        if let Some(obj) = value.as_object_mut() {
+            if let Some(sid) = obj.get_mut("sessionId") {
+                if sid.is_string() {
+                    *sid = serde_json::Value::String(new_session_id.to_string());
+                }
+            }
+        }
+
+        let uuid_match = value
+            .get("uuid")
+            .and_then(|v| v.as_str())
+            .map(|u| u == last_kept_uuid)
+            .unwrap_or(false);
+
+        let serialized =
+            serde_json::to_string(&value).map_err(|e| JsonlError::MalformedLine {
+                line_no,
+                reason: e.to_string(),
+            })?;
+        writeln!(out, "{serialized}").map_err(|e| JsonlError::Io(e.to_string()))?;
+
+        if uuid_match {
+            found = true;
+            break;
+        }
+    }
+
+    out.flush().map_err(|e| JsonlError::Io(e.to_string()))?;
+
+    if !found {
+        // Best-effort cleanup of the half-written destination so the caller
+        // doesn't see a misleading file.
+        let _ = std::fs::remove_file(dest);
+        return Err(JsonlError::MessageUuidNotFound(last_kept_uuid.to_string()));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn write(path: &Path, content: &str) {
+        std::fs::write(path, content).unwrap();
+    }
+
+    #[test]
+    fn encode_cwd_replaces_slashes_and_dots() {
+        let p = Path::new("/Users/me/Project.X");
+        assert_eq!(encode_cwd(p), "-Users-me-Project-X");
+    }
+
+    #[test]
+    fn truncates_at_message_and_rewrites_session_id() {
+        let dir = TempDir::new().unwrap();
+        let src = dir.path().join("orig.jsonl");
+        let dest = dir.path().join("forked.jsonl");
+
+        write(
+            &src,
+            r#"{"type":"system","sessionId":"old-id"}
+{"type":"user","uuid":"u1","sessionId":"old-id","message":{"role":"user","content":"hi"}}
+{"type":"assistant","uuid":"a1","sessionId":"old-id","message":{"role":"assistant","content":"hello"}}
+{"type":"user","uuid":"u2","sessionId":"old-id","message":{"role":"user","content":"again"}}
+{"type":"assistant","uuid":"a2","sessionId":"old-id","message":{"role":"assistant","content":"second reply"}}
+"#,
+        );
+
+        truncate_after_message(&src, &dest, "new-id", "a1").unwrap();
+
+        let out = std::fs::read_to_string(&dest).unwrap();
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines.len(), 3, "expected 3 lines, got {lines:?}");
+
+        for line in &lines {
+            assert!(line.contains("\"new-id\""));
+            assert!(!line.contains("\"old-id\""));
+        }
+        assert!(lines[2].contains("\"a1\""));
+    }
+
+    #[test]
+    fn errors_when_uuid_not_found() {
+        let dir = TempDir::new().unwrap();
+        let src = dir.path().join("orig.jsonl");
+        let dest = dir.path().join("forked.jsonl");
+        write(&src, r#"{"type":"user","uuid":"u1"}"#);
+        let err = truncate_after_message(&src, &dest, "new-id", "missing").unwrap_err();
+        assert!(matches!(err, JsonlError::MessageUuidNotFound(_)));
+        assert!(!dest.exists(), "dest should be cleaned up on error");
+    }
+}

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -153,6 +153,25 @@ pub fn migrations() -> Vec<Migration> {
         description: "add auto_start toggle to projects",
         sql: "ALTER TABLE projects ADD COLUMN auto_start INTEGER NOT NULL DEFAULT 0;",
         kind: MigrationKind::Up,
+    },
+    Migration {
+        version: 12,
+        description: "add fork lineage and per-turn worktree snapshots",
+        sql: r#"
+            ALTER TABLE sessions ADD COLUMN parent_session_id TEXT;
+            ALTER TABLE sessions ADD COLUMN forked_at_message_uuid TEXT;
+            ALTER TABLE tasks ADD COLUMN parent_task_id TEXT;
+
+            CREATE TABLE IF NOT EXISTS turn_snapshots (
+                session_id TEXT NOT NULL,
+                message_uuid TEXT NOT NULL,
+                stash_sha TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                PRIMARY KEY (session_id, message_uuid)
+            );
+            CREATE INDEX IF NOT EXISTS idx_turn_snapshots_session ON turn_snapshots(session_id);
+        "#,
+        kind: MigrationKind::Up,
     }]
 }
 
@@ -191,6 +210,8 @@ pub struct Task {
     pub archived_at: Option<i64>,
     #[sqlx(default)]
     pub last_commit_message: Option<String>,
+    #[sqlx(default)]
+    pub parent_task_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
@@ -204,6 +225,10 @@ pub struct Session {
     pub started_at: i64,
     pub ended_at: Option<i64>,
     pub total_cost: f64,
+    #[sqlx(default)]
+    pub parent_session_id: Option<String>,
+    #[sqlx(default)]
+    pub forked_at_message_uuid: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
@@ -225,6 +250,15 @@ pub struct AuditEntry {
     pub tool_input_summary: String,
     pub decision: String,
     pub reason: String,
+    pub created_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+#[serde(rename_all = "camelCase")]
+pub struct TurnSnapshot {
+    pub session_id: String,
+    pub message_uuid: String,
+    pub stash_sha: String,
     pub created_at: i64,
 }
 
@@ -276,6 +310,10 @@ pub enum DbWrite {
     // Output
     InsertOutputLines { session_id: String, lines: Vec<(String, i64)> },
     DeleteOutputLines { session_id: String },
+
+    // Turn snapshots (per-turn worktree state for forking)
+    InsertTurnSnapshot { session_id: String, message_uuid: String, stash_sha: String, created_at: i64 },
+    DeleteTurnSnapshotsForSession { session_id: String },
 
     // Policy
     SetTrustLevel { task_id: String, trust_level: String, updated_at: i64 },
@@ -353,7 +391,7 @@ async fn process_write(pool: &SqlitePool, write: DbWrite) -> Result<(), sqlx::Er
                 .await?;
         }
         DbWrite::DeleteProject { id } => {
-            // Cascade: audit_log → trust_levels → steps → output_lines → sessions → tasks → project
+            // Cascade: audit_log → trust_levels → steps → output_lines → turn_snapshots → sessions → tasks → project
             sqlx::query(
                 "DELETE FROM policy_audit_log WHERE task_id IN \
                  (SELECT id FROM tasks WHERE project_id = ?)",
@@ -375,6 +413,11 @@ async fn process_write(pool: &SqlitePool, write: DbWrite) -> Result<(), sqlx::Er
             )
             .bind(&id).execute(pool).await?;
             sqlx::query(
+                "DELETE FROM turn_snapshots WHERE session_id IN \
+                 (SELECT s.id FROM sessions s JOIN tasks t ON s.task_id = t.id WHERE t.project_id = ?)",
+            )
+            .bind(&id).execute(pool).await?;
+            sqlx::query(
                 "DELETE FROM sessions WHERE task_id IN \
                  (SELECT id FROM tasks WHERE project_id = ?)",
             )
@@ -388,8 +431,8 @@ async fn process_write(pool: &SqlitePool, write: DbWrite) -> Result<(), sqlx::Er
         // -- Tasks --
         DbWrite::InsertTask(t) => {
             sqlx::query(
-                "INSERT INTO tasks (id, project_id, name, worktree_path, branch, created_at, port_offset) \
-                 VALUES (?, ?, ?, ?, ?, ?, ?)",
+                "INSERT INTO tasks (id, project_id, name, worktree_path, branch, created_at, port_offset, parent_task_id) \
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
             )
             .bind(&t.id)
             .bind(&t.project_id)
@@ -398,6 +441,7 @@ async fn process_write(pool: &SqlitePool, write: DbWrite) -> Result<(), sqlx::Er
             .bind(&t.branch)
             .bind(t.created_at)
             .bind(t.port_offset)
+            .bind(&t.parent_task_id)
             .execute(pool)
             .await?;
         }
@@ -430,6 +474,11 @@ async fn process_write(pool: &SqlitePool, write: DbWrite) -> Result<(), sqlx::Er
                  (SELECT id FROM sessions WHERE task_id = ?)",
             )
             .bind(&id).execute(pool).await?;
+            sqlx::query(
+                "DELETE FROM turn_snapshots WHERE session_id IN \
+                 (SELECT id FROM sessions WHERE task_id = ?)",
+            )
+            .bind(&id).execute(pool).await?;
             sqlx::query("DELETE FROM sessions WHERE task_id = ?")
                 .bind(&id).execute(pool).await?;
             sqlx::query("DELETE FROM tasks WHERE id = ?")
@@ -449,8 +498,8 @@ async fn process_write(pool: &SqlitePool, write: DbWrite) -> Result<(), sqlx::Er
         // -- Sessions --
         DbWrite::CreateSession(s) => {
             sqlx::query(
-                "INSERT INTO sessions (id, task_id, name, claude_session_id, status, started_at, ended_at, total_cost) \
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                "INSERT INTO sessions (id, task_id, name, claude_session_id, status, started_at, ended_at, total_cost, parent_session_id, forked_at_message_uuid) \
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             )
             .bind(&s.id)
             .bind(&s.task_id)
@@ -460,6 +509,8 @@ async fn process_write(pool: &SqlitePool, write: DbWrite) -> Result<(), sqlx::Er
             .bind(s.started_at)
             .bind(s.ended_at)
             .bind(s.total_cost)
+            .bind(&s.parent_session_id)
+            .bind(&s.forked_at_message_uuid)
             .execute(pool)
             .await?;
         }
@@ -524,6 +575,25 @@ async fn process_write(pool: &SqlitePool, write: DbWrite) -> Result<(), sqlx::Er
 
         DbWrite::DeleteOutputLines { session_id } => {
             sqlx::query("DELETE FROM output_lines WHERE session_id = ?")
+                .bind(&session_id)
+                .execute(pool)
+                .await?;
+        }
+
+        DbWrite::InsertTurnSnapshot { session_id, message_uuid, stash_sha, created_at } => {
+            sqlx::query(
+                "INSERT OR REPLACE INTO turn_snapshots (session_id, message_uuid, stash_sha, created_at) \
+                 VALUES (?, ?, ?, ?)",
+            )
+            .bind(&session_id)
+            .bind(&message_uuid)
+            .bind(&stash_sha)
+            .bind(created_at)
+            .execute(pool)
+            .await?;
+        }
+        DbWrite::DeleteTurnSnapshotsForSession { session_id } => {
+            sqlx::query("DELETE FROM turn_snapshots WHERE session_id = ?")
                 .bind(&session_id)
                 .execute(pool)
                 .await?;
@@ -718,6 +788,23 @@ pub async fn get_output_lines(
     .map_err(|e| e.to_string())
 }
 
+// Turn snapshots
+
+pub async fn get_turn_snapshot(
+    pool: &SqlitePool,
+    session_id: &str,
+    message_uuid: &str,
+) -> Result<Option<TurnSnapshot>, String> {
+    sqlx::query_as::<_, TurnSnapshot>(
+        "SELECT * FROM turn_snapshots WHERE session_id = ? AND message_uuid = ?",
+    )
+    .bind(session_id)
+    .bind(message_uuid)
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| e.to_string())
+}
+
 // Steps
 
 pub async fn list_steps(pool: &SqlitePool, session_id: &str) -> Result<Vec<Step>, String> {
@@ -803,9 +890,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn has_eleven_migrations() {
+    fn has_twelve_migrations() {
         let m = migrations();
-        assert_eq!(m.len(), 11);
+        assert_eq!(m.len(), 12);
         assert_eq!(m[0].version, 1);
         assert_eq!(m[1].version, 2);
         assert_eq!(m[2].version, 3);
@@ -817,6 +904,7 @@ mod tests {
         assert_eq!(m[8].version, 9);
         assert_eq!(m[9].version, 10);
         assert_eq!(m[10].version, 11);
+        assert_eq!(m[11].version, 12);
     }
 
     #[test]
@@ -860,6 +948,7 @@ mod tests {
             archived: false,
             archived_at: None,
             last_commit_message: None,
+            parent_task_id: None,
         }
     }
 
@@ -873,6 +962,8 @@ mod tests {
             started_at: 3000,
             ended_at: None,
             total_cost: 0.0,
+            parent_session_id: None,
+            forked_at_message_uuid: None,
         }
     }
 

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -486,42 +486,61 @@ pub async fn create_session(
 #[tauri::command]
 pub async fn fork_session_in_task(
     pool: State<'_, SqlitePool>,
-    db_tx: State<'_, DbWriteTx>,
     session_id: String,
     fork_after_message_uuid: String,
 ) -> Result<Session, String> {
-    task::fork_session_in_task(
-        pool.inner(),
-        db_tx.inner(),
-        session_id,
-        fork_after_message_uuid,
-    )
-    .await
+    task::fork_session_in_task(pool.inner(), session_id, fork_after_message_uuid).await
 }
 
 /// Fork an existing session at a specific assistant message uuid into a new
 /// task with its own worktree. `worktree_state` controls whether the new
 /// worktree is restored to the per-turn snapshot ("snapshot") or seeded from
-/// the parent's current code ("current").
+/// the parent's current code ("current"). After the fork completes, the
+/// project's setup hook is spawned on the new worktree so dependencies,
+/// `.env` files, etc. are installed — same treatment as a fresh task.
+#[allow(clippy::too_many_arguments)]
 #[tauri::command]
 pub async fn fork_session_to_new_task(
     app: AppHandle,
     pool: State<'_, SqlitePool>,
-    db_tx: State<'_, DbWriteTx>,
+    pty_map: State<'_, ActivePtyMap>,
+    hook_pty_map: State<'_, HookPtyMap>,
+    setup_in_progress: State<'_, SetupInProgress>,
     session_id: String,
     fork_after_message_uuid: String,
     worktree_state: task::WorktreeForkState,
 ) -> Result<TaskWithSession, String> {
-    let (task, session) = task::fork_session_to_new_task(
+    let (new_task, new_session) = task::fork_session_to_new_task(
         &app,
         pool.inner(),
-        db_tx.inner(),
         session_id,
         fork_after_message_uuid,
         worktree_state,
     )
     .await?;
-    Ok(TaskWithSession { task, session })
+
+    // Spawn the project's setup hook on the new worktree so gitignored
+    // files (node_modules, .env, build artifacts) are materialized the same
+    // way a fresh task's worktree gets them. Without this, forked tasks
+    // look broken for any project with non-trivial setup.
+    if let Some(project) = db::get_project(pool.inner(), &new_task.project_id).await? {
+        task::spawn_setup_hook(
+            &app,
+            pty_map.inner(),
+            hook_pty_map.inner(),
+            setup_in_progress.inner(),
+            &new_task.id,
+            &new_task.worktree_path,
+            &project.setup_hook,
+            new_task.port_offset,
+            &project.repo_path,
+        );
+    }
+
+    Ok(TaskWithSession {
+        task: new_task,
+        session: new_session,
+    })
 }
 
 /// Send a message to Claude in this session.

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -481,6 +481,49 @@ pub async fn create_session(
     task::create_session(db_tx.inner(), task_id).await
 }
 
+/// Fork an existing session at a specific assistant message uuid into a new
+/// session inside the SAME task. The worktree is unchanged.
+#[tauri::command]
+pub async fn fork_session_in_task(
+    pool: State<'_, SqlitePool>,
+    db_tx: State<'_, DbWriteTx>,
+    session_id: String,
+    fork_after_message_uuid: String,
+) -> Result<Session, String> {
+    task::fork_session_in_task(
+        pool.inner(),
+        db_tx.inner(),
+        session_id,
+        fork_after_message_uuid,
+    )
+    .await
+}
+
+/// Fork an existing session at a specific assistant message uuid into a new
+/// task with its own worktree. `worktree_state` controls whether the new
+/// worktree is restored to the per-turn snapshot ("snapshot") or seeded from
+/// the parent's current code ("current").
+#[tauri::command]
+pub async fn fork_session_to_new_task(
+    app: AppHandle,
+    pool: State<'_, SqlitePool>,
+    db_tx: State<'_, DbWriteTx>,
+    session_id: String,
+    fork_after_message_uuid: String,
+    worktree_state: task::WorktreeForkState,
+) -> Result<TaskWithSession, String> {
+    let (task, session) = task::fork_session_to_new_task(
+        &app,
+        pool.inner(),
+        db_tx.inner(),
+        session_id,
+        fork_after_message_uuid,
+        worktree_state,
+    )
+    .await?;
+    Ok(TaskWithSession { task, session })
+}
+
 /// Send a message to Claude in this session.
 /// Spawns claude -p with --resume if we have a prior session_id.
 #[allow(clippy::too_many_arguments)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod claude_jsonl;
 mod db;
 mod env_path;
 mod git_ops;
@@ -6,6 +7,7 @@ mod ipc;
 mod lsp;
 mod policy;
 mod pty;
+mod snapshots;
 mod stream;
 mod task;
 mod watcher;
@@ -234,6 +236,8 @@ pub fn run() {
             ipc::list_sessions,
             ipc::get_session,
             ipc::get_output_lines,
+            ipc::fork_session_in_task,
+            ipc::fork_session_to_new_task,
             // Policy / Trust levels
             ipc::set_trust_level,
             ipc::get_trust_level,

--- a/src-tauri/src/snapshots.rs
+++ b/src-tauri/src/snapshots.rs
@@ -1,0 +1,316 @@
+// Per-turn worktree snapshots used by the "fork from a past message" feature.
+//
+// We capture the worktree state using git plumbing with a temporary index file
+// (so the user's real index is untouched). The flow:
+//
+//   1. Copy the real .git/index to a temp file
+//   2. Run `git add -A` against the temp index to stage tracked + untracked
+//   3. `git write-tree` against the temp index → tree SHA containing everything
+//   4. `git commit-tree <tree> -p HEAD` → commit SHA pointing at HEAD as parent
+//   5. Discard the temp index
+//
+// We avoid `git stash create -u` because Apple Git's implementation does not
+// actually include untracked files in the resulting commit (it produces only
+// 2 parents, no untracked tree).
+//
+// The resulting SHA is anchored under refs/verun/snapshots/<session>/<msg_uuid>
+// so `git gc` will not reap it.
+//
+// Restore creates a new worktree detached at the snapshot's HEAD parent and
+// then resets its working tree + index to the snapshot's tree, which already
+// contains everything (tracked + untracked).
+
+use std::path::Path;
+use std::process::Command;
+
+#[derive(Debug)]
+pub enum SnapshotError {
+    Io(String),
+    GitFailed { cmd: String, stderr: String },
+}
+
+impl std::fmt::Display for SnapshotError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SnapshotError::Io(s) => write!(f, "snapshot io error: {s}"),
+            SnapshotError::GitFailed { cmd, stderr } => {
+                write!(f, "git {cmd} failed: {stderr}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for SnapshotError {}
+
+fn git(repo: &Path) -> Command {
+    let mut cmd = Command::new("git");
+    cmd.current_dir(repo)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_INDEX_FILE")
+        .env_remove("GIT_WORK_TREE");
+    cmd
+}
+
+fn run_git(repo: &Path, args: &[&str]) -> Result<String, SnapshotError> {
+    let output = git(repo)
+        .args(args)
+        .output()
+        .map_err(|e| SnapshotError::Io(e.to_string()))?;
+    if !output.status.success() {
+        return Err(SnapshotError::GitFailed {
+            cmd: args.join(" "),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        });
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+/// Capture the current state of a worktree (tracked + index + untracked) as a
+/// git commit object, without touching the working tree or the user's index.
+///
+/// Returns the SHA of the snapshot commit, or `None` if the worktree has no
+/// HEAD yet (brand-new repo with no commits — uncommon for Verun).
+///
+/// The SHA is anchored under `refs/verun/snapshots/<session_id>/<message_uuid>`
+/// so `git gc` will not collect it.
+pub fn snapshot_turn(
+    worktree: &Path,
+    session_id: &str,
+    message_uuid: &str,
+) -> Result<Option<String>, SnapshotError> {
+    let head = run_git(worktree, &["rev-parse", "HEAD"]).ok();
+    let head_sha = match head {
+        Some(s) if !s.is_empty() => s,
+        _ => return Ok(None),
+    };
+
+    // Use a temporary index file so the user's real index is untouched. We
+    // include a nanosecond-precision timestamp + atomic counter so concurrent
+    // snapshots and re-runs never collide on the .lock file git creates.
+    static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let counter = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let tmp_index = std::env::temp_dir().join(format!(
+        "verun-snap-{}-{}-{}-{}.idx",
+        std::process::id(),
+        nanos,
+        counter,
+        message_uuid.replace('/', "_"),
+    ));
+    let lock_file = tmp_index.with_extension("idx.lock");
+    let _ = std::fs::remove_file(&tmp_index);
+    let _ = std::fs::remove_file(&lock_file);
+
+    // Worktrees have a .git file pointing to the real gitdir, not a directory.
+    // `git rev-parse --git-path index` resolves to the correct index path
+    // regardless of whether this is the main checkout or a linked worktree.
+    let index_path = run_git(worktree, &["rev-parse", "--git-path", "index"])?;
+    let real_index_buf = std::path::PathBuf::from(&index_path);
+    let real_index = if real_index_buf.is_absolute() {
+        real_index_buf
+    } else {
+        worktree.join(&index_path)
+    };
+
+    // Best-effort copy. If the real index doesn't exist yet (very fresh repo),
+    // start from an empty temp index — `git add -A` will populate it.
+    if real_index.exists() {
+        std::fs::copy(&real_index, &tmp_index)
+            .map_err(|e| SnapshotError::Io(format!("copy index: {e}")))?;
+    }
+
+    let tmp_index_str = tmp_index
+        .to_str()
+        .ok_or_else(|| SnapshotError::Io("non-utf8 tmp index path".into()))?;
+
+    // Stage tracked + untracked into the temp index.
+    let add_status = git(worktree)
+        .env("GIT_INDEX_FILE", tmp_index_str)
+        .args(["add", "-A"])
+        .output()
+        .map_err(|e| SnapshotError::Io(e.to_string()))?;
+    if !add_status.status.success() {
+        let _ = std::fs::remove_file(&tmp_index);
+        let _ = std::fs::remove_file(&lock_file);
+        return Err(SnapshotError::GitFailed {
+            cmd: "add -A".into(),
+            stderr: String::from_utf8_lossy(&add_status.stderr).into_owned(),
+        });
+    }
+
+    // Write the temp index out to a tree.
+    let tree_out = git(worktree)
+        .env("GIT_INDEX_FILE", tmp_index_str)
+        .args(["write-tree"])
+        .output()
+        .map_err(|e| SnapshotError::Io(e.to_string()))?;
+    let _ = std::fs::remove_file(&tmp_index);
+    let _ = std::fs::remove_file(&lock_file);
+    if !tree_out.status.success() {
+        return Err(SnapshotError::GitFailed {
+            cmd: "write-tree".into(),
+            stderr: String::from_utf8_lossy(&tree_out.stderr).into_owned(),
+        });
+    }
+    let tree_sha = String::from_utf8_lossy(&tree_out.stdout).trim().to_string();
+
+    // Commit the tree with HEAD as the sole parent so the snapshot has a clean
+    // single-parent shape that's easy to restore from.
+    let commit_sha = run_git(
+        worktree,
+        &[
+            "commit-tree",
+            &tree_sha,
+            "-p",
+            &head_sha,
+            "-m",
+            "verun turn snapshot",
+        ],
+    )?;
+
+    anchor_ref(worktree, session_id, message_uuid, &commit_sha)?;
+    Ok(Some(commit_sha))
+}
+
+fn anchor_ref(
+    worktree: &Path,
+    session_id: &str,
+    message_uuid: &str,
+    sha: &str,
+) -> Result<(), SnapshotError> {
+    let refname = format!("refs/verun/snapshots/{session_id}/{message_uuid}");
+    run_git(worktree, &["update-ref", &refname, sha])?;
+    Ok(())
+}
+
+/// Restore a snapshot into a brand-new worktree at `new_worktree_path`.
+///
+/// The new worktree's HEAD is detached at the snapshot's parent (the original
+/// HEAD at snapshot time), and its working tree + index are reset to the
+/// snapshot's tree. Because we used `git add -A` against a temporary index
+/// when snapshotting, the tree already contains tracked + untracked files in
+/// a single tree object — one `read-tree --reset -u` restores everything.
+pub fn restore_into_new_worktree(
+    repo: &Path,
+    new_worktree_path: &Path,
+    snapshot_sha: &str,
+) -> Result<(), SnapshotError> {
+    // Resolve the snapshot's parent (the HEAD at snapshot time).
+    let head_parent = run_git(repo, &["rev-parse", &format!("{snapshot_sha}^")])
+        .unwrap_or_else(|_| snapshot_sha.to_string());
+
+    let new_path_str = new_worktree_path
+        .to_str()
+        .ok_or_else(|| SnapshotError::Io("non-utf8 worktree path".into()))?;
+
+    run_git(
+        repo,
+        &["worktree", "add", "--detach", new_path_str, &head_parent],
+    )?;
+
+    // If the snapshot is just HEAD itself (clean worktree case), there's
+    // nothing to overlay.
+    if snapshot_sha != head_parent {
+        let tree_ref = format!("{snapshot_sha}^{{tree}}");
+        run_git(
+            new_worktree_path,
+            &["read-tree", "--reset", "-u", &tree_ref],
+        )?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn init_repo() -> TempDir {
+        let dir = TempDir::new().unwrap();
+        run_git(dir.path(), &["init", "-q", "-b", "main"]).unwrap();
+        run_git(dir.path(), &["config", "user.email", "test@verun.local"]).unwrap();
+        run_git(dir.path(), &["config", "user.name", "Verun Test"]).unwrap();
+        fs::write(dir.path().join("README.md"), "hello\n").unwrap();
+        run_git(dir.path(), &["add", "README.md"]).unwrap();
+        run_git(dir.path(), &["commit", "-q", "-m", "init"]).unwrap();
+        dir
+    }
+
+    #[test]
+    fn snapshot_clean_worktree_returns_commit_with_head_parent() {
+        let dir = init_repo();
+        let sha = snapshot_turn(dir.path(), "sess", "msg1").unwrap().unwrap();
+        let head = run_git(dir.path(), &["rev-parse", "HEAD"]).unwrap();
+        // Snapshot's parent should be HEAD.
+        let parent = run_git(dir.path(), &["rev-parse", &format!("{sha}^")]).unwrap();
+        assert_eq!(parent, head);
+    }
+
+    #[test]
+    fn snapshot_captures_uncommitted_and_untracked_without_touching_worktree() {
+        let dir = init_repo();
+        // Modify tracked file + add an untracked one + leave a real index entry.
+        fs::write(dir.path().join("README.md"), "hello\nchanged\n").unwrap();
+        fs::write(dir.path().join("new.txt"), "untracked content\n").unwrap();
+
+        let sha = snapshot_turn(dir.path(), "sess", "msg1").unwrap().unwrap();
+
+        // Snapshot tree should contain BOTH README.md (modified) and new.txt.
+        let tree_listing =
+            run_git(dir.path(), &["ls-tree", "-r", &sha]).unwrap();
+        assert!(tree_listing.contains("README.md"));
+        assert!(tree_listing.contains("new.txt"));
+
+        // Worktree should be untouched and its real index should still be clean
+        // (the temp index dance must not have modified .git/index).
+        assert_eq!(
+            fs::read_to_string(dir.path().join("README.md")).unwrap(),
+            "hello\nchanged\n"
+        );
+        assert_eq!(
+            fs::read_to_string(dir.path().join("new.txt")).unwrap(),
+            "untracked content\n"
+        );
+        // Read status without our run_git trim() so we see the leading space
+        // that distinguishes ` M` (unstaged) from `M ` (staged).
+        let raw = git(dir.path()).args(["status", "--porcelain"]).output().unwrap();
+        let real_status = String::from_utf8_lossy(&raw.stdout).into_owned();
+        let lines: Vec<&str> = real_status.lines().collect();
+        let readme = lines.iter().find(|l| l.contains("README.md")).expect("README.md status missing");
+        assert!(
+            readme.starts_with(" M"),
+            "expected unstaged modification, got: {readme:?}"
+        );
+        assert!(
+            real_status.contains("?? new.txt"),
+            "expected untracked, got: {real_status:?}"
+        );
+        assert!(
+            !real_status.contains("M  README.md"),
+            "real index was modified, got: {real_status:?}"
+        );
+    }
+
+    #[test]
+    fn restore_reproduces_uncommitted_state() {
+        let dir = init_repo();
+        fs::write(dir.path().join("README.md"), "hello\nv2\n").unwrap();
+        fs::write(dir.path().join("untracked.txt"), "extra\n").unwrap();
+        let sha = snapshot_turn(dir.path(), "sess", "msg1").unwrap().unwrap();
+
+        // Now mutate the worktree further to prove restore is independent.
+        fs::write(dir.path().join("README.md"), "hello\nv3\n").unwrap();
+
+        let new_dir = TempDir::new().unwrap();
+        let new_path = new_dir.path().join("restored");
+        restore_into_new_worktree(dir.path(), &new_path, &sha).unwrap();
+
+        assert_eq!(fs::read_to_string(new_path.join("README.md")).unwrap(), "hello\nv2\n");
+        assert_eq!(fs::read_to_string(new_path.join("untracked.txt")).unwrap(), "extra\n");
+    }
+}

--- a/src-tauri/src/snapshots.rs
+++ b/src-tauri/src/snapshots.rs
@@ -78,15 +78,33 @@ pub fn snapshot_turn(
     session_id: &str,
     message_uuid: &str,
 ) -> Result<Option<String>, SnapshotError> {
+    let Some(commit_sha) = build_snapshot_commit(worktree)? else {
+        return Ok(None);
+    };
+    anchor_ref(worktree, session_id, message_uuid, &commit_sha)?;
+    Ok(Some(commit_sha))
+}
+
+/// Capture the current worktree state as a commit object WITHOUT anchoring a
+/// ref. Used for the "fork with current code" path where we want to carry
+/// the parent's uncommitted work into a new worktree but don't want to leak
+/// a ref under refs/verun/snapshots/ that git gc will never reap.
+///
+/// The returned commit is unreferenced and will be garbage-collected when
+/// the caller is done with it. Callers should use the SHA immediately.
+pub fn ephemeral_snapshot(worktree: &Path) -> Result<Option<String>, SnapshotError> {
+    build_snapshot_commit(worktree)
+}
+
+/// Build a snapshot commit object (no ref anchoring). Shared between
+/// `snapshot_turn` (which anchors) and `ephemeral_snapshot` (which doesn't).
+fn build_snapshot_commit(worktree: &Path) -> Result<Option<String>, SnapshotError> {
     let head = run_git(worktree, &["rev-parse", "HEAD"]).ok();
     let head_sha = match head {
         Some(s) if !s.is_empty() => s,
         _ => return Ok(None),
     };
 
-    // Use a temporary index file so the user's real index is untouched. We
-    // include a nanosecond-precision timestamp + atomic counter so concurrent
-    // snapshots and re-runs never collide on the .lock file git creates.
     static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
     let counter = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let nanos = std::time::SystemTime::now()
@@ -94,19 +112,15 @@ pub fn snapshot_turn(
         .map(|d| d.as_nanos())
         .unwrap_or(0);
     let tmp_index = std::env::temp_dir().join(format!(
-        "verun-snap-{}-{}-{}-{}.idx",
+        "verun-eph-{}-{}-{}.idx",
         std::process::id(),
         nanos,
         counter,
-        message_uuid.replace('/', "_"),
     ));
     let lock_file = tmp_index.with_extension("idx.lock");
     let _ = std::fs::remove_file(&tmp_index);
     let _ = std::fs::remove_file(&lock_file);
 
-    // Worktrees have a .git file pointing to the real gitdir, not a directory.
-    // `git rev-parse --git-path index` resolves to the correct index path
-    // regardless of whether this is the main checkout or a linked worktree.
     let index_path = run_git(worktree, &["rev-parse", "--git-path", "index"])?;
     let real_index_buf = std::path::PathBuf::from(&index_path);
     let real_index = if real_index_buf.is_absolute() {
@@ -114,9 +128,6 @@ pub fn snapshot_turn(
     } else {
         worktree.join(&index_path)
     };
-
-    // Best-effort copy. If the real index doesn't exist yet (very fresh repo),
-    // start from an empty temp index — `git add -A` will populate it.
     if real_index.exists() {
         std::fs::copy(&real_index, &tmp_index)
             .map_err(|e| SnapshotError::Io(format!("copy index: {e}")))?;
@@ -126,7 +137,6 @@ pub fn snapshot_turn(
         .to_str()
         .ok_or_else(|| SnapshotError::Io("non-utf8 tmp index path".into()))?;
 
-    // Stage tracked + untracked into the temp index.
     let add_status = git(worktree)
         .env("GIT_INDEX_FILE", tmp_index_str)
         .args(["add", "-A"])
@@ -141,7 +151,6 @@ pub fn snapshot_turn(
         });
     }
 
-    // Write the temp index out to a tree.
     let tree_out = git(worktree)
         .env("GIT_INDEX_FILE", tmp_index_str)
         .args(["write-tree"])
@@ -157,8 +166,6 @@ pub fn snapshot_turn(
     }
     let tree_sha = String::from_utf8_lossy(&tree_out.stdout).trim().to_string();
 
-    // Commit the tree with HEAD as the sole parent so the snapshot has a clean
-    // single-parent shape that's easy to restore from.
     let commit_sha = run_git(
         worktree,
         &[
@@ -170,8 +177,6 @@ pub fn snapshot_turn(
             "verun turn snapshot",
         ],
     )?;
-
-    anchor_ref(worktree, session_id, message_uuid, &commit_sha)?;
     Ok(Some(commit_sha))
 }
 

--- a/src-tauri/src/stream.rs
+++ b/src-tauri/src/stream.rs
@@ -1,7 +1,10 @@
+use crate::claude_jsonl;
 use crate::db::{DbWrite, DbWriteTx};
 use crate::policy::{self, PolicyDecision, TrustLevel};
+use crate::snapshots;
 use crate::task::{ApprovalResponse, PendingApprovalEntry, PendingApprovalMeta, PendingApprovals};
 use serde::Serialize;
+use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter};
@@ -56,6 +59,12 @@ pub enum OutputItem {
         input_tokens: Option<u64>,
         output_tokens: Option<u64>,
     },
+
+    /// Per-turn snapshot marker — frontend attaches the message uuid to the
+    /// most recent assistant block so the "fork from here" affordance has a
+    /// stable identifier to send back to the backend.
+    #[serde(rename_all = "camelCase")]
+    TurnSnapshot { message_uuid: String },
 
     /// Raw line (fallback for unrecognized events)
     #[serde(rename_all = "camelCase")]
@@ -368,6 +377,139 @@ pub struct StreamResult {
 /// When a `control_request` (tool approval) is detected, we emit it to the
 /// frontend and block until the user responds via `respond_to_approval`.
 #[allow(clippy::too_many_arguments)]
+/// After a turn ends, snapshot the worktree and persist a `turn_snapshots`
+/// row keyed to the latest assistant message uuid in the on-disk JSONL.
+///
+/// All failures are logged and swallowed — the snapshot machinery is
+/// best-effort and must never break the streaming hot path.
+async fn snapshot_turn_best_effort(
+    verun_session_id: &str,
+    worktree_path: &str,
+    claude_session_id: Option<&str>,
+    db_tx: &DbWriteTx,
+    app: &AppHandle,
+) {
+    let csid = match claude_session_id {
+        Some(s) => s.to_string(),
+        None => return,
+    };
+    let worktree = worktree_path.to_string();
+    let verun_sid = verun_session_id.to_string();
+    let db_tx = db_tx.clone();
+    let app = app.clone();
+
+    // Do all blocking I/O off the runtime thread.
+    let result = tokio::task::spawn_blocking(move || {
+        let wt_path = Path::new(&worktree);
+        let jsonl = match claude_jsonl::session_path(wt_path, &csid) {
+            Some(p) => p,
+            None => return Err("no $HOME for jsonl path".to_string()),
+        };
+        if !jsonl.exists() {
+            return Err(format!("jsonl not found: {}", jsonl.display()));
+        }
+        let last_uuid = latest_assistant_text_uuid(&jsonl)
+            .ok_or_else(|| "no assistant text uuid in jsonl".to_string())?;
+        let sha = snapshots::snapshot_turn(wt_path, &verun_sid, &last_uuid)
+            .map_err(|e| e.to_string())?
+            .ok_or_else(|| "snapshot returned None (no HEAD?)".to_string())?;
+        Ok::<(String, String), String>((last_uuid, sha))
+    })
+    .await;
+
+    match result {
+        Ok(Ok((message_uuid, stash_sha))) => {
+            let now = now_ms();
+            let _ = db_tx
+                .send(DbWrite::InsertTurnSnapshot {
+                    session_id: verun_session_id.to_string(),
+                    message_uuid: message_uuid.clone(),
+                    stash_sha,
+                    created_at: now,
+                })
+                .await;
+
+            // Persist a synthetic marker line into output_lines so the frontend
+            // can attach the message uuid to the most recent assistant block on
+            // session reload, and so the fork operation can find the truncation
+            // boundary in output_lines without having to re-parse stream state.
+            let marker = serde_json::json!({
+                "type": "verun_turn_snapshot",
+                "sessionId": verun_session_id,
+                "messageUuid": message_uuid,
+            })
+            .to_string();
+            let _ = db_tx
+                .send(DbWrite::InsertOutputLines {
+                    session_id: verun_session_id.to_string(),
+                    lines: vec![(marker.clone(), now)],
+                })
+                .await;
+
+            // Also push the marker as a live event so any open chat view picks
+            // it up immediately without a session reload.
+            let _ = app.emit(
+                "session-output",
+                SessionOutputEvent {
+                    session_id: verun_session_id.to_string(),
+                    items: vec![OutputItem::TurnSnapshot {
+                        message_uuid: message_uuid.clone(),
+                    }],
+                },
+            );
+        }
+        Ok(Err(e)) => eprintln!("[verun] snapshot_turn skipped: {e}"),
+        Err(e) => eprintln!("[verun] snapshot_turn join error: {e}"),
+    }
+}
+
+/// Walk a Claude Code session JSONL and return the uuid of the most recent
+/// `type=assistant` line whose message content contains a `text` block.
+fn latest_assistant_text_uuid(jsonl_path: &Path) -> Option<String> {
+    use std::io::{BufRead, BufReader};
+    let f = std::fs::File::open(jsonl_path).ok()?;
+    let reader = BufReader::new(f);
+    let mut last: Option<String> = None;
+    for line in reader.lines().map_while(Result::ok) {
+        if line.is_empty() {
+            continue;
+        }
+        let v: serde_json::Value = match serde_json::from_str(&line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        if v.get("type").and_then(|t| t.as_str()) != Some("assistant") {
+            continue;
+        }
+        let content = v
+            .get("message")
+            .and_then(|m| m.get("content"))
+            .and_then(|c| c.as_array());
+        let has_text = match content {
+            Some(arr) => arr
+                .iter()
+                .any(|c| c.get("type").and_then(|t| t.as_str()) == Some("text")),
+            None => false,
+        };
+        if !has_text {
+            continue;
+        }
+        if let Some(uuid) = v.get("uuid").and_then(|u| u.as_str()) {
+            last = Some(uuid.to_string());
+        }
+    }
+    last
+}
+
+fn now_ms() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+#[allow(clippy::too_many_arguments)]
 pub async fn stream_and_capture(
     app: AppHandle,
     session_id: String,
@@ -387,6 +529,8 @@ pub async fn stream_and_capture(
     let mut last_flush = Instant::now();
     let mut total_persisted: usize = 0;
     let mut total_cost: f64 = 0.0;
+    // Captured from `system.init` events for the per-turn snapshot hook.
+    let mut claude_session_id_for_snapshot: Option<String> = None;
 
     loop {
         let deadline = tokio::time::sleep(FLUSH_INTERVAL);
@@ -412,6 +556,20 @@ pub async fn stream_and_capture(
                                 }
                                 persist_line(&db_tx, &session_id, &line, &mut total_persisted);
                                 continue;
+                            }
+                        }
+
+                        // Capture claude session_id from `system.init` so the snapshot hook
+                        // at turn end can locate the on-disk JSONL transcript.
+                        if claude_session_id_for_snapshot.is_none() {
+                            if let Ok(v) = serde_json::from_str::<serde_json::Value>(&line) {
+                                if v.get("type").and_then(|t| t.as_str()) == Some("system")
+                                    && v.get("subtype").and_then(|t| t.as_str()) == Some("init")
+                                {
+                                    if let Some(sid) = v.get("session_id").and_then(|s| s.as_str()) {
+                                        claude_session_id_for_snapshot = Some(sid.to_string());
+                                    }
+                                }
                             }
                         }
 
@@ -472,10 +630,37 @@ pub async fn stream_and_capture(
                             drop(guard.take());
                         }
 
-                        // Flush non-streaming buffer periodically
-                        if !buffer.is_empty() && (has_immediate || last_flush.elapsed() >= FLUSH_INTERVAL) {
+                        // Flush buffer. On turn end we ALWAYS flush so the TurnEnd
+                        // event reaches the frontend before any subsequent turn-snapshot
+                        // marker — otherwise the marker walks back to find an assistant
+                        // block that hasn't been created yet.
+                        if !buffer.is_empty()
+                            && (has_immediate || is_turn_end || last_flush.elapsed() >= FLUSH_INTERVAL)
+                        {
                             flush_buffer(&app, &session_id, &mut buffer);
                             last_flush = Instant::now();
+                        }
+
+                        // Fire-and-forget: snapshot the worktree and persist a turn_snapshots
+                        // row keyed to the latest assistant message uuid in the on-disk JSONL.
+                        // Used by the "fork from this message" feature. We deliberately do
+                        // NOT await this so the stream loop is never blocked on git I/O.
+                        if is_turn_end {
+                            let sid = session_id.clone();
+                            let wt = worktree_path.clone();
+                            let csid = claude_session_id_for_snapshot.clone();
+                            let dbtx = db_tx.clone();
+                            let app2 = app.clone();
+                            tokio::spawn(async move {
+                                snapshot_turn_best_effort(
+                                    &sid,
+                                    &wt,
+                                    csid.as_deref(),
+                                    &dbtx,
+                                    &app2,
+                                )
+                                .await;
+                            });
                         }
                     }
                     Ok(None) => break,

--- a/src-tauri/src/stream.rs
+++ b/src-tauri/src/stream.rs
@@ -368,15 +368,6 @@ pub struct StreamResult {
     pub total_cost: f64,
 }
 
-/// Stream stdout from the claude process, parse NDJSON events, emit
-/// structured items to frontend, persist to DB, and return all captured lines.
-///
-/// Text and thinking deltas are emitted immediately for real-time feel.
-/// Other items are batched with a short flush interval.
-///
-/// When a `control_request` (tool approval) is detected, we emit it to the
-/// frontend and block until the user responds via `respond_to_approval`.
-#[allow(clippy::too_many_arguments)]
 /// After a turn ends, snapshot the worktree and persist a `turn_snapshots`
 /// row keyed to the latest assistant message uuid in the on-disk JSONL.
 ///
@@ -509,6 +500,14 @@ fn now_ms() -> i64 {
         .unwrap_or(0)
 }
 
+/// Stream stdout from the claude process, parse NDJSON events, emit
+/// structured items to frontend, persist to DB, and return all captured lines.
+///
+/// Text and thinking deltas are emitted immediately for real-time feel.
+/// Other items are batched with a short flush interval.
+///
+/// When a `control_request` (tool approval) is detected, we emit it to the
+/// frontend and block until the user responds via `respond_to_approval`.
 #[allow(clippy::too_many_arguments)]
 pub async fn stream_and_capture(
     app: AppHandle,

--- a/src-tauri/src/task.rs
+++ b/src-tauri/src/task.rs
@@ -1061,10 +1061,10 @@ pub enum WorktreeForkState {
 ///
 /// We also copy the parent's `output_lines` rows up to and including the
 /// `verun_turn_snapshot` marker for `fork_after_message_uuid` so the new
-/// session's chat view shows the inherited history.
+/// session's chat view shows the inherited history. Session row + output
+/// lines are written in a single transaction for consistency.
 pub async fn fork_session_in_task(
     pool: &sqlx::sqlite::SqlitePool,
-    db_tx: &DbWriteTx,
     source_session_id: String,
     fork_after_message_uuid: String,
 ) -> Result<Session, String> {
@@ -1106,11 +1106,10 @@ pub async fn fork_session_in_task(
     .await
     .map_err(|e| format!("spawn_blocking: {e}"))??;
 
-    // Insert the new session row + copied output_lines synchronously via the
-    // pool. If we used the async DbWrite queue here the IPC would return
-    // before persistence completed and the frontend's immediate
-    // loadOutputLines call would see an empty session.
-    let _ = db_tx; // intentionally unused on this path
+    // Load parent output_lines outside the transaction so we can hold the
+    // boundary check's error path separate from DB state.
+    let parent_lines = db::get_output_lines(pool, &parent.id).await?;
+
     let new_session = Session {
         id: new_verun_sid.clone(),
         task_id: parent.task_id.clone(),
@@ -1123,28 +1122,61 @@ pub async fn fork_session_in_task(
         parent_session_id: Some(parent.id.clone()),
         forked_at_message_uuid: Some(fork_after_message_uuid.clone()),
     };
-    insert_session_row(pool, &new_session).await?;
 
-    // Copy parent's output_lines up to and including the matching
-    // verun_turn_snapshot marker.
-    let parent_lines = db::get_output_lines(pool, &parent.id).await?;
-    let needle = format!("\"messageUuid\":\"{fork_after_message_uuid}\"");
-    let mut copied: Vec<(String, i64)> = Vec::new();
-    for ol in &parent_lines {
-        copied.push((ol.line.clone(), ol.emitted_at));
-        if ol.line.contains("\"verun_turn_snapshot\"") && ol.line.contains(&needle) {
-            break;
-        }
-    }
-    if !copied.is_empty() {
-        insert_output_lines_sync(pool, &new_verun_sid, &copied).await?;
-    }
+    // Single transaction: insert session row + copy output_lines up to the
+    // matching verun_turn_snapshot marker. If the marker is missing we fail
+    // BEFORE committing so the DB stays clean.
+    let mut tx = pool.begin().await.map_err(|e| e.to_string())?;
+    insert_session_row_tx(&mut tx, &new_session).await?;
+    copy_output_lines_up_to_marker_tx(
+        &mut tx,
+        &parent_lines,
+        &new_verun_sid,
+        &fork_after_message_uuid,
+    )
+    .await?;
+    tx.commit().await.map_err(|e| format!("commit: {e}"))?;
 
     Ok(new_session)
 }
 
-async fn insert_session_row(
-    pool: &sqlx::sqlite::SqlitePool,
+/// Copy parent output_lines to the new session up to and including the
+/// `verun_turn_snapshot` marker whose `messageUuid` matches `fork_uuid`.
+/// Fails with a clear error if the marker is missing — otherwise the copy
+/// silently includes the entire parent session.
+async fn copy_output_lines_up_to_marker_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    parent_lines: &[crate::db::OutputLine],
+    new_session_id: &str,
+    fork_uuid: &str,
+) -> Result<(), String> {
+    let needle = format!("\"messageUuid\":\"{fork_uuid}\"");
+    let mut found = false;
+    let mut insert_count = 0usize;
+    for ol in parent_lines {
+        sqlx::query("INSERT INTO output_lines (session_id, line, emitted_at) VALUES (?, ?, ?)")
+            .bind(new_session_id)
+            .bind(&ol.line)
+            .bind(ol.emitted_at)
+            .execute(&mut **tx)
+            .await
+            .map_err(|e| format!("insert output_line: {e}"))?;
+        insert_count += 1;
+        if ol.line.contains("\"verun_turn_snapshot\"") && ol.line.contains(&needle) {
+            found = true;
+            break;
+        }
+    }
+    if !found {
+        return Err(format!(
+            "fork marker not found for message {fork_uuid} (scanned {insert_count} rows)"
+        ));
+    }
+    Ok(())
+}
+
+async fn insert_session_row_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
     s: &Session,
 ) -> Result<(), String> {
     sqlx::query(
@@ -1161,14 +1193,14 @@ async fn insert_session_row(
     .bind(s.total_cost)
     .bind(&s.parent_session_id)
     .bind(&s.forked_at_message_uuid)
-    .execute(pool)
+    .execute(&mut **tx)
     .await
     .map_err(|e| format!("insert session: {e}"))?;
     Ok(())
 }
 
-async fn insert_task_row(
-    pool: &sqlx::sqlite::SqlitePool,
+async fn insert_task_row_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
     t: &Task,
 ) -> Result<(), String> {
     sqlx::query(
@@ -1183,28 +1215,9 @@ async fn insert_task_row(
     .bind(t.created_at)
     .bind(t.port_offset)
     .bind(&t.parent_task_id)
-    .execute(pool)
+    .execute(&mut **tx)
     .await
     .map_err(|e| format!("insert task: {e}"))?;
-    Ok(())
-}
-
-async fn insert_output_lines_sync(
-    pool: &sqlx::sqlite::SqlitePool,
-    session_id: &str,
-    lines: &[(String, i64)],
-) -> Result<(), String> {
-    let mut tx = pool.begin().await.map_err(|e| e.to_string())?;
-    for (line, emitted_at) in lines {
-        sqlx::query("INSERT INTO output_lines (session_id, line, emitted_at) VALUES (?, ?, ?)")
-            .bind(session_id)
-            .bind(line)
-            .bind(emitted_at)
-            .execute(&mut *tx)
-            .await
-            .map_err(|e| format!("insert output_line: {e}"))?;
-    }
-    tx.commit().await.map_err(|e| e.to_string())?;
     Ok(())
 }
 
@@ -1213,11 +1226,12 @@ async fn insert_output_lines_sync(
 /// `worktree_state` controls whether the new worktree starts from the
 /// per-turn snapshot taken at the chosen message (true counterfactual) or
 /// from the parent's current worktree state (HEAD + any uncommitted edits).
-#[allow(clippy::too_many_arguments)]
+///
+/// Returns the new task + session. The caller is responsible for spawning
+/// the project's setup hook on the new worktree (see ipc::fork_session_to_new_task).
 pub async fn fork_session_to_new_task(
     app: &AppHandle,
     pool: &sqlx::sqlite::SqlitePool,
-    db_tx: &DbWriteTx,
     source_session_id: String,
     fork_after_message_uuid: String,
     worktree_state: WorktreeForkState,
@@ -1249,6 +1263,11 @@ pub async fn fork_session_to_new_task(
         WorktreeForkState::Current => None,
     };
 
+    // Load parent output_lines BEFORE creating the worktree so a missing
+    // marker fails fast without leaving stray filesystem state behind.
+    let parent_lines = db::get_output_lines(pool, &parent_session.id).await?;
+    validate_fork_marker_present(&parent_lines, &fork_after_message_uuid)?;
+
     // Create the new worktree (off the runtime).
     let branch = funny_branch_name();
     let repo_path = project.repo_path.clone();
@@ -1260,7 +1279,7 @@ pub async fn fork_session_to_new_task(
         match snapshot_for_blocking {
             Some(sha) => {
                 // Build the new worktree path manually so we can hand it to
-                // restore_into_new_worktree, then add a branch label after.
+                // restore_into_new_worktree, then attach a real branch after.
                 let new_path = std::path::Path::new(&repo_path)
                     .join(".verun")
                     .join("worktrees")
@@ -1277,31 +1296,40 @@ pub async fn fork_session_to_new_task(
                 .map_err(|e| e.to_string())?;
                 // Attach the funny branch name pointing at the snapshot's HEAD
                 // parent so subsequent commits go on a real branch (not detached).
-                let _ = std::process::Command::new("git")
-                    .current_dir(&new_path_str)
-                    .args(["checkout", "-b", &branch_for_blocking])
-                    .output();
+                run_git_ignoring_env(&new_path, &["checkout", "-b", &branch_for_blocking])
+                    .map_err(|e| format!("git checkout -b {branch_for_blocking}: {e}"))?;
                 Ok(new_path_str)
             }
             None => {
                 // Plain worktree creation, then overlay the parent's current
-                // tracked + untracked changes via the snapshot mechanism so
-                // we don't lose uncommitted work.
+                // tracked + untracked changes via a transient commit-tree so
+                // uncommitted work is carried over. Unlike the per-turn
+                // snapshot machinery this does NOT anchor a ref — git gc
+                // will reap the transient commit when nothing else holds it.
                 let new_path = crate::worktree::create_worktree(
                     &repo_path,
                     &branch_for_blocking,
                     &base_branch,
                 )?;
                 let parent_wt = std::path::Path::new(&parent_worktree);
-                if let Ok(Some(temp_sha)) =
-                    crate::snapshots::snapshot_turn(parent_wt, "fork-current", "transient")
-                {
-                    let new_pb = std::path::PathBuf::from(&new_path);
-                    let tree_ref = format!("{temp_sha}^{{tree}}");
-                    let _ = std::process::Command::new("git")
-                        .current_dir(&new_pb)
-                        .args(["read-tree", "--reset", "-u", &tree_ref])
-                        .output();
+                match crate::snapshots::ephemeral_snapshot(parent_wt) {
+                    Ok(Some(temp_sha)) => {
+                        let new_pb = std::path::PathBuf::from(&new_path);
+                        let tree_ref = format!("{temp_sha}^{{tree}}");
+                        run_git_ignoring_env(
+                            &new_pb,
+                            &["read-tree", "--reset", "-u", &tree_ref],
+                        )
+                        .map_err(|e| format!("git read-tree on new worktree: {e}"))?;
+                    }
+                    Ok(None) => {
+                        // Parent worktree has no HEAD — nothing to overlay.
+                    }
+                    Err(e) => {
+                        // Non-fatal: the new worktree is usable without the overlay,
+                        // the user just loses their uncommitted parent work.
+                        eprintln!("[verun] fork-current ephemeral snapshot failed: {e}");
+                    }
                 }
                 Ok(new_path)
             }
@@ -1310,7 +1338,6 @@ pub async fn fork_session_to_new_task(
     .await
     .map_err(|e| format!("spawn_blocking: {e}"))??;
 
-    // Insert the new task row.
     let new_task = Task {
         id: Uuid::new_v4().to_string(),
         project_id: parent_task.project_id.clone(),
@@ -1325,11 +1352,10 @@ pub async fn fork_session_to_new_task(
         last_commit_message: None,
         parent_task_id: Some(parent_task.id.clone()),
     };
-    insert_task_row(pool, &new_task).await?;
 
-    // Now build a forked session attached to the new task. Reuse
-    // fork_session_in_task's machinery but override the destination task_id
-    // by directly calling the same logic.
+    // Write the truncated on-disk JSONL into the NEW worktree's projects dir
+    // (Claude keys transcripts by cwd, so the new session's cwd is what
+    // matters for `claude --resume`).
     let new_csid = Uuid::new_v4().to_string();
     let new_verun_sid = Uuid::new_v4().to_string();
     let now = epoch_ms();
@@ -1340,10 +1366,6 @@ pub async fn fork_session_to_new_task(
     let new_wt_for_blocking = new_task.worktree_path.clone();
     let parent_wt_for_blocking = parent_task.worktree_path.clone();
     tokio::task::spawn_blocking(move || -> Result<(), String> {
-        // The on-disk JSONL is keyed by cwd. Claude wrote the parent's
-        // transcript under the parent's cwd; the new session will run in the
-        // new worktree's cwd, so we have to write the truncated JSONL into
-        // the NEW cwd's projects dir.
         let parent_wt = std::path::Path::new(&parent_wt_for_blocking);
         let new_wt = std::path::Path::new(&new_wt_for_blocking);
         let src = crate::claude_jsonl::session_path(parent_wt, &parent_csid_for_blocking)
@@ -1373,29 +1395,65 @@ pub async fn fork_session_to_new_task(
         parent_session_id: Some(parent_session.id.clone()),
         forked_at_message_uuid: Some(fork_after_message_uuid.clone()),
     };
-    insert_session_row(pool, &new_session).await?;
 
-    // Copy parent output lines up to the boundary into the new session.
-    let parent_lines = db::get_output_lines(pool, &parent_session.id).await?;
-    let needle = format!("\"messageUuid\":\"{fork_after_message_uuid}\"");
-    let mut copied: Vec<(String, i64)> = Vec::new();
-    for ol in &parent_lines {
-        copied.push((ol.line.clone(), ol.emitted_at));
-        if ol.line.contains("\"verun_turn_snapshot\"") && ol.line.contains(&needle) {
-            break;
-        }
-    }
-    if !copied.is_empty() {
-        insert_output_lines_sync(pool, &new_verun_sid, &copied).await?;
-    }
+    // Single transaction: task row + session row + copied output_lines.
+    // If anything fails, the DB rolls back cleanly. The filesystem worktree
+    // is already created at this point — on failure the caller should tell
+    // the user to clean up, but that's rare given we validated the marker up top.
+    let mut tx = pool.begin().await.map_err(|e| e.to_string())?;
+    insert_task_row_tx(&mut tx, &new_task).await?;
+    insert_session_row_tx(&mut tx, &new_session).await?;
+    copy_output_lines_up_to_marker_tx(
+        &mut tx,
+        &parent_lines,
+        &new_verun_sid,
+        &fork_after_message_uuid,
+    )
+    .await?;
+    tx.commit().await.map_err(|e| format!("commit: {e}"))?;
 
-    let _ = db_tx;
     let _ = app.emit(
         "task-created",
         serde_json::json!({ "taskId": new_task.id, "projectId": new_task.project_id }),
     );
 
     Ok((new_task, new_session))
+}
+
+/// Scan parent output_lines for a `verun_turn_snapshot` marker whose
+/// `messageUuid` matches. Fails fast before we spin up worktrees or open
+/// transactions when the fork point doesn't exist in the parent session.
+fn validate_fork_marker_present(
+    parent_lines: &[crate::db::OutputLine],
+    fork_uuid: &str,
+) -> Result<(), String> {
+    let needle = format!("\"messageUuid\":\"{fork_uuid}\"");
+    let found = parent_lines
+        .iter()
+        .any(|ol| ol.line.contains("\"verun_turn_snapshot\"") && ol.line.contains(&needle));
+    if !found {
+        return Err(format!(
+            "no turn-snapshot marker for message {fork_uuid} in parent session — the fork point must be an assistant turn that was snapshotted on turn-end"
+        ));
+    }
+    Ok(())
+}
+
+/// Run a git command in `cwd` with inherited `GIT_*` env vars stripped so
+/// the child process always operates on the given directory's own git state.
+fn run_git_ignoring_env(cwd: &std::path::Path, args: &[&str]) -> Result<(), String> {
+    let out = std::process::Command::new("git")
+        .current_dir(cwd)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_INDEX_FILE")
+        .env_remove("GIT_WORK_TREE")
+        .args(args)
+        .output()
+        .map_err(|e| e.to_string())?;
+    if !out.status.success() {
+        return Err(String::from_utf8_lossy(&out.stderr).into_owned());
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src-tauri/src/task.rs
+++ b/src-tauri/src/task.rs
@@ -1135,6 +1135,7 @@ pub async fn fork_session_in_task(
         &fork_after_message_uuid,
     )
     .await?;
+    copy_turn_snapshots_tx(&mut tx, &parent.id, &new_verun_sid).await?;
     tx.commit().await.map_err(|e| format!("commit: {e}"))?;
 
     Ok(new_session)
@@ -1172,6 +1173,32 @@ async fn copy_output_lines_up_to_marker_tx(
             "fork marker not found for message {fork_uuid} (scanned {insert_count} rows)"
         ));
     }
+    Ok(())
+}
+
+/// Copy `turn_snapshots` rows from the parent session to the newly-forked
+/// session. Without this the forked session has output_lines markers that
+/// reference message uuids, but no corresponding snapshot rows under its own
+/// session_id — so every subsequent fork from the forked session in
+/// "code as of this message" mode fails with "no snapshot exists for this
+/// message". The git commit objects themselves are shared (they're anchored
+/// under refs/verun/snapshots/<parent>/... regardless of this table), so
+/// these are cheap pointer rows, not a duplication of git state.
+async fn copy_turn_snapshots_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    parent_session_id: &str,
+    new_session_id: &str,
+) -> Result<(), String> {
+    sqlx::query(
+        "INSERT OR IGNORE INTO turn_snapshots (session_id, message_uuid, stash_sha, created_at) \
+         SELECT ?, message_uuid, stash_sha, created_at \
+         FROM turn_snapshots WHERE session_id = ?",
+    )
+    .bind(new_session_id)
+    .bind(parent_session_id)
+    .execute(&mut **tx)
+    .await
+    .map_err(|e| format!("copy turn_snapshots: {e}"))?;
     Ok(())
 }
 
@@ -1410,6 +1437,7 @@ pub async fn fork_session_to_new_task(
         &fork_after_message_uuid,
     )
     .await?;
+    copy_turn_snapshots_tx(&mut tx, &parent_session.id, &new_verun_sid).await?;
     tx.commit().await.map_err(|e| format!("commit: {e}"))?;
 
     let _ = app.emit(

--- a/src-tauri/src/task.rs
+++ b/src-tauri/src/task.rs
@@ -368,6 +368,7 @@ pub async fn create_task(
         archived: false,
         archived_at: None,
         last_commit_message: None,
+        parent_task_id: None,
     };
 
     db_tx
@@ -548,6 +549,8 @@ pub async fn create_session(db_tx: &DbWriteTx, task_id: String) -> Result<Sessio
         started_at: epoch_ms(),
         ended_at: None,
         total_cost: 0.0,
+        parent_session_id: None,
+        forked_at_message_uuid: None,
     };
 
     db_tx
@@ -1031,6 +1034,368 @@ pub fn epoch_ms() -> i64 {
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
         .as_millis() as i64
+}
+
+// ---------------------------------------------------------------------------
+// Fork from a past message
+// ---------------------------------------------------------------------------
+
+/// Worktree state to use when forking to a new task. The "in this task" fork
+/// path always preserves the parent's worktree as-is and is not gated by this
+/// enum.
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum WorktreeForkState {
+    /// Use the per-turn snapshot of the worktree taken at the chosen message.
+    Snapshot,
+    /// Copy the parent's current worktree state (HEAD + uncommitted changes).
+    Current,
+}
+
+/// Fork a session at a specific assistant message uuid into a NEW session
+/// inside the SAME task (the worktree is unchanged).
+///
+/// The new session has a fresh claude session id; we hand-craft a truncated
+/// JSONL transcript at `~/.claude/projects/<dir>/<new-uuid>.jsonl` so
+/// `claude --resume <new-uuid>` picks up exactly the prefix the user chose.
+///
+/// We also copy the parent's `output_lines` rows up to and including the
+/// `verun_turn_snapshot` marker for `fork_after_message_uuid` so the new
+/// session's chat view shows the inherited history.
+pub async fn fork_session_in_task(
+    pool: &sqlx::sqlite::SqlitePool,
+    db_tx: &DbWriteTx,
+    source_session_id: String,
+    fork_after_message_uuid: String,
+) -> Result<Session, String> {
+    let parent = db::get_session(pool, &source_session_id)
+        .await?
+        .ok_or_else(|| format!("Session {source_session_id} not found"))?;
+    let parent_csid = parent
+        .claude_session_id
+        .clone()
+        .ok_or_else(|| "Parent session has no claude session id (never started?)".to_string())?;
+
+    let task = db::get_task(pool, &parent.task_id)
+        .await?
+        .ok_or_else(|| format!("Task {} not found", parent.task_id))?;
+
+    let new_csid = Uuid::new_v4().to_string();
+    let new_verun_sid = Uuid::new_v4().to_string();
+    let now = epoch_ms();
+
+    // Truncate the on-disk JSONL transcript.
+    let worktree_path = task.worktree_path.clone();
+    let parent_csid_for_blocking = parent_csid.clone();
+    let new_csid_for_blocking = new_csid.clone();
+    let fork_uuid_for_blocking = fork_after_message_uuid.clone();
+    tokio::task::spawn_blocking(move || {
+        let wt = std::path::Path::new(&worktree_path);
+        let src = crate::claude_jsonl::session_path(wt, &parent_csid_for_blocking)
+            .ok_or_else(|| "no $HOME for jsonl path".to_string())?;
+        let dest = crate::claude_jsonl::session_path(wt, &new_csid_for_blocking)
+            .ok_or_else(|| "no $HOME for jsonl path".to_string())?;
+        crate::claude_jsonl::truncate_after_message(
+            &src,
+            &dest,
+            &new_csid_for_blocking,
+            &fork_uuid_for_blocking,
+        )
+        .map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| format!("spawn_blocking: {e}"))??;
+
+    // Insert the new session row + copied output_lines synchronously via the
+    // pool. If we used the async DbWrite queue here the IPC would return
+    // before persistence completed and the frontend's immediate
+    // loadOutputLines call would see an empty session.
+    let _ = db_tx; // intentionally unused on this path
+    let new_session = Session {
+        id: new_verun_sid.clone(),
+        task_id: parent.task_id.clone(),
+        name: parent.name.as_ref().map(|n| format!("{n} (fork)")),
+        claude_session_id: Some(new_csid),
+        status: "idle".to_string(),
+        started_at: now,
+        ended_at: None,
+        total_cost: 0.0,
+        parent_session_id: Some(parent.id.clone()),
+        forked_at_message_uuid: Some(fork_after_message_uuid.clone()),
+    };
+    insert_session_row(pool, &new_session).await?;
+
+    // Copy parent's output_lines up to and including the matching
+    // verun_turn_snapshot marker.
+    let parent_lines = db::get_output_lines(pool, &parent.id).await?;
+    let needle = format!("\"messageUuid\":\"{fork_after_message_uuid}\"");
+    let mut copied: Vec<(String, i64)> = Vec::new();
+    for ol in &parent_lines {
+        copied.push((ol.line.clone(), ol.emitted_at));
+        if ol.line.contains("\"verun_turn_snapshot\"") && ol.line.contains(&needle) {
+            break;
+        }
+    }
+    if !copied.is_empty() {
+        insert_output_lines_sync(pool, &new_verun_sid, &copied).await?;
+    }
+
+    Ok(new_session)
+}
+
+async fn insert_session_row(
+    pool: &sqlx::sqlite::SqlitePool,
+    s: &Session,
+) -> Result<(), String> {
+    sqlx::query(
+        "INSERT INTO sessions (id, task_id, name, claude_session_id, status, started_at, ended_at, total_cost, parent_session_id, forked_at_message_uuid) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&s.id)
+    .bind(&s.task_id)
+    .bind(&s.name)
+    .bind(&s.claude_session_id)
+    .bind(&s.status)
+    .bind(s.started_at)
+    .bind(s.ended_at)
+    .bind(s.total_cost)
+    .bind(&s.parent_session_id)
+    .bind(&s.forked_at_message_uuid)
+    .execute(pool)
+    .await
+    .map_err(|e| format!("insert session: {e}"))?;
+    Ok(())
+}
+
+async fn insert_task_row(
+    pool: &sqlx::sqlite::SqlitePool,
+    t: &Task,
+) -> Result<(), String> {
+    sqlx::query(
+        "INSERT INTO tasks (id, project_id, name, worktree_path, branch, created_at, port_offset, parent_task_id) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&t.id)
+    .bind(&t.project_id)
+    .bind(&t.name)
+    .bind(&t.worktree_path)
+    .bind(&t.branch)
+    .bind(t.created_at)
+    .bind(t.port_offset)
+    .bind(&t.parent_task_id)
+    .execute(pool)
+    .await
+    .map_err(|e| format!("insert task: {e}"))?;
+    Ok(())
+}
+
+async fn insert_output_lines_sync(
+    pool: &sqlx::sqlite::SqlitePool,
+    session_id: &str,
+    lines: &[(String, i64)],
+) -> Result<(), String> {
+    let mut tx = pool.begin().await.map_err(|e| e.to_string())?;
+    for (line, emitted_at) in lines {
+        sqlx::query("INSERT INTO output_lines (session_id, line, emitted_at) VALUES (?, ?, ?)")
+            .bind(session_id)
+            .bind(line)
+            .bind(emitted_at)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| format!("insert output_line: {e}"))?;
+    }
+    tx.commit().await.map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+/// Fork a session into a NEW task with its OWN worktree.
+///
+/// `worktree_state` controls whether the new worktree starts from the
+/// per-turn snapshot taken at the chosen message (true counterfactual) or
+/// from the parent's current worktree state (HEAD + any uncommitted edits).
+#[allow(clippy::too_many_arguments)]
+pub async fn fork_session_to_new_task(
+    app: &AppHandle,
+    pool: &sqlx::sqlite::SqlitePool,
+    db_tx: &DbWriteTx,
+    source_session_id: String,
+    fork_after_message_uuid: String,
+    worktree_state: WorktreeForkState,
+) -> Result<(Task, Session), String> {
+    let parent_session = db::get_session(pool, &source_session_id)
+        .await?
+        .ok_or_else(|| format!("Session {source_session_id} not found"))?;
+    let parent_csid = parent_session
+        .claude_session_id
+        .clone()
+        .ok_or_else(|| "Parent session has no claude session id (never started?)".to_string())?;
+    let parent_task = db::get_task(pool, &parent_session.task_id)
+        .await?
+        .ok_or_else(|| format!("Task {} not found", parent_session.task_id))?;
+    let project = db::get_project(pool, &parent_task.project_id)
+        .await?
+        .ok_or_else(|| format!("Project {} not found", parent_task.project_id))?;
+
+    // Snapshot SHA lookup for "code as it was at this message" mode.
+    let snapshot_sha = match worktree_state {
+        WorktreeForkState::Snapshot => Some(
+            db::get_turn_snapshot(pool, &parent_session.id, &fork_after_message_uuid)
+                .await?
+                .ok_or_else(|| {
+                    "no snapshot exists for this message — try 'current code' instead".to_string()
+                })?
+                .stash_sha,
+        ),
+        WorktreeForkState::Current => None,
+    };
+
+    // Create the new worktree (off the runtime).
+    let branch = funny_branch_name();
+    let repo_path = project.repo_path.clone();
+    let parent_worktree = parent_task.worktree_path.clone();
+    let base_branch = project.base_branch.clone();
+    let branch_for_blocking = branch.clone();
+    let snapshot_for_blocking = snapshot_sha.clone();
+    let new_worktree_path = tokio::task::spawn_blocking(move || -> Result<String, String> {
+        match snapshot_for_blocking {
+            Some(sha) => {
+                // Build the new worktree path manually so we can hand it to
+                // restore_into_new_worktree, then add a branch label after.
+                let new_path = std::path::Path::new(&repo_path)
+                    .join(".verun")
+                    .join("worktrees")
+                    .join(&branch_for_blocking);
+                let new_path_str = new_path
+                    .to_str()
+                    .ok_or_else(|| "non-utf8 worktree path".to_string())?
+                    .to_string();
+                crate::snapshots::restore_into_new_worktree(
+                    std::path::Path::new(&repo_path),
+                    &new_path,
+                    &sha,
+                )
+                .map_err(|e| e.to_string())?;
+                // Attach the funny branch name pointing at the snapshot's HEAD
+                // parent so subsequent commits go on a real branch (not detached).
+                let _ = std::process::Command::new("git")
+                    .current_dir(&new_path_str)
+                    .args(["checkout", "-b", &branch_for_blocking])
+                    .output();
+                Ok(new_path_str)
+            }
+            None => {
+                // Plain worktree creation, then overlay the parent's current
+                // tracked + untracked changes via the snapshot mechanism so
+                // we don't lose uncommitted work.
+                let new_path = crate::worktree::create_worktree(
+                    &repo_path,
+                    &branch_for_blocking,
+                    &base_branch,
+                )?;
+                let parent_wt = std::path::Path::new(&parent_worktree);
+                if let Ok(Some(temp_sha)) =
+                    crate::snapshots::snapshot_turn(parent_wt, "fork-current", "transient")
+                {
+                    let new_pb = std::path::PathBuf::from(&new_path);
+                    let tree_ref = format!("{temp_sha}^{{tree}}");
+                    let _ = std::process::Command::new("git")
+                        .current_dir(&new_pb)
+                        .args(["read-tree", "--reset", "-u", &tree_ref])
+                        .output();
+                }
+                Ok(new_path)
+            }
+        }
+    })
+    .await
+    .map_err(|e| format!("spawn_blocking: {e}"))??;
+
+    // Insert the new task row.
+    let new_task = Task {
+        id: Uuid::new_v4().to_string(),
+        project_id: parent_task.project_id.clone(),
+        name: parent_task.name.as_ref().map(|n| format!("{n} (fork)")),
+        worktree_path: new_worktree_path,
+        branch,
+        created_at: epoch_ms(),
+        merge_base_sha: None,
+        port_offset: db::next_port_offset(pool, &parent_task.project_id).await?,
+        archived: false,
+        archived_at: None,
+        last_commit_message: None,
+        parent_task_id: Some(parent_task.id.clone()),
+    };
+    insert_task_row(pool, &new_task).await?;
+
+    // Now build a forked session attached to the new task. Reuse
+    // fork_session_in_task's machinery but override the destination task_id
+    // by directly calling the same logic.
+    let new_csid = Uuid::new_v4().to_string();
+    let new_verun_sid = Uuid::new_v4().to_string();
+    let now = epoch_ms();
+
+    let parent_csid_for_blocking = parent_csid.clone();
+    let new_csid_for_blocking = new_csid.clone();
+    let fork_uuid_for_blocking = fork_after_message_uuid.clone();
+    let new_wt_for_blocking = new_task.worktree_path.clone();
+    let parent_wt_for_blocking = parent_task.worktree_path.clone();
+    tokio::task::spawn_blocking(move || -> Result<(), String> {
+        // The on-disk JSONL is keyed by cwd. Claude wrote the parent's
+        // transcript under the parent's cwd; the new session will run in the
+        // new worktree's cwd, so we have to write the truncated JSONL into
+        // the NEW cwd's projects dir.
+        let parent_wt = std::path::Path::new(&parent_wt_for_blocking);
+        let new_wt = std::path::Path::new(&new_wt_for_blocking);
+        let src = crate::claude_jsonl::session_path(parent_wt, &parent_csid_for_blocking)
+            .ok_or_else(|| "no $HOME for src jsonl".to_string())?;
+        let dest = crate::claude_jsonl::session_path(new_wt, &new_csid_for_blocking)
+            .ok_or_else(|| "no $HOME for dest jsonl".to_string())?;
+        crate::claude_jsonl::truncate_after_message(
+            &src,
+            &dest,
+            &new_csid_for_blocking,
+            &fork_uuid_for_blocking,
+        )
+        .map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| format!("spawn_blocking: {e}"))??;
+
+    let new_session = Session {
+        id: new_verun_sid.clone(),
+        task_id: new_task.id.clone(),
+        name: parent_session.name.as_ref().map(|n| format!("{n} (fork)")),
+        claude_session_id: Some(new_csid),
+        status: "idle".to_string(),
+        started_at: now,
+        ended_at: None,
+        total_cost: 0.0,
+        parent_session_id: Some(parent_session.id.clone()),
+        forked_at_message_uuid: Some(fork_after_message_uuid.clone()),
+    };
+    insert_session_row(pool, &new_session).await?;
+
+    // Copy parent output lines up to the boundary into the new session.
+    let parent_lines = db::get_output_lines(pool, &parent_session.id).await?;
+    let needle = format!("\"messageUuid\":\"{fork_after_message_uuid}\"");
+    let mut copied: Vec<(String, i64)> = Vec::new();
+    for ol in &parent_lines {
+        copied.push((ol.line.clone(), ol.emitted_at));
+        if ol.line.contains("\"verun_turn_snapshot\"") && ol.line.contains(&needle) {
+            break;
+        }
+    }
+    if !copied.is_empty() {
+        insert_output_lines_sync(pool, &new_verun_sid, &copied).await?;
+    }
+
+    let _ = db_tx;
+    let _ = app.emit(
+        "task-created",
+        serde_json::json!({ "taskId": new_task.id, "projectId": new_task.project_id }),
+    );
+
+    Ok((new_task, new_session))
 }
 
 #[cfg(test)]

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -1,14 +1,19 @@
 import { Component, For, Show, createEffect, on, createSignal, onMount, onCleanup } from 'solid-js'
-import { createStore } from 'solid-js/store'
+import { createStore, produce, reconcile } from 'solid-js/store'
 import { clsx } from 'clsx'
 import { marked } from 'marked'
 import { openUrl } from '@tauri-apps/plugin-opener'
 import type { OutputItem, SessionStatus } from '../types'
-import { ChevronDown, ChevronRight, AlertTriangle, Copy, Check, ArrowUp, ArrowDown, X } from 'lucide-solid'
+import { ChevronDown, ChevronRight, AlertTriangle, Copy, Check, ArrowUp, ArrowDown, X, GitBranch } from 'lucide-solid'
 import { FileMentionBadge } from './FileMentionBadge'
 import { ImageViewer } from './ImageViewer'
 import { BlobImage } from './BlobImage'
 import { parseMentions } from '../lib/mentions'
+import { Popover } from './Popover'
+import * as ipc from '../lib/ipc'
+import { addToast, setSelectedTaskId, setSelectedSessionId } from '../store/ui'
+import { setSessions, loadOutputLines } from '../store/sessions'
+import { setTasks } from '../store/tasks'
 
 marked.setOptions({ breaks: true, gfm: true })
 
@@ -61,6 +66,8 @@ interface AssistantBlock {
   turnCost?: number
   turnTokens?: { input: number; output: number }
   isLastInTurn?: boolean
+  /** On-disk message uuid attached at turn end via verun_turn_snapshot. Used as the fork point. */
+  messageUuid?: string
 }
 interface ThinkingBlock {
   type: 'thinking'
@@ -181,6 +188,19 @@ function rebuildBlocks(items: OutputItem[]): DisplayBlock[] {
         turnStartTs = undefined
         break
       }
+      case 'turnSnapshot': {
+        // Attach the message uuid to the most recent assistant block, walking
+        // back past tools/thinking. This is the stable id for "fork from here".
+        for (let i = blocks.length - 1; i >= 0; i--) {
+          const b = blocks[i]
+          if (b.type === 'assistant') {
+            ;(b as AssistantBlock).messageUuid = item.messageUuid
+            break
+          }
+          if (b.type === 'user') break
+        }
+        break
+      }
       case 'raw':
         break
     }
@@ -220,6 +240,121 @@ const CopyButton: Component<{ text: string }> = (props) => {
         <Check size={13} class="text-status-running" />
       </Show>
     </button>
+  )
+}
+
+const ForkButton: Component<{ sessionId: string; messageUuid: string }> = (props) => {
+  const [open, setOpen] = createSignal(false)
+  const [submenuOpen, setSubmenuOpen] = createSignal(false)
+  const [busy, setBusy] = createSignal(false)
+  const [error, setError] = createSignal<string | null>(null)
+
+  const close = () => {
+    setOpen(false)
+    setSubmenuOpen(false)
+    setError(null)
+  }
+
+  const forkInTask = async () => {
+    setBusy(true)
+    try {
+      const session = await ipc.forkSessionInTask(props.sessionId, props.messageUuid)
+      setSessions(produce(s => { if (!s.find(x => x.id === session.id)) s.push(session) }))
+      await loadOutputLines(session.id, session.taskId)
+      setSelectedSessionId(session.id)
+      addToast('Forked in this task', 'success')
+      close()
+    } catch (e) {
+      setError(String(e))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const forkToNewTask = async (worktreeState: 'snapshot' | 'current') => {
+    setBusy(true)
+    try {
+      const tws = await ipc.forkSessionToNewTask(props.sessionId, props.messageUuid, worktreeState)
+      setTasks(produce(t => { if (!t.find(x => x.id === tws.task.id)) t.unshift(tws.task) }))
+      setSessions(produce(s => { if (!s.find(x => x.id === tws.session.id)) s.push(tws.session) }))
+      await loadOutputLines(tws.session.id, tws.task.id)
+      setSelectedTaskId(tws.task.id)
+      setSelectedSessionId(tws.session.id)
+      addToast('Forked to new task', 'success')
+      close()
+    } catch (e) {
+      setError(String(e))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div class="relative">
+      <button
+        class="p-1 rounded-md text-text-dim hover:text-text-muted hover:bg-surface-2 transition-colors"
+        onClick={() => setOpen(o => !o)}
+        title="Fork from this message"
+        disabled={busy()}
+      >
+        <GitBranch size={13} />
+      </button>
+      <Popover
+        open={open()}
+        onClose={close}
+        class="py-1 min-w-44 absolute bottom-full left-0 mb-1"
+      >
+        <button
+          class="w-full flex items-center gap-2 text-left px-2.5 py-1 text-[11px] text-text-secondary hover:bg-surface-3 hover:text-text-primary disabled:opacity-35 disabled:pointer-events-none"
+          disabled={busy()}
+          onMouseEnter={() => setSubmenuOpen(false)}
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={forkInTask}
+        >
+          <span class="flex-1 truncate">Fork in this task</span>
+        </button>
+        <div
+          class="relative"
+          onMouseEnter={() => setSubmenuOpen(true)}
+        >
+          <button
+            class="w-full flex items-center gap-2 text-left px-2.5 py-1 text-[11px] text-text-secondary hover:bg-surface-3 hover:text-text-primary disabled:opacity-35 disabled:pointer-events-none"
+            disabled={busy()}
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => setSubmenuOpen(v => !v)}
+          >
+            <span class="flex-1 truncate">Fork in a new task</span>
+            <ChevronRight size={11} class="text-text-dim shrink-0" />
+          </button>
+          <Show when={submenuOpen()}>
+            <div
+              class="absolute -top-1 left-[calc(100%-4px)] py-1 min-w-48 bg-surface-2 ring-1 ring-white/8 rounded-md shadow-xl animate-in"
+              onMouseDown={(e) => e.preventDefault()}
+            >
+              <button
+                class="w-full flex items-center gap-2 text-left px-2.5 py-1 text-[11px] text-text-secondary hover:bg-surface-3 hover:text-text-primary disabled:opacity-35 disabled:pointer-events-none"
+                disabled={busy()}
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => forkToNewTask('snapshot')}
+              >
+                <span class="flex-1 truncate">Code as of this message</span>
+              </button>
+              <button
+                class="w-full flex items-center gap-2 text-left px-2.5 py-1 text-[11px] text-text-secondary hover:bg-surface-3 hover:text-text-primary disabled:opacity-35 disabled:pointer-events-none"
+                disabled={busy()}
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => forkToNewTask('current')}
+              >
+                <span class="flex-1 truncate">Current code</span>
+              </button>
+            </div>
+          </Show>
+        </div>
+        <Show when={error()}>
+          <div class="mt-1 px-2.5 py-1 text-[10px] text-status-error border-t border-white/8">{error()}</div>
+        </Show>
+      </Popover>
+    </div>
   )
 }
 
@@ -582,7 +717,7 @@ export const ChatView: Component<Props> = (props) => {
     }
     if (len !== lastItemCount) {
       const newBlocks = rebuildBlocks(props.output)
-      setBlocks(newBlocks)
+      setBlocks(reconcile(newBlocks, { merge: true }))
       lastItemCount = len
       // Re-apply search highlights after block rebuild
       if (showSearch() && searchQuery()) {
@@ -766,6 +901,12 @@ export const ChatView: Component<Props> = (props) => {
                           })()}
                         </Show>
                         <CopyButton text={block.text} />
+                        <Show when={(block as AssistantBlock).messageUuid && props.sessionId}>
+                          <ForkButton
+                            sessionId={props.sessionId!}
+                            messageUuid={(block as AssistantBlock).messageUuid!}
+                          />
+                        </Show>
                       </div>
                     </Show>
                   </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -66,7 +66,7 @@ import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { listen } from "@tauri-apps/api/event";
 import * as ipc from "../lib/ipc";
 import { hasOverlayTitlebar } from "../lib/platform";
-import { ExternalLink } from "lucide-solid";
+import { ExternalLink, GitBranch } from "lucide-solid";
 
 // ---------------------------------------------------------------------------
 // Per-project chip color — deterministic hash → palette index. Subtle bg
@@ -472,6 +472,9 @@ export const Sidebar: Component = () => {
                                 />
                               </Show>
                               <div class={clsx("text-[10px] truncate flex items-center gap-1", hasIndicator() || isSelected() ? "text-text-muted" : "text-text-dim")}>
+                                <Show when={task.parentTaskId}>
+                                  <GitBranch size={9} class="shrink-0 text-text-dim/70" />
+                                </Show>
                                 {task.branch}
                                 <Show when={isTaskWindowed(task.id)}>
                                   <ExternalLink size={9} class="shrink-0 text-accent/60" />

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -95,6 +95,20 @@ export const listSessions = (taskId: string) =>
 export const getSession = (id: string) =>
   invoke<Session | null>('get_session', { id })
 
+export const forkSessionInTask = (sessionId: string, forkAfterMessageUuid: string) =>
+  invoke<Session>('fork_session_in_task', { sessionId, forkAfterMessageUuid })
+
+export const forkSessionToNewTask = (
+  sessionId: string,
+  forkAfterMessageUuid: string,
+  worktreeState: 'snapshot' | 'current',
+) =>
+  invoke<TaskWithSession>('fork_session_to_new_task', {
+    sessionId,
+    forkAfterMessageUuid,
+    worktreeState,
+  })
+
 export const getOutputLines = (sessionId: string) =>
   invoke<OutputLine[]>('get_output_lines', { sessionId })
 

--- a/src/store/sessions.test.ts
+++ b/src/store/sessions.test.ts
@@ -11,6 +11,8 @@ const makeSession = (overrides: Partial<Session> = {}): Session => ({
   startedAt: 1000,
   endedAt: null,
   totalCost: 0,
+  parentSessionId: null,
+  forkedAtMessageUuid: null,
   ...overrides,
 })
 

--- a/src/store/sessions.ts
+++ b/src/store/sessions.ts
@@ -222,6 +222,14 @@ function parseNdjsonLine(line: string, emittedAt?: number): OutputItem[] | null 
     return [{ kind: 'userMessage', text: v.text as string, timestamp: emittedAt }]
   }
 
+  // Per-turn snapshot marker — attach the message uuid to the most recent
+  // assistant block so the "fork from here" affordance has a stable id.
+  if (type === 'verun_turn_snapshot') {
+    const uuid = v.messageUuid as string | undefined
+    if (uuid) return [{ kind: 'turnSnapshot', messageUuid: uuid }]
+    return null
+  }
+
   // Stream event (content_block_delta)
   if (type === 'stream_event') {
     const event = v.event as Record<string, unknown> | undefined

--- a/src/store/tasks.ts
+++ b/src/store/tasks.ts
@@ -81,6 +81,7 @@ export function startTaskCreation(projectId: string, baseBranch: string): string
     archived: false,
     archivedAt: null,
     lastCommitMessage: null,
+    parentTaskId: null,
   }
 
   setTasks(produce(t => t.unshift(placeholder)))

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,6 +24,7 @@ export interface Task {
   archived: boolean
   archivedAt: number | null
   lastCommitMessage: string | null
+  parentTaskId: string | null
 }
 
 export interface Session {
@@ -35,6 +36,8 @@ export interface Session {
   startedAt: number
   endedAt: number | null
   totalCost: number
+  parentSessionId: string | null
+  forkedAtMessageUuid: string | null
 }
 
 export interface OutputLine {
@@ -97,6 +100,7 @@ export type OutputItem =
   | { kind: 'toolResult'; text: string; isError: boolean }
   | { kind: 'system'; text: string }
   | { kind: 'turnEnd'; status: string; timestamp?: number; cost?: number; inputTokens?: number; outputTokens?: number }
+  | { kind: 'turnSnapshot'; messageUuid: string }
   | { kind: 'userMessage'; text: string; images?: Array<{ mimeType: string; data: Uint8Array }>; timestamp?: number }
   | { kind: 'raw'; text: string }
 


### PR DESCRIPTION
## Summary

- Hover any past assistant reply → context-menu popover with **Fork in this task** (rewinds the chat in place, keeps current code) or **Fork in a new task** (cascading submenu offering "Code as of this message" for true counterfactual exploration, or "Current code" for a fresh worktree from the parent's HEAD).
- Per-turn worktree snapshots captured at every assistant turn end via git plumbing (temp index → `git add -A` → `write-tree` → `commit-tree`, anchored under `refs/verun/snapshots/` so `git gc` never reaps them). Tracked + index + untracked files all preserved without touching the user's real index.
- Forking truncates Claude Code's on-disk JSONL transcript at the chosen message uuid and rewrites `sessionId` fields to a fresh UUID, then `claude --resume` picks it up as a real session. Verified end-to-end against Claude Code 2.1.101.
- For "fork to new task", the truncated transcript is written to the encoded-cwd path of the *destination* worktree so Claude finds it from the new cwd.
- Sidebar shows a small `GitBranch` icon next to forked tasks for lineage at a glance.

## Implementation notes

- New module `src-tauri/src/snapshots.rs` — captures worktree state via git plumbing without touching the user's real index, anchors the resulting commit under `refs/verun/snapshots/<session>/<message_uuid>` so `git gc` won't reap it. Restore creates a fresh worktree detached at the snapshot's parent then `read-tree --reset -u` to overlay the snapshot's tree.
- New module `src-tauri/src/claude_jsonl.rs` — quarantines all knowledge of Claude Code's on-disk JSONL format (pinned to verified version 2.1.101). Format drift will break here loudly rather than silently produce broken forks.
- DB migration v12 adds `parent_session_id`, `forked_at_message_uuid`, `parent_task_id`, and a `turn_snapshots` table; cascades wired through delete paths.
- Snapshot machinery on turn end is fire-and-forget via `tokio::spawn` so the stream loop never blocks on git I/O. The buffer is always flushed on turn end *before* the snapshot fires, otherwise the synthetic snapshot marker reaches the frontend before the `TurnEnd` event and the marker walks back looking for an assistant block that hasn't been created yet.
- Fork DB inserts (session row, task row, copied output_lines) happen synchronously via the pool rather than the fire-and-forget DB write queue — the IPC must not return before persistence completes, otherwise the frontend's immediate `loadOutputLines` call hits an empty session.
- Frontend uses the existing `Popover` component with a cascading submenu positioned at `left-[calc(100%-4px)] -top-1` (slight overlap, macOS-style).

## Test plan

- [ ] Send several messages in a session, hover the most recent assistant reply, click **Fork in this task** — chat shows the inherited history truncated at that turn, worktree on disk is unchanged, sending a new prompt continues coherently.
- [ ] Hover an earlier assistant message, click **Fork in a new task → Code as of this message** — new task appears in sidebar, new worktree contents match the code state at the chosen turn (verify by inspecting a file Claude edited *after* that turn — should show the older version), session has the inherited chat history.
- [ ] Same again with **Current code** — new worktree, code matches the parent's *current* state including any uncommitted edits.
- [ ] Restart Verun — both forked sessions are still listed, lineage hints render in the sidebar, `claude --resume` still works on the hand-crafted JSONL files.
- [ ] Forks of forks: fork session A → fork the resulting session B → confirm the chain works and `parent_session_id` is preserved.