### PR TITLE
Fix sidebar collapsing empty projects on click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Unreleased
 
+- Clicking a project header no longer collapses other empty projects — removed stale "selected project" gating that hid the "+ New task" hint on non-selected empty projects
 - Normal trust level now auto-allows non-destructive `git push` — only `git push --force`, `-f`, and `--delete` still require approval
 - Fork a session from a past assistant message: hover any assistant reply to fork in this task (rewinds the chat, keeps current code), or fork to a new task with the worktree restored to the code as it was at that message (true counterfactual) or seeded from the parent's current code
 - Per-turn worktree snapshots taken at every assistant turn end via git plumbing (commit-tree against a temporary index), anchored under `refs/verun/snapshots/` so they survive `git gc`

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -23,7 +23,6 @@ import {
   updateTaskName,
 } from "../store/tasks";
 import {
-  selectedProjectId,
   setSelectedProjectId,
   selectedTaskId,
   setSelectedTaskId,
@@ -231,10 +230,6 @@ export const Sidebar: Component = () => {
   );
 
 
-  const handleSelectProject = (id: string) => {
-    setSelectedProjectId(id);
-  };
-
   const showProjectMenu = (e: MouseEvent, projectId: string) => {
     e.preventDefault();
     const project = projects.find((p) => p.id === projectId);
@@ -341,7 +336,6 @@ export const Sidebar: Component = () => {
               <div class="mb-3">
                 <div
                   class="w-full text-left px-2 py-1 rounded-md flex items-center justify-between group cursor-pointer min-w-0 hover:bg-surface-2"
-                  onClick={() => handleSelectProject(project.id)}
                   onContextMenu={(e) => showProjectMenu(e, project.id)}
                 >
                   <span class="flex items-center gap-2 min-w-0">
@@ -370,12 +364,7 @@ export const Sidebar: Component = () => {
                   </button>
                 </div>
 
-                <Show
-                  when={
-                    activeTasksForProject(project.id).length === 0 &&
-                    selectedProjectId() === project.id
-                  }
-                >
+                <Show when={activeTasksForProject(project.id).length === 0}>
                   <div class="px-2 pt-1">
                     <button
                       class="text-[10px] text-text-dim hover:text-text-muted transition-colors cursor-pointer"


### PR DESCRIPTION
## Summary
- Removed the `handleSelectProject` handler and its `onClick` on project headers — clicking a project header no longer sets `selectedProjectId`, which was causing the "+ New task" hint on other empty projects to disappear (visually collapsing them)
- Empty projects now always show the "+ New task" hint instead of gating it behind `selectedProjectId() === project.id`

## Test plan
- [ ] Open the app with multiple projects, at least one with no tasks
- [ ] Click different project headers and verify empty projects keep their "+ New task" hint visible
- [ ] Verify clicking a task still works correctly (sets selected project via the task click handler)
- [ ] Verify creating a new task from the "+ New task" hint still works
- [ ] Verify right-click context menu on project headers still works