### PR TITLE
fix: chat messages rendering with wrong role on session switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - CMD+P now correctly focuses an already-open file tab even when the session view is active
 - Hide copy and fork buttons on the currently streaming assistant message - completed turns still show their buttons
+- Fix messages rendering with the wrong role (user as agent, agent as user) when switching between sessions/tasks with similar output lengths - ChatView block rebuild now tracks session ID, not just item count
 - Clicking a project header no longer collapses other empty projects — removed stale "selected project" gating that hid the "+ New task" hint on non-selected empty projects
 - Task and session unread indicators now only appear when a session finishes (status → idle/error), not after every streamed chunk or tool call
 - Update notification converted from a top bar to a dismissible bottom-right toast; dismissing during a download hides the toast without cancelling the download, and the restart prompt re-appears automatically once the download completes

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -707,37 +707,50 @@ export const ChatView: Component<Props> = (props) => {
     })
   })
 
-  // Rebuild blocks only when output items change
-  createEffect(on(() => props.output.length, (len) => {
-    if (len === 0 && lastItemCount !== 0) {
-      setBlocks([])
-      lastItemCount = 0
-      return
-    }
-    if (len !== lastItemCount) {
-      const newBlocks = rebuildBlocks(props.output)
-      setBlocks(reconcile(newBlocks, { merge: true }))
-      lastItemCount = len
-      // Re-apply search highlights after block rebuild
-      if (showSearch() && searchQuery()) {
-        requestAnimationFrame(() => runSearch(searchQuery()))
+  // Rebuild blocks when output items change OR session switches.
+  // ChatView stays mounted across session/task switches (Solid <Show> doesn't
+  // remount on truthy->truthy), so we must track sessionId to avoid showing
+  // stale blocks from the previous session when item counts happen to match.
+  let lastSessionId: string | null | undefined = props.sessionId
+  createEffect(on(
+    [() => props.sessionId, () => props.output.length] as const,
+    ([sid, len]) => {
+      const sessionChanged = sid !== lastSessionId
+      lastSessionId = sid
+
+      if (len === 0 && (lastItemCount !== 0 || sessionChanged)) {
+        setBlocks([])
+        lastItemCount = 0
+        if (sessionChanged) scheduleAutoScroll()
+        return
       }
-      // On remount: restore saved scroll position instead of auto-scrolling
-      if (pendingScrollRestore) {
-        const restore = pendingScrollRestore
-        pendingScrollRestore = null
-        if (!restore.autoScroll) {
-          requestAnimationFrame(() => {
-            if (containerRef) containerRef.scrollTop = restore.scrollTop
-          })
+      if (len !== lastItemCount || sessionChanged) {
+        const newBlocks = rebuildBlocks(props.output)
+        setBlocks(reconcile(newBlocks, { merge: !sessionChanged }))
+        lastItemCount = len
+        // Re-apply search highlights after block rebuild
+        if (showSearch() && searchQuery()) {
+          requestAnimationFrame(() => runSearch(searchQuery()))
+        }
+        if (sessionChanged) {
+          scheduleAutoScroll()
+        } else if (pendingScrollRestore) {
+          // On remount: restore saved scroll position instead of auto-scrolling
+          const restore = pendingScrollRestore
+          pendingScrollRestore = null
+          if (!restore.autoScroll) {
+            requestAnimationFrame(() => {
+              if (containerRef) containerRef.scrollTop = restore.scrollTop
+            })
+          } else {
+            scheduleAutoScroll()
+          }
         } else {
           scheduleAutoScroll()
         }
-      } else {
-        scheduleAutoScroll()
       }
     }
-  }))
+  ))
 
   // Auto-scroll when session starts running (thinking dots appear)
   createEffect(on(() => props.sessionStatus, (status) => {


### PR DESCRIPTION
## Summary

- Fix messages displaying with the wrong role (user as agent, agent as user) when switching between sessions or tasks
- Root cause: `ChatView`'s block rebuild effect only tracked `props.output.length`, so when switching to a session with the same item count, the old blocks persisted on screen with stale type info
- Now tracks `[sessionId, length]` and forces a clean `reconcile` (no merge) on session change to guarantee a full block rebuild

## Test plan

- [ ] Switch between two sessions that have a similar number of messages - verify blocks rebuild correctly with proper roles
- [ ] Switch between tasks - verify no stale messages from the previous task's session appear
- [ ] Verify scrolling behavior: session switch scrolls to bottom, same-session updates preserve scroll position
- [ ] Verify `make check` passes (typecheck, tests, clippy)