### PR TITLE
Configure parallel worktree development with .verun.json

### DIFF
--- a/.verun.json
+++ b/.verun.json
@@ -1,0 +1,7 @@
+{
+  "hooks": {
+    "setup": "pnpm install --frozen-lockfile",
+    "destroy": "rm -rf node_modules src-tauri/target"
+  },
+  "startCommand": "TASK_ID=$(basename \"$PWD\") && VITE_PORT=$VERUN_PORT_0 VITE_HMR_PORT=$VERUN_PORT_1 pnpm tauri dev --config src-tauri/tauri.dev.conf.json --config '{\"productName\":\"Verun ('\"$TASK_ID\"')\",\"identifier\":\"com.softwaresavants.verun.dev.'\"$TASK_ID\"'\",\"build\":{\"devUrl\":\"http://localhost:'\"$VERUN_PORT_0\"'\"}}'"
+}

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6139,7 +6139,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "verun"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "dashmap",
  "ignore",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,10 @@ import UnoCSS from "unocss/vite";
 
 // @ts-expect-error process is a nodejs global
 const host = process.env.TAURI_DEV_HOST;
+// @ts-expect-error process is a nodejs global
+const vitePort = Number(process.env.VITE_PORT) || 1420;
+// @ts-expect-error process is a nodejs global
+const viteHmrPort = Number(process.env.VITE_HMR_PORT) || 1421;
 
 // https://vite.dev/config/
 export default defineConfig(async () => ({
@@ -18,14 +22,14 @@ export default defineConfig(async () => ({
 
   clearScreen: false,
   server: {
-    port: 1420,
+    port: vitePort,
     strictPort: true,
     host: host || false,
     hmr: host
       ? {
           protocol: "ws",
           host,
-          port: 1421,
+          port: viteHmrPort,
         }
       : undefined,
     watch: {


### PR DESCRIPTION
## Summary
- Add `.verun.json` with setup/destroy hooks and a start command that allocates unique ports and bundle IDs per task
- Make Vite dev server and HMR ports configurable via `VITE_PORT` / `VITE_HMR_PORT` env vars (defaults unchanged at 1420/1421)
- Each parallel task gets a unique Tauri bundle identifier (`com.softwaresavants.verun.dev.<task-id>`) so macOS launches separate app instances with isolated SQLite databases
- Task window title shows the branch name (e.g. "Verun (zippy-axolotl-929)") for easy identification in Dock and ⌘-Tab

## Test plan
- [ ] Run `pnpm tauri dev` without env vars — should use default ports 1420/1421
- [ ] Run with `VITE_PORT=3000 VITE_HMR_PORT=3001 pnpm tauri dev` — should bind to custom ports
- [ ] Verify `~/Library/Application Support/` contains a directory matching the task-specific bundle ID
- [ ] Launch two parallel tasks and confirm both app windows open independently