### PR TITLE
Replace update top bar with dismissible bottom-right toast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Clicking a project header no longer collapses other empty projects — removed stale "selected project" gating that hid the "+ New task" hint on non-selected empty projects
 - Task and session unread indicators now only appear when a session finishes (status → idle/error), not after every streamed chunk or tool call
+- Update notification converted from a top bar to a dismissible bottom-right toast; dismissing during a download hides the toast without cancelling the download, and the restart prompt re-appears automatically once the download completes
 - Normal trust level now auto-allows non-destructive `git push` — only `git push --force`, `-f`, and `--delete` still require approval
 - Fork a session from a past assistant message: hover any assistant reply to fork in this task (rewinds the chat, keeps current code), or fork to a new task with the worktree restored to the code as it was at that message (true counterfactual) or seeded from the parent's current code
 - Per-turn worktree snapshots taken at every assistant turn end via git plumbing (commit-tree against a temporary index), anchored under `refs/verun/snapshots/` so they survive `git gc`

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -2,7 +2,6 @@ import { Component, Show, onMount, onCleanup, createSignal } from 'solid-js'
 import { listen } from '@tauri-apps/api/event'
 import { open as openDialog } from '@tauri-apps/plugin-dialog'
 import { Sidebar } from './Sidebar'
-import { UpdateBanner } from './UpdateBanner'
 import { TaskPanel } from './TaskPanel'
 import { SettingsPage, selectSettingsSection, setSettingsSaveRequested } from './SettingsPage'
 import { ArchivedPage } from './ArchivedPage'
@@ -269,7 +268,6 @@ export const Layout: Component = () => {
       </Show>
 
       <div class="flex flex-col flex-1 min-w-0 overflow-hidden">
-        <UpdateBanner />
         <Show when={showSettings()}>
           <SettingsPage />
         </Show>

--- a/src/components/TaskWindowShell.tsx
+++ b/src/components/TaskWindowShell.tsx
@@ -17,7 +17,6 @@ import { NewTaskDialog } from './NewTaskDialog'
 import { ConfirmDialog } from './ConfirmDialog'
 import { ToastContainer } from './ToastContainer'
 import { SelectionMenu } from './SelectionMenu'
-import { UpdateBanner } from './UpdateBanner'
 import * as ipc from '../lib/ipc'
 
 export const TaskWindowShell: Component = () => {
@@ -191,7 +190,6 @@ export const TaskWindowShell: Component = () => {
   return (
     <>
       <div class="flex flex-col h-screen w-screen bg-surface-0 text-text-primary select-none overflow-hidden">
-        <UpdateBanner />
         <TaskPanel />
       </div>
       <ToastContainer />

--- a/src/components/ToastContainer.tsx
+++ b/src/components/ToastContainer.tsx
@@ -2,6 +2,7 @@ import { Component, For, Show } from 'solid-js'
 import { toasts, dismissToast, type ToastAction } from '../store/ui'
 import { clsx } from 'clsx'
 import { CheckCircle, AlertCircle, Info, X } from 'lucide-solid'
+import { UpdateToast } from './UpdateBanner'
 
 const icons = {
   success: CheckCircle,
@@ -73,6 +74,7 @@ export const ToastContainer: Component = () => {
           )
         }}
       </For>
+      <UpdateToast />
     </div>
   )
 }

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -1,102 +1,125 @@
 import { Component, Show } from 'solid-js'
-import { CheckCircle2, Download, Loader2, RefreshCw, X, AlertTriangle } from 'lucide-solid'
+import { CheckCircle2, Loader2, RefreshCw, X, AlertTriangle } from 'lucide-solid'
 import {
   updateAvailable, updateProgress, updateReady, updateError,
-  updateChecking, updateUpToDate,
+  updateChecking, updateUpToDate, dismissed,
   downloadAndInstall, restartApp, dismissUpdate,
 } from '../lib/updater'
 
-export const UpdateBanner: Component = () => {
+export const UpdateToast: Component = () => {
   const visible = () =>
-    updateAvailable() !== null
-    || updateChecking()
-    || updateUpToDate()
-    || updateError() !== null
+    !dismissed() && (
+      updateAvailable() !== null
+      || updateChecking()
+      || updateUpToDate()
+      || updateError() !== null
+    )
 
   return (
     <Show when={visible()}>
-      <div class="flex items-center gap-3 px-4 py-2 bg-accent-muted/30 border-b border-accent/10 text-xs text-text-secondary">
+      <div class="pointer-events-auto rounded-xl border border-border shadow-xl bg-surface-2/90 backdrop-blur-sm p-3.5 min-w-64 max-w-sm animate-slide-in">
+
         <Show when={updateError()}>
           {(err) => (
-            <>
-              <AlertTriangle size={13} class="text-red-400 shrink-0" />
-              <span class="flex-1 text-red-400">Update check failed: {err()}</span>
+            <div class="flex items-start gap-2.5">
+              <AlertTriangle size={15} class="text-status-error shrink-0 mt-0.5" />
+              <span class="text-sm text-text-primary flex-1">Update check failed: {err()}</span>
               <button
-                class="p-0.5 text-text-dim hover:text-text-muted transition-colors"
+                class="p-0.5 rounded text-text-dim hover:text-text-muted transition-colors shrink-0"
                 onClick={dismissUpdate}
               >
                 <X size={13} />
               </button>
-            </>
+            </div>
           )}
         </Show>
 
         <Show when={!updateError() && updateChecking()}>
-          <Loader2 size={13} class="text-accent shrink-0 animate-spin" />
-          <span class="flex-1">Checking for updates…</span>
+          <div class="flex items-center gap-2.5">
+            <Loader2 size={15} class="text-accent shrink-0 animate-spin" />
+            <span class="text-sm text-text-primary flex-1">Checking for updates…</span>
+          </div>
         </Show>
 
         <Show when={!updateError() && !updateChecking() && updateUpToDate() && !updateAvailable()}>
-          <CheckCircle2 size={13} class="text-accent shrink-0" />
-          <span class="flex-1">You're up to date.</span>
-          <button
-            class="p-0.5 text-text-dim hover:text-text-muted transition-colors"
-            onClick={dismissUpdate}
-          >
-            <X size={13} />
-          </button>
+          <div class="flex items-center gap-2.5">
+            <CheckCircle2 size={15} class="text-accent shrink-0" />
+            <span class="text-sm text-text-primary flex-1">You're up to date.</span>
+            <button
+              class="p-0.5 rounded text-text-dim hover:text-text-muted transition-colors shrink-0"
+              onClick={dismissUpdate}
+            >
+              <X size={13} />
+            </button>
+          </div>
         </Show>
 
-        <Show when={!updateError() && updateAvailable()}>
+        <Show when={!updateError() && !updateChecking() && updateAvailable()}>
           {(info) => (
             <>
-              <Download size={13} class="text-accent shrink-0" />
-
               <Show when={updateReady()}>
-                <span class="flex-1">
-                  Update installed. Restart to use v{info().version}.
-                </span>
-                <button
-                  class="px-3 py-1 rounded-md bg-accent/10 text-accent hover:bg-accent/20 transition-colors flex items-center gap-1.5"
-                  onClick={restartApp}
-                >
-                  <RefreshCw size={11} />
-                  Restart
-                </button>
+                <div class="flex items-center gap-2.5">
+                  <RefreshCw size={15} class="text-accent shrink-0" />
+                  <div class="flex-1 min-w-0">
+                    <div class="text-sm text-text-primary">Ready to restart</div>
+                    <div class="text-xs text-text-secondary mt-0.5">v{info().version} installed</div>
+                  </div>
+                  <button
+                    class="px-2.5 py-1 rounded-lg bg-accent/10 text-accent hover:bg-accent/20 text-xs flex items-center gap-1.5 shrink-0"
+                    onClick={restartApp}
+                  >
+                    Restart
+                  </button>
+                </div>
               </Show>
 
               <Show when={updateProgress() !== null && !updateReady()}>
-                <span class="flex-1">
-                  Downloading v{info().version}… {updateProgress()}%
-                </span>
-                <div class="w-32 h-1 bg-surface-3 rounded-full overflow-hidden">
-                  <div
-                    class="h-full bg-accent rounded-full transition-all"
-                    style={{ width: `${updateProgress()}%` }}
-                  />
+                <div class="flex items-start gap-2.5">
+                  <div class="flex-1 min-w-0">
+                    <div class="flex items-center justify-between gap-2">
+                      <span class="text-sm text-text-primary">Downloading v{info().version}…</span>
+                      <span class="text-xs text-text-secondary shrink-0">{updateProgress()}%</span>
+                    </div>
+                    <div class="mt-1.5 h-1 bg-surface-3 rounded-full overflow-hidden">
+                      <div
+                        class="h-full bg-accent rounded-full"
+                        style={{ width: `${updateProgress()}%`, transition: 'width 0.3s ease' }}
+                      />
+                    </div>
+                  </div>
+                  <button
+                    class="p-0.5 rounded text-text-dim hover:text-text-muted transition-colors shrink-0 mt-0.5"
+                    onClick={dismissUpdate}
+                  >
+                    <X size={13} />
+                  </button>
                 </div>
               </Show>
 
               <Show when={updateProgress() === null && !updateReady()}>
-                <span class="flex-1">
-                  Verun v{info().version} is available.
-                </span>
-                <button
-                  class="px-3 py-1 rounded-md bg-accent/10 text-accent hover:bg-accent/20 transition-colors"
-                  onClick={downloadAndInstall}
-                >
-                  Update Now
-                </button>
-                <button
-                  class="p-0.5 text-text-dim hover:text-text-muted transition-colors"
-                  onClick={dismissUpdate}
-                >
-                  <X size={13} />
-                </button>
+                <div>
+                  <div class="text-sm text-text-primary">Update available</div>
+                  <div class="text-xs text-text-secondary mt-0.5">v{info().version} is ready to download</div>
+                  <div class="flex items-center justify-end gap-2 mt-2.5">
+                    <button
+                      class="px-2.5 py-1 rounded-lg text-text-dim hover:text-text-muted text-xs"
+                      onClick={dismissUpdate}
+                    >
+                      Later
+                    </button>
+                    <button
+                      class="btn-primary text-xs px-2.5 py-1"
+                      onClick={downloadAndInstall}
+                    >
+                      Update now
+                    </button>
+                  </div>
+                </div>
               </Show>
             </>
           )}
         </Show>
+
       </div>
     </Show>
   )

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -14,6 +14,7 @@ const [updateReady, setUpdateReady] = createSignal(false)
 const [updateError, setUpdateError] = createSignal<string | null>(null)
 const [updateChecking, setUpdateChecking] = createSignal(false)
 const [updateUpToDate, setUpdateUpToDate] = createSignal(false)
+const [dismissed, setDismissed] = createSignal(false)
 
 export {
   updateAvailable,
@@ -22,6 +23,7 @@ export {
   updateError,
   updateChecking,
   updateUpToDate,
+  dismissed,
 }
 
 let upToDateTimer: number | null = null
@@ -44,6 +46,7 @@ let currentUpdate: Update | null = null
 export function initUpdateListener() {
   listen<UpdateInfo>('update-available', (event) => {
     setUpdateAvailable(event.payload)
+    setDismissed(false)
   })
 
   listen('check-updates', () => {
@@ -54,8 +57,13 @@ export function initUpdateListener() {
 export async function checkForUpdate() {
   if (updateChecking()) return
   try {
+    setDismissed(false)
     setUpdateError(null)
     setUpdateUpToDate(false)
+    setUpdateAvailable(null)
+    setUpdateProgress(null)
+    setUpdateReady(false)
+    currentUpdate = null
     setUpdateChecking(true)
     const update = await check()
     if (update) {
@@ -99,6 +107,7 @@ export async function downloadAndInstall() {
       } else if (event.event === 'Finished') {
         setUpdateProgress(100)
         setUpdateReady(true)
+        setDismissed(false)
       }
     })
   } catch (e) {
@@ -112,9 +121,5 @@ export async function restartApp() {
 }
 
 export function dismissUpdate() {
-  setUpdateAvailable(null)
-  setUpdateProgress(null)
-  setUpdateReady(false)
-  setUpdateError(null)
-  setUpdateUpToDate(false)
+  setDismissed(true)
 }


### PR DESCRIPTION
## Summary

- Converts the update notification from a full-width top bar (`UpdateBanner`) into a dismissible bottom-right toast (`UpdateToast`) rendered inside the existing `ToastContainer` flex column — works in both main and task windows
- Dismissing the toast during a download hides it without cancelling the download; the restart prompt automatically re-appears once the download completes
- "Update available" state shows version info with **Later** / **Update now** (primary) buttons; downloading state shows version + progress bar with inline dismiss; restart-ready and error states also covered

## Test plan

- [ ] Run `make dev`, trigger "Check for Updates…" from the app menu — toast appears in bottom-right corner
- [ ] Dismiss the toast and re-trigger via menu — toast reappears
- [ ] Verify toast renders correctly in both main window and detached task windows
- [ ] Confirm no layout shift — the old top bar no longer pushes content down