### PR TITLE
fix: only show unread indicator on session completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Unreleased
 
 - Clicking a project header no longer collapses other empty projects — removed stale "selected project" gating that hid the "+ New task" hint on non-selected empty projects
+- Task and session unread indicators now only appear when a session finishes (status → idle/error), not after every streamed chunk or tool call
 - Normal trust level now auto-allows non-destructive `git push` — only `git push --force`, `-f`, and `--delete` still require approval
 - Fork a session from a past assistant message: hover any assistant reply to fork in this task (rewinds the chat, keeps current code), or fork to a new task with the worktree restored to the code as it was at that message (true counterfactual) or seeded from the parent's current code
 - Per-turn worktree snapshots taken at every assistant turn end via git plumbing (commit-tree against a temporary index), anchored under `refs/verun/snapshots/` so they survive `git gc`

--- a/src/store/sessions.ts
+++ b/src/store/sessions.ts
@@ -395,11 +395,6 @@ export async function initSessionListeners() {
         }
       }
     }
-    // Mark task as unread if it's not currently selected
-    const session = sessions.find(s => s.id === sessionId)
-    if (session) markTaskUnread(session.taskId)
-    // Mark session tab as unread if it's not the selected session
-    markSessionUnread(sessionId)
   })
 
   await listen<SessionStatusEvent>('session-status', (event) => {
@@ -423,8 +418,10 @@ export async function initSessionListeners() {
     if (status === 'error') {
       disarmAllSteps(sessionId)
     }
-    // OS notification on completion/error (suppress if queue drained — more work pending)
+    // Mark unread + OS notification on completion/error
     if (wasRunning && (status === 'idle' || status === 'error') && prevSession) {
+      markTaskUnread(prevSession.taskId)
+      markSessionUnread(sessionId)
       const taskName = taskById(prevSession.taskId)?.name || 'Task'
       notify({
         title: status === 'error' ? 'Task failed' : 'Task completed',


### PR DESCRIPTION
## Summary

- Moved `markTaskUnread()` and `markSessionUnread()` from the `session-output` event listener to the `session-status` listener, gated on `running → idle/error` transitions
- Previously, every streamed text chunk, tool call, and tool result would light up the unread dot — now it only appears when the agent finishes its turn or errors out
- Tool approval requests (`markTaskAttention`) are unchanged and still fire immediately

## Test plan

- [ ] Start a task and confirm no blue unread dot appears while the agent is streaming or making tool calls
- [ ] Switch away from the task tab and confirm the blue dot appears only after the agent completes
- [ ] Confirm the amber attention dot still appears immediately on tool approval requests
- [ ] Verify session tab unread indicator follows the same behavior