### PR TITLE
fix: resolve stale diff keys causing errors in file viewers

### DIFF
--- a/src/components/FileViewer.tsx
+++ b/src/components/FileViewer.tsx
@@ -7,7 +7,7 @@ import { DiffEditor } from './DiffEditor'
 import { BreadcrumbBar } from './BreadcrumbBar'
 import { getPreviewType } from '../lib/fileTypes'
 import * as ipc from '../lib/ipc'
-import { getCachedContent, setCachedContent, setCachedOriginal, isDiffKey, openTabs } from '../store/files'
+import { getCachedContent, setCachedContent, setCachedOriginal, isDiffKey, pathFromDiffKey, openTabs } from '../store/files'
 
 interface Props {
   taskId: string
@@ -17,13 +17,20 @@ interface Props {
 // ── FileViewer — routes to the correct sub-viewer by file type ─────────
 
 export const FileViewer: Component<Props> = (props) => {
-  const type = () => getPreviewType(props.relativePath)
-
   // Diff tabs use a synthetic key — look up the tab to recover source/path.
   const diffTab = () => {
     if (!isDiffKey(props.relativePath)) return null
     return openTabs(props.taskId).find(t => t.relativePath === props.relativePath) ?? null
   }
+
+  // If mainView holds a stale diff key whose tab no longer exists, fall back
+  // to the real file path so viewers don't try to read the synthetic key.
+  const resolvedPath = () => {
+    if (!isDiffKey(props.relativePath) || diffTab()) return props.relativePath
+    return pathFromDiffKey(props.relativePath) ?? props.relativePath
+  }
+
+  const type = () => getPreviewType(resolvedPath())
 
   return (
     <Show when={!diffTab()} fallback={
@@ -36,27 +43,27 @@ export const FileViewer: Component<Props> = (props) => {
     <Switch fallback={
       <div class="flex flex-col h-full">
         <div class="flex items-center px-3 py-1 shrink-0">
-          <BreadcrumbBar taskId={props.taskId} currentPath={props.relativePath} />
+          <BreadcrumbBar taskId={props.taskId} currentPath={resolvedPath()} />
         </div>
         <div class="flex-1 overflow-hidden">
-          <CodeEditor taskId={props.taskId} relativePath={props.relativePath} />
+          <CodeEditor taskId={props.taskId} relativePath={resolvedPath()} />
         </div>
       </div>
     }>
       <Match when={type() === 'image'}>
-        <ImageViewer taskId={props.taskId} relativePath={props.relativePath} />
+        <ImageViewer taskId={props.taskId} relativePath={resolvedPath()} />
       </Match>
       <Match when={type() === 'video'}>
-        <VideoViewer taskId={props.taskId} relativePath={props.relativePath} />
+        <VideoViewer taskId={props.taskId} relativePath={resolvedPath()} />
       </Match>
       <Match when={type() === 'audio'}>
-        <AudioViewer taskId={props.taskId} relativePath={props.relativePath} />
+        <AudioViewer taskId={props.taskId} relativePath={resolvedPath()} />
       </Match>
       <Match when={type() === 'markdown'}>
-        <MarkdownViewer taskId={props.taskId} relativePath={props.relativePath} />
+        <MarkdownViewer taskId={props.taskId} relativePath={resolvedPath()} />
       </Match>
       <Match when={type() === 'svg'}>
-        <SvgViewer taskId={props.taskId} relativePath={props.relativePath} />
+        <SvgViewer taskId={props.taskId} relativePath={resolvedPath()} />
       </Match>
     </Switch>
     </Show>

--- a/src/store/files.ts
+++ b/src/store/files.ts
@@ -37,6 +37,13 @@ export function isDiffKey(key: string | null | undefined): boolean {
   return !!key && key.startsWith('__diff__:')
 }
 
+/** Extract the real relative path from a synthetic diff key. */
+export function pathFromDiffKey(key: string): string | null {
+  if (key.startsWith('__diff__:working:')) return key.slice('__diff__:working:'.length)
+  const m = key.match(/^__diff__:commit:[^:]+:(.+)$/)
+  return m ? m[1] : null
+}
+
 const [taskOpenTabs, setTaskOpenTabs] = createSignal<Record<string, EditorTab[]>>({})
 const [taskActiveTab, setTaskActiveTab] = createSignal<Record<string, string | null>>({})
 
@@ -393,7 +400,11 @@ export function reopenClosedTab(taskId: string) {
     ...prev,
     [taskId]: (prev[taskId] ?? []).slice(1),
   }))
-  openFile(taskId, tab.relativePath, tab.name)
+  if (tab.kind === 'diff' && tab.diffPath && tab.diffSource) {
+    openDiffTab(taskId, tab.diffPath, tab.diffSource)
+  } else {
+    openFile(taskId, tab.relativePath, tab.name)
+  }
 }
 
 export function setTabDirty(taskId: string, relativePath: string, dirty: boolean) {


### PR DESCRIPTION
## Summary

- When a diff tab is closed but `mainView` still references its synthetic key (e.g. from localStorage restoration or a timing gap), FileViewer passed the raw `__diff__:...` key to file readers like `readWorktreeFile`, causing read errors
- Added `pathFromDiffKey()` to extract the real relative path from synthetic diff keys, and `resolvedPath()` in FileViewer to gracefully fall back to the real path when the diff tab no longer exists
- Fixed `reopenClosedTab()` to properly restore diff tabs via `openDiffTab` instead of `openFile`

## Test plan

- [ ] Open a diff tab, close it, verify no error flashes in the viewer
- [ ] Reopen a closed diff tab via Cmd+Shift+T - verify it opens as a diff, not a plain file
- [ ] Open a diff tab, quit and relaunch the app - verify no error on restore if the diff tab state is stale