### PR TITLE
feat: support images and clickable file links in markdown rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Add project dialog now always applies the user's edits to hooks, fixing a bug where clearing pre-populated fields from .verun.json had no effect
 - Auto-detect section and "Or configure manually" label are hidden when .verun.json already provides hooks
 - Persist `claude_session_id` eagerly from the `system.init` event at stream start instead of only after process exit - prevents session context loss on crashes, aborts, or abnormal exits
+- Markdown images now render in chat, plan review, file preview, and file mention popups - local image paths are resolved to Tauri asset:// URLs via `convertFileSrc`
+- File links in markdown are now clickable - relative paths open in Verun's file viewer instead of the browser, especially useful in plan review where links were previously inert
 
 ## Unreleased
 

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -1,8 +1,7 @@
 import { Component, For, Show, createEffect, on, createSignal, onMount, onCleanup } from 'solid-js'
 import { createStore, produce, reconcile } from 'solid-js/store'
 import { clsx } from 'clsx'
-import { marked } from 'marked'
-import { openUrl } from '@tauri-apps/plugin-opener'
+import { renderMarkdown, handleMarkdownLinkClick, getWorktreePath } from '../lib/markdown'
 import type { OutputItem, SessionStatus } from '../types'
 import { ChevronDown, ChevronRight, AlertTriangle, Copy, Check, ArrowUp, ArrowDown, X, GitBranch } from 'lucide-solid'
 import { FileMentionBadge } from './FileMentionBadge'
@@ -14,8 +13,6 @@ import * as ipc from '../lib/ipc'
 import { addToast, setSelectedTaskId, setSelectedSessionId } from '../store/ui'
 import { setSessions, loadOutputLines } from '../store/sessions'
 import { setTasks } from '../store/tasks'
-
-marked.setOptions({ breaks: true, gfm: true })
 
 function formatDuration(ms: number): string {
   const totalSec = Math.round(ms / 1000)
@@ -39,8 +36,8 @@ function formatTokens(n: number): string {
   return `${n}`
 }
 
-function renderMarkdown(text: string): string {
-  return marked.parse(text, { async: false }) as string
+function renderMarkdownForTask(text: string, taskId?: string): string {
+  return renderMarkdown(text, getWorktreePath(taskId))
 }
 
 interface Props {
@@ -762,13 +759,7 @@ export const ChatView: Component<Props> = (props) => {
     autoScroll = scrollHeight - scrollTop - clientHeight < 30
   }
 
-  const handleLinkClick = (e: MouseEvent) => {
-    const anchor = (e.target as HTMLElement).closest('a')
-    if (anchor?.href) {
-      e.preventDefault()
-      openUrl(anchor.href)
-    }
-  }
+  const handleLinkClick = (e: MouseEvent) => handleMarkdownLinkClick(e, props.taskId)
 
   return (
     <div class="w-full h-full relative">
@@ -875,7 +866,7 @@ export const ChatView: Component<Props> = (props) => {
                   <div class="px-5 py-1">
                     <div
                       class="text-sm text-text-primary leading-relaxed prose-verun select-text break-words overflow-hidden"
-                      innerHTML={renderMarkdown(block.text)}
+                      innerHTML={renderMarkdownForTask(block.text, props.taskId)}
                     />
                     <Show when={(block as AssistantBlock).isLastInTurn}>
                       <div class="flex items-center gap-2 mt-0.5">

--- a/src/components/FileMentionBadge.tsx
+++ b/src/components/FileMentionBadge.tsx
@@ -2,7 +2,7 @@ import { Component, Show, Switch, Match, createSignal, onCleanup } from 'solid-j
 import { Portal } from 'solid-js/web'
 import { computePosition, flip, shift, offset } from '@floating-ui/dom'
 import { convertFileSrc } from '@tauri-apps/api/core'
-import { marked } from 'marked'
+import { renderMarkdown, getWorktreePath } from '../lib/markdown'
 import { getFileIcon } from '../lib/fileIcons'
 import { highlightCode, langFromPath } from '../lib/highlighter'
 import { getPreviewType, isMediaType } from '../lib/fileTypes'
@@ -83,7 +83,7 @@ export const FileMentionBadge: Component<Props> = (props) => {
         result = { type: 'svg', dataUrl }
       } else if (pvType === 'markdown') {
         const content = await readWorktreeFile(props.taskId, props.filePath)
-        const html = marked.parse(content, { async: false }) as string
+        const html = renderMarkdown(content, getWorktreePath(props.taskId))
         result = { type: 'markdown', html }
       } else {
         const content = await readWorktreeFile(props.taskId, props.filePath)

--- a/src/components/FileViewer.tsx
+++ b/src/components/FileViewer.tsx
@@ -1,6 +1,6 @@
 import { Component, Switch, Match, Show, createSignal, createEffect, on } from 'solid-js'
 import { convertFileSrc } from '@tauri-apps/api/core'
-import { marked } from 'marked'
+import { renderMarkdown, handleMarkdownLinkClick, getWorktreePath } from '../lib/markdown'
 import { Image, Film, Music, Eye, Code2, Loader2, AlertCircle } from 'lucide-solid'
 import { CodeEditor } from './CodeEditor'
 import { DiffEditor } from './DiffEditor'
@@ -284,7 +284,8 @@ const MarkdownViewer: Component<Props> = (props) => {
 
   const renderedHtml = () => {
     try {
-      return marked.parse(content(), { async: false }) as string
+      const dir = props.relativePath.includes('/') ? props.relativePath.replace(/\/[^/]+$/, '') : undefined
+      return renderMarkdown(content(), { worktreePath: getWorktreePath(props.taskId), fileDir: dir })
     } catch {
       return content()
     }
@@ -335,6 +336,7 @@ const MarkdownViewer: Component<Props> = (props) => {
           ref={previewEl}
           class="flex-1 overflow-auto px-6 py-4 text-sm text-text-primary leading-relaxed prose-verun select-text"
           style={{ display: mode() === 'preview' ? '' : 'none' }}
+          onClick={(e) => handleMarkdownLinkClick(e, props.taskId)}
           innerHTML={renderedHtml()}
         />
         <div ref={editorWrapperEl} class="flex-1 overflow-hidden" style={{ display: mode() === 'edit' ? '' : 'none' }}>

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -7,9 +7,9 @@ import { ModelSelector } from './ModelSelector'
 import { CommandPalette } from './CommandPalette'
 import { FileMention } from './FileMention'
 import { openFile } from '../store/files'
+import { renderMarkdown, handleMarkdownLinkClick, getWorktreePath } from '../lib/markdown'
 import type { Command } from '../store/commands'
 import { ArrowUp, Square, X, Plus, ShieldAlert, HelpCircle, Shield, ShieldCheck, ListChecks, Zap, Brain, Minimize2, Maximize2, Loader2, Activity, ListPlus, Check } from 'lucide-solid'
-import { marked } from 'marked'
 import { invoke } from '@tauri-apps/api/core'
 import { clsx } from 'clsx'
 import type { Attachment, ModelId, TrustLevel } from '../types'
@@ -1710,8 +1710,11 @@ export const MessageInput: Component<Props> = (props) => {
                   [&_th]:text-left [&_th]:text-text-muted [&_th]:font-medium [&_th]:px-2 [&_th]:py-1.5 [&_th]:border-b [&_th]:border-border
                   [&_td]:text-text-secondary [&_td]:px-2 [&_td]:py-1.5 [&_td]:border-b [&_td]:border-border/50
                   [&_strong]:text-text-primary [&_strong]:font-semibold
+                  [&_a]:text-accent [&_a]:no-underline [&_a]:cursor-pointer hover:[&_a]:underline
+                  [&_img]:max-w-full [&_img]:h-auto [&_img]:rounded-lg [&_img]:my-2
                   [&_blockquote]:border-l-2 [&_blockquote]:border-accent/40 [&_blockquote]:pl-4 [&_blockquote]:text-text-muted [&_blockquote]:italic"
-                innerHTML={marked.parse(plan().plan, { async: false }) as string}
+                onClick={(e) => handleMarkdownLinkClick(e, selectedTaskId() ?? undefined)}
+                innerHTML={renderMarkdown(plan().plan, getWorktreePath(selectedTaskId() ?? undefined))}
               />
             </div>
 

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -1,0 +1,104 @@
+import { marked } from 'marked'
+import { convertFileSrc } from '@tauri-apps/api/core'
+import { openUrl } from '@tauri-apps/plugin-opener'
+import { openFile } from '../store/files'
+import { tasks } from '../store/tasks'
+import { resolveWorktreeFilePath } from './ipc'
+
+marked.setOptions({ breaks: true, gfm: true })
+
+const FILE_EXT_RE = /\.(ts|tsx|js|jsx|mjs|cjs|rs|py|go|rb|java|kt|swift|c|cpp|h|hpp|cs|css|scss|less|html|htm|vue|svelte|astro|json|jsonc|yaml|yml|toml|xml|sql|sh|bash|zsh|md|mdx|txt|cfg|conf|ini|env|makefile|proto|graphql|gql|lock)$/i
+
+function looksLikeFilePath(text: string): boolean {
+  const t = text.trim()
+  if (t.includes(' ') || t.includes('\n')) return false
+  const withoutLineNum = t.replace(/:\d+$/, '')
+  return FILE_EXT_RE.test(withoutLineNum)
+}
+
+function resolveLocalImages(doc: Document, worktreePath: string, fileDir?: string) {
+  doc.querySelectorAll('img').forEach(img => {
+    const src = img.getAttribute('src')
+    if (!src || src.startsWith('http://') || src.startsWith('https://') || src.startsWith('data:') || src.startsWith('blob:')) return
+    let absPath: string
+    if (src.startsWith('/')) {
+      absPath = src
+    } else if (fileDir) {
+      absPath = `${worktreePath}/${fileDir}/${src}`
+    } else {
+      absPath = `${worktreePath}/${src}`
+    }
+    img.src = convertFileSrc(absPath)
+  })
+}
+
+function linkifyFilePaths(doc: Document) {
+  doc.querySelectorAll('code').forEach(code => {
+    if (code.closest('pre') || code.closest('a')) return
+    const text = code.textContent
+    if (!text || !looksLikeFilePath(text)) return
+    const link = doc.createElement('a')
+    link.setAttribute('href', text.trim().replace(/:\d+$/, ''))
+    link.setAttribute('data-file-link', '')
+    code.parentNode!.replaceChild(link, code)
+    link.appendChild(code)
+  })
+}
+
+export function getWorktreePath(taskId?: string): string | undefined {
+  if (!taskId) return undefined
+  return tasks.find(t => t.id === taskId)?.worktreePath || undefined
+}
+
+export interface RenderOptions {
+  worktreePath?: string
+  fileDir?: string
+}
+
+export function renderMarkdown(text: string, opts?: string | RenderOptions): string {
+  const options: RenderOptions = typeof opts === 'string' ? { worktreePath: opts } : (opts ?? {})
+  const raw = marked.parse(text, { async: false }) as string
+
+  const parser = new DOMParser()
+  const doc = parser.parseFromString(raw, 'text/html')
+
+  if (options.worktreePath) {
+    resolveLocalImages(doc, options.worktreePath, options.fileDir)
+  }
+  linkifyFilePaths(doc)
+
+  return doc.body.innerHTML
+}
+
+function isFileLinkHref(href: string): boolean {
+  if (href.startsWith('http://') || href.startsWith('https://') || href.startsWith('#') || href.startsWith('mailto:')) return false
+  return true
+}
+
+export function handleMarkdownLinkClick(e: MouseEvent, taskId?: string) {
+  const anchor = (e.target as HTMLElement).closest('a')
+  if (!anchor) return
+
+  e.preventDefault()
+
+  const rawHref = anchor.getAttribute('href')
+  if (!rawHref) return
+
+  if (!isFileLinkHref(rawHref)) {
+    openUrl(anchor.href)
+    return
+  }
+
+  if (taskId) {
+    const filePath = rawHref.replace(/^\.\//, '')
+    resolveWorktreeFilePath(taskId, filePath)
+      .then(() => {
+        const name = filePath.split('/').pop() || filePath
+        openFile(taskId, filePath, name)
+      })
+      .catch(() => {})
+    return
+  }
+
+  openUrl(anchor.href)
+}

--- a/uno.config.ts
+++ b/uno.config.ts
@@ -198,8 +198,9 @@ export default defineConfig({
           margin: 0.4em 0;
           color: #a1a1aa;
         }
-        .prose-verun a { color: #2d6e4f; text-decoration: none; }
+        .prose-verun a { color: #2d6e4f; text-decoration: none; cursor: pointer; }
         .prose-verun a:hover { text-decoration: underline; }
+        .prose-verun img { max-width: 100%; height: auto; border-radius: 8px; margin: 0.5em 0; }
         .prose-verun hr { border: none; border-top: 1px solid #1e1e26; margin: 0.8em 0; }
 
         /* Thinking dots */


### PR DESCRIPTION
## Summary
- Markdown images now render across the app (chat, plan review, file preview, file mention popups) - local image paths are resolved to Tauri `asset://` URLs via `convertFileSrc`, with correct relative-path resolution from the markdown file's directory
- Inline code spans that look like file paths (e.g. `src/components/Foo.tsx`) are automatically linkified - clicking opens the file in Verun's file viewer if it exists in the worktree, otherwise the click is silently ignored
- Consolidated all `marked` usage into a shared `src/lib/markdown.ts` module, replacing scattered direct `marked.parse()` calls across ChatView, FileViewer, MessageInput, and FileMentionBadge

## Test plan
- [ ] Open a README.md with image references (e.g. `![screenshot](assets/screenshot.png)`) in the file viewer and verify images render
- [ ] Open a README.md in a subdirectory and verify relative image paths resolve correctly
- [ ] Trigger a plan review and verify file paths in the plan are clickable and open in the file viewer
- [ ] Click a file path that doesn't exist in the worktree and verify nothing happens (no error)
- [ ] Verify external URLs (https://) in markdown still open in the browser
- [ ] Verify chat assistant messages still render markdown correctly with images and file path links