### PR TITLE
fix: persist claude_session_id eagerly from system.init event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add project dialog now always applies the user's edits to hooks, fixing a bug where clearing pre-populated fields from .verun.json had no effect
 - Auto-detect section and "Or configure manually" label are hidden when .verun.json already provides hooks
+- Persist `claude_session_id` eagerly from the `system.init` event at stream start instead of only after process exit - prevents session context loss on crashes, aborts, or abnormal exits
 
 ## Unreleased
 

--- a/src-tauri/src/stream.rs
+++ b/src-tauri/src/stream.rs
@@ -560,6 +560,7 @@ pub async fn stream_and_capture(
 
                         // Capture claude session_id from `system.init` so the snapshot hook
                         // at turn end can locate the on-disk JSONL transcript.
+                        // Also persist it to the DB immediately so it survives crashes/aborts.
                         if claude_session_id_for_snapshot.is_none() {
                             if let Ok(v) = serde_json::from_str::<serde_json::Value>(&line) {
                                 if v.get("type").and_then(|t| t.as_str()) == Some("system")
@@ -567,6 +568,10 @@ pub async fn stream_and_capture(
                                 {
                                     if let Some(sid) = v.get("session_id").and_then(|s| s.as_str()) {
                                         claude_session_id_for_snapshot = Some(sid.to_string());
+                                        let _ = db_tx.send(crate::db::DbWrite::SetClaudeSessionId {
+                                            id: session_id.clone(),
+                                            claude_session_id: sid.to_string(),
+                                        }).await;
                                     }
                                 }
                             }


### PR DESCRIPTION
## Summary

- Persist `claude_session_id` to the DB immediately when the `system.init` event arrives during streaming, instead of only after the Claude Code process exits
- Prevents session context loss when a process crashes, is aborted, or exits abnormally before the post-exit extraction runs
- The existing post-process extraction at turn end remains as an idempotent safety net

## Context

Sessions were losing their `claude_session_id` when navigating between tasks. The root cause: the session ID was only extracted and persisted *after* the Claude Code process exited (`task.rs:834`). If anything interrupted that flow (crash, abort, early return at `task.rs:830`), the ID was never stored - causing the next message to spawn a fresh Claude Code process without `--resume`, losing all conversation context.

The `system.init` event (which contains the session ID) was already being captured during streaming into a local variable for the snapshot hook, but was never written to the DB at that point. This fix adds a single DB write right where that capture happens.

## Test plan

- [ ] Send a message, let it complete, send a follow-up - session context should be preserved (regression check)
- [ ] Send a message, abort mid-stream, send a follow-up - session should now resume with context instead of starting fresh
- [ ] Send a message, force-quit Verun while it's running, relaunch, send a follow-up - session should resume with context