### PR TITLE
Replace notification permission dialog with toast

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,7 @@ import { initProblemsListener } from './store/problems'
 import { loadClaudeSkills } from './store/commands'
 import * as ipc from './lib/ipc'
 import { selectedTaskId, setSelectedTaskId, setSelectedProjectId } from './store/ui'
-import { initNotifications, showNotificationDialog, onNotificationDialogConfirm, onNotificationDialogCancel } from './lib/notifications'
+import { initNotifications } from './lib/notifications'
 import { initUpdateListener } from './lib/updater'
 
 const ctx = parseWindowContext()
@@ -64,14 +64,6 @@ const MainApp: Component = () => {
         danger
         onConfirm={() => ipc.quitApp()}
         onCancel={closeQuitDialog}
-      />
-      <ConfirmDialog
-        open={showNotificationDialog()}
-        title="Enable desktop notifications?"
-        message="Verun can notify you when tasks complete, fail, or need your approval. This is especially useful when you're running multiple sessions in parallel — you'll know exactly when something needs your attention, even if the app is in the background."
-        confirmLabel="Enable"
-        onConfirm={onNotificationDialogConfirm}
-        onCancel={onNotificationDialogCancel}
       />
       <FileConflictDialog />
     </>

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,5 +1,5 @@
 import { createSignal } from 'solid-js'
-import { selectedTaskId } from '../store/ui'
+import { selectedTaskId, addToast, dismissToast } from '../store/ui'
 import * as ipc from './ipc'
 
 // User preference — persisted to localStorage, default enabled
@@ -13,36 +13,38 @@ export function setNotificationsEnabledAndPersist(v: boolean) {
   localStorage.setItem(PREF_KEY, String(v))
 }
 
-// Whether the user has already seen the explanation dialog
-export function wasPrompted(): boolean {
+function wasPrompted(): boolean {
   return localStorage.getItem(PROMPTED_KEY) === 'true'
 }
 
-export function markPrompted() {
+function markPrompted() {
   localStorage.setItem(PROMPTED_KEY, 'true')
 }
 
-// Signal to drive the explanation dialog in App.tsx
-export const [showNotificationDialog, setShowNotificationDialog] = createSignal(false)
+const TOAST_ID = 'notification-prompt'
 
-/** Call on app mount. Shows the opt-in dialog on first launch. */
+/** Call on app mount. Shows an opt-in toast on first launch. */
 export function initNotifications() {
   if (!wasPrompted()) {
-    setShowNotificationDialog(true)
+    addToast('Enable desktop notifications for task updates?', 'info', {
+      id: TOAST_ID,
+      persistent: true,
+      onDismiss: () => {
+        markPrompted()
+        setNotificationsEnabledAndPersist(false)
+      },
+      actions: [
+        {
+          label: 'Enable',
+          variant: 'primary',
+          onClick: () => {
+            markPrompted()
+            dismissToast(TOAST_ID)
+          },
+        },
+      ],
+    })
   }
-}
-
-/** Called when user confirms the explanation dialog. */
-export function onNotificationDialogConfirm() {
-  setShowNotificationDialog(false)
-  markPrompted()
-}
-
-/** Called when user dismisses the explanation dialog. */
-export function onNotificationDialogCancel() {
-  setShowNotificationDialog(false)
-  markPrompted()
-  setNotificationsEnabledAndPersist(false)
 }
 
 // Suppress if the user is already looking at this task

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -172,6 +172,7 @@ export interface Toast {
   type: 'info' | 'error' | 'success'
   persistent?: boolean
   actions?: ToastAction[]
+  onDismiss?: () => void
 }
 
 export interface AddToastOptions {
@@ -179,6 +180,7 @@ export interface AddToastOptions {
   persistent?: boolean
   duration?: number
   actions?: ToastAction[]
+  onDismiss?: () => void
 }
 
 export const [toasts, setToasts] = createSignal<Toast[]>([])
@@ -190,7 +192,7 @@ export function addToast(
   opts: AddToastOptions = {},
 ): string {
   const id = opts.id ?? crypto.randomUUID()
-  const toast: Toast = { id, message, type, persistent: opts.persistent, actions: opts.actions }
+  const toast: Toast = { id, message, type, persistent: opts.persistent, actions: opts.actions, onDismiss: opts.onDismiss }
   setToasts(prev => {
     const existing = prev.findIndex(t => t.id === id)
     if (existing >= 0) {
@@ -214,7 +216,11 @@ export function dismissToast(id: string) {
   const timer = toastTimers.get(id)
   if (timer) clearTimeout(timer)
   toastTimers.delete(id)
-  setToasts(prev => prev.filter(t => t.id !== id))
+  setToasts(prev => {
+    const toast = prev.find(t => t.id === id)
+    toast?.onDismiss?.()
+    return prev.filter(t => t.id !== id)
+  })
 }
 
 // Shared edit-step signal — set by StepList edit button, consumed by MessageInput


### PR DESCRIPTION
## Summary
- Replace the modal `ConfirmDialog` for notification permissions with a small persistent toast in the bottom-right corner
- Toast shows an "Enable" button; the existing X dismiss button handles declining
- Add `onDismiss` callback to the toast system so dismissing via X still marks the user as prompted and persists the preference

## Test plan
- [ ] Clear `verun:notificationsPrompted` from localStorage and relaunch - toast should appear in the bottom-right
- [ ] Click "Enable" - toast dismisses, notifications stay enabled, toast does not reappear on next launch
- [ ] Clear localStorage again, relaunch, click the X button - toast dismisses, notifications are disabled, toast does not reappear
- [ ] Verify existing toasts (update, errors, etc.) still work correctly with the new `onDismiss` field