### PR TITLE
fix: hide copy/fork buttons on streaming assistant message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 - CMD+P now correctly focuses an already-open file tab even when the session view is active
+- Hide copy and fork buttons on the currently streaming assistant message - completed turns still show their buttons
 - Clicking a project header no longer collapses other empty projects — removed stale "selected project" gating that hid the "+ New task" hint on non-selected empty projects
 - Task and session unread indicators now only appear when a session finishes (status → idle/error), not after every streamed chunk or tool call
 - Update notification converted from a top bar to a dismissible bottom-right toast; dismissing during a download hides the toast without cancelling the download, and the restart prompt re-appears automatically once the download completes

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -66,6 +66,7 @@ interface AssistantBlock {
   turnCost?: number
   turnTokens?: { input: number; output: number }
   isLastInTurn?: boolean
+  isStreaming?: boolean
   /** On-disk message uuid attached at turn end via verun_turn_snapshot. Used as the fork point. */
   messageUuid?: string
 }
@@ -211,6 +212,7 @@ function rebuildBlocks(items: OutputItem[]): DisplayBlock[] {
     for (let i = blocks.length - 1; i >= 0; i--) {
       if (blocks[i].type === 'assistant') {
         (blocks[i] as AssistantBlock).isLastInTurn = true
+        ;(blocks[i] as AssistantBlock).isStreaming = true
         break
       }
       if (blocks[i].type === 'user') break
@@ -900,12 +902,14 @@ export const ChatView: Component<Props> = (props) => {
                             )
                           })()}
                         </Show>
-                        <CopyButton text={block.text} />
-                        <Show when={(block as AssistantBlock).messageUuid && props.sessionId}>
-                          <ForkButton
-                            sessionId={props.sessionId!}
-                            messageUuid={(block as AssistantBlock).messageUuid!}
-                          />
+                        <Show when={!(block as AssistantBlock).isStreaming}>
+                          <CopyButton text={block.text} />
+                          <Show when={(block as AssistantBlock).messageUuid && props.sessionId}>
+                            <ForkButton
+                              sessionId={props.sessionId!}
+                              messageUuid={(block as AssistantBlock).messageUuid!}
+                            />
+                          </Show>
                         </Show>
                       </div>
                     </Show>


### PR DESCRIPTION
## Summary

- Copy and fork buttons on the currently streaming assistant message are now hidden until the turn completes
- Previous completed turns still show their buttons as before
- Adds an `isStreaming` flag to `AssistantBlock`, set only on the in-progress turn (no `turnEnd` yet), to distinguish it from completed turns

## Test plan

- [ ] Start a session and verify copy/fork buttons do not appear on the actively streaming message
- [ ] Verify completed turns still show copy/fork buttons while the session is running
- [ ] Verify all buttons appear normally once the session finishes