### PR TITLE
fix: CMD+P quick open doesn't focus already-open file tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Unreleased
 
+- CMD+P now correctly focuses an already-open file tab even when the session view is active
 - Clicking a project header no longer collapses other empty projects — removed stale "selected project" gating that hid the "+ New task" hint on non-selected empty projects
 - Task and session unread indicators now only appear when a session finishes (status → idle/error), not after every streamed chunk or tool call
 - Update notification converted from a top bar to a dismissible bottom-right toast; dismissing during a download hides the toast without cancelling the download, and the restart prompt re-appears automatically once the download completes

--- a/src/store/files.ts
+++ b/src/store/files.ts
@@ -267,8 +267,8 @@ export function openFilePinned(taskId: string, relativePath: string, name: strin
     }
     if (activeTabPath(taskId) !== relativePath) {
       setTaskActiveTab(prev => ({ ...prev, [taskId]: relativePath }))
-      setMainView(taskId, relativePath)
     }
+    setMainView(taskId, relativePath)
     pushMru(taskId, relativePath)
     persistTabState(taskId)
     return


### PR DESCRIPTION
## Summary

- Selecting an already-open file from CMD+P (Quick Open) while viewing a session no longer fails to switch to the file tab
- Root cause: `openFilePinned` guarded `setMainView` behind `activeTabPath !== relativePath`, so when the file was already the active tab but `mainView` was `'session'`, the view never switched back to the file
- Moved `setMainView` outside the conditional so it always fires (it already no-ops when the value is unchanged)

## Test plan

- [ ] Open a file tab, switch to a session view, then CMD+P and select the same file - it should focus the file tab
- [ ] Open a file via CMD+P that is not yet open - should still create a new pinned tab as before
- [ ] Open a preview tab, then CMD+P the same file - should pin it and focus it