### PR TITLE
Add merge PR dialog with force merge and delete branch options

### DIFF
--- a/src-tauri/src/github.rs
+++ b/src-tauri/src/github.rs
@@ -224,11 +224,43 @@ pub fn merge_pr(worktree_path: &str, force: bool, delete_branch: bool) -> Result
         .map_err(|e| format!("Failed to merge PR: {e}"))?;
 
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!("gh pr merge failed: {stderr}"));
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        let msg = parse_merge_error(&stderr);
+        return Err(msg);
     }
 
     Ok(())
+}
+
+fn parse_merge_error(stderr: &str) -> String {
+    let s = stderr.trim();
+
+    if let Some(pos) = s.find("is not mergeable:") {
+        let after = s[pos + "is not mergeable:".len()..].trim();
+        let reason = after
+            .split(". To ")
+            .next()
+            .unwrap_or(after)
+            .trim_end_matches('.');
+        return capitalize(reason);
+    }
+
+    if let Some(pos) = s.find("not mergeable") {
+        let after = s[pos..].trim();
+        return capitalize(after);
+    }
+
+    s.strip_prefix("gh pr merge failed: ")
+        .unwrap_or(s)
+        .to_string()
+}
+
+fn capitalize(s: &str) -> String {
+    let mut c = s.chars();
+    match c.next() {
+        None => String::new(),
+        Some(f) => f.to_uppercase().to_string() + c.as_str(),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -360,5 +392,19 @@ mod tests {
     fn parse_empty_url() {
         let result = parse_github_url("").unwrap();
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn merge_error_branch_protection() {
+        let stderr = "X Pull request SoftwareSavants/verun#24 is not mergeable: the base branch policy prohibits the merge. To have the pull request merged after all the requirements have been met, add the `--auto` flag. To use administrator privileges to immediately merge the pull request, add the `--admin` flag.";
+        assert_eq!(
+            parse_merge_error(stderr),
+            "The base branch policy prohibits the merge"
+        );
+    }
+
+    #[test]
+    fn merge_error_passthrough() {
+        assert_eq!(parse_merge_error("some unknown error"), "some unknown error");
     }
 }

--- a/src-tauri/src/github.rs
+++ b/src-tauri/src/github.rs
@@ -205,11 +205,21 @@ pub fn mark_pr_ready(worktree_path: &str) -> Result<(), String> {
 }
 
 /// Merge the PR for the current branch.
-pub fn merge_pr(worktree_path: &str) -> Result<(), String> {
+/// When `force` is true, passes `--admin` to bypass branch protection rules.
+/// When `delete_branch` is true, passes `--delete-branch` to remove the remote branch.
+pub fn merge_pr(worktree_path: &str, force: bool, delete_branch: bool) -> Result<(), String> {
     check_gh_installed()?;
 
-    let output = gh(worktree_path)
-        .args(["pr", "merge", "--merge"])
+    let mut cmd = gh(worktree_path);
+    cmd.args(["pr", "merge", "--merge"]);
+    if force {
+        cmd.arg("--admin");
+    }
+    if delete_branch {
+        cmd.arg("--delete-branch");
+    }
+
+    let output = cmd
         .output()
         .map_err(|e| format!("Failed to merge PR: {e}"))?;
 

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -1214,13 +1214,17 @@ pub async fn mark_pr_ready(
 pub async fn merge_pull_request(
     pool: State<'_, SqlitePool>,
     task_id: String,
+    force: Option<bool>,
+    delete_branch: Option<bool>,
 ) -> Result<(), String> {
     let t = db::get_task(pool.inner(), &task_id)
         .await?
         .ok_or_else(|| format!("Task {task_id} not found"))?;
 
+    let force = force.unwrap_or(false);
+    let delete_branch = delete_branch.unwrap_or(false);
     flatten_join(
-        tokio::task::spawn_blocking(move || github::merge_pr(&t.worktree_path)).await,
+        tokio::task::spawn_blocking(move || github::merge_pr(&t.worktree_path, force, delete_branch)).await,
     )
 }
 

--- a/src/components/GitActions.tsx
+++ b/src/components/GitActions.tsx
@@ -7,6 +7,8 @@ import { sendMessage } from '../store/sessions'
 import { addToast } from '../store/ui'
 import { taskGit, refreshTaskGit, invalidateRemote } from '../store/git'
 import { registerDismissable } from '../lib/dismissable'
+import { Dialog } from './Dialog'
+import { DialogFooter } from './DialogFooter'
 
 interface GitAction {
   icon: Component<{ size: number }>
@@ -37,6 +39,11 @@ export const GitActions: Component<Props> = (props) => {
   const [open, setOpen] = createSignal(false)
   const [confirming, setConfirming] = createSignal<string | null>(null)
   const [actionLoading, setActionLoading] = createSignal(false)
+  const [mergeDialogOpen, setMergeDialogOpen] = createSignal(false)
+  const [mergeFailure, setMergeFailure] = createSignal<string | null>(null)
+  const [deleteBranch, setDeleteBranch] = createSignal(false)
+  const [forceMerge, setForceMerge] = createSignal(false)
+  const [merging, setMerging] = createSignal(false)
 
   // Read all git state from the centralized store
   const git = () => taskGit(props.taskId)
@@ -61,7 +68,7 @@ export const GitActions: Component<Props> = (props) => {
   }
 
   const needsConfirmation = (label: string) =>
-    label === 'Push' || label === 'Commit & Push' || label === 'Merge PR'
+    label === 'Push' || label === 'Commit & Push'
 
   const runAction = async (a: GitAction) => {
     if (needsConfirmation(a.label) && confirming() !== a.label) {
@@ -94,14 +101,36 @@ export const GitActions: Component<Props> = (props) => {
     }
   }
 
-  const doMerge = async () => {
+  const openMergeDialog = () => {
+    setMergeDialogOpen(true)
+    setDeleteBranch(false)
+    setForceMerge(false)
+    setMergeFailure(null)
+  }
+
+  const closeMergeDialog = () => {
+    setMergeDialogOpen(false)
+    setMergeFailure(null)
+  }
+
+  const doMerge = async (force?: boolean) => {
+    setMerging(true)
     try {
-      await ipc.mergePullRequest(props.taskId)
+      await ipc.mergePullRequest(props.taskId, force, deleteBranch())
       addToast('PR merged', 'success')
+      closeMergeDialog()
       invalidateRemote(props.taskId)
       await refreshTaskGit(props.taskId, { force: true })
     } catch (e: any) {
-      addToast(`Merge failed: ${e}`, 'error')
+      if (!force) {
+        setMergeFailure(String(e))
+        setForceMerge(false)
+      } else {
+        addToast(`Force merge failed: ${e}`, 'error')
+        closeMergeDialog()
+      }
+    } finally {
+      setMerging(false)
     }
   }
 
@@ -143,7 +172,7 @@ export const GitActions: Component<Props> = (props) => {
   const draftPrAction = (): GitAction => ({ icon: GitPullRequest, label: 'Draft PR', message: 'create a draft pull request with an appropriate title and description' })
   const pullAction = (): GitAction => ({ icon: Download, label: 'Update Branch', message: 'this branch is behind the base branch. rebase onto the base branch to bring it up to date. Use git rebase, not merge.' })
   const resolveConflictsAction = (): GitAction => ({ icon: Swords, label: 'Resolve conflicts', message: 'rebase this branch onto the base branch and resolve any conflicts. Use git rebase, not merge. If conflicts arise during rebase, resolve them and continue with git rebase --continue' })
-  const mergePrAction = (): GitAction => ({ icon: GitMerge, label: 'Merge PR', action: doMerge })
+  const mergePrAction = (): GitAction => ({ icon: GitMerge, label: 'Merge PR', action: async () => openMergeDialog() })
   const readyForReviewAction = (): GitAction => ({ icon: Eye, label: 'Ready for Review', action: doMarkReady })
 
   const isDraft = () => pr()?.isDraft ?? false
@@ -363,6 +392,60 @@ export const GitActions: Component<Props> = (props) => {
         </div>
       </Show>
       </Show>
+
+      <Dialog open={mergeDialogOpen()} onClose={closeMergeDialog} onConfirm={() => !mergeFailure() && doMerge()}>
+        <h2 class="text-base font-semibold text-text-primary mb-2">
+          {mergeFailure() ? 'Merge blocked' : 'Merge PR'}
+        </h2>
+
+        <Show when={mergeFailure()}>
+          <p class="text-sm text-text-muted mb-4">{mergeFailure()}</p>
+        </Show>
+
+        <label class="flex items-center gap-2 mb-2 cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={deleteBranch()}
+            onChange={(e) => setDeleteBranch(e.currentTarget.checked)}
+            class="accent-blue-500 w-3.5 h-3.5"
+          />
+          <span class="text-sm text-text-secondary">Delete branch after merge</span>
+        </label>
+
+        <Show when={mergeFailure()}>
+          <label class="flex items-center gap-2 mb-2 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={forceMerge()}
+              onChange={(e) => setForceMerge(e.currentTarget.checked)}
+              class="accent-amber-500 w-3.5 h-3.5"
+            />
+            <span class="text-sm text-amber-400">Force merge (bypass branch protection)</span>
+          </label>
+        </Show>
+
+        <div class="mt-4">
+          <Show when={mergeFailure()} fallback={
+            <DialogFooter
+              onCancel={closeMergeDialog}
+              onConfirm={() => doMerge()}
+              confirmLabel="Merge"
+              loading={merging()}
+              loadingLabel="Merging..."
+            />
+          }>
+            <DialogFooter
+              onCancel={closeMergeDialog}
+              onConfirm={() => doMerge(true)}
+              confirmLabel="Force Merge"
+              confirmClass="btn-danger border border-status-error/20"
+              disabled={!forceMerge()}
+              loading={merging()}
+              loadingLabel="Merging..."
+            />
+          </Show>
+        </div>
+      </Dialog>
     </div>
   )
 }

--- a/src/components/GitActions.tsx
+++ b/src/components/GitActions.tsx
@@ -1,5 +1,5 @@
 import { Component, createSignal, createEffect, on, Show, For, onCleanup } from 'solid-js'
-import { Upload, Download, GitPullRequest, GitMerge, Swords, Wrench, Search, ExternalLink, CircleCheck, CircleX, Clock, Circle, ChevronDown, Loader2, Eye } from 'lucide-solid'
+import { ArrowUpFromLine, Download, GitPullRequest, GitMerge, Swords, Wrench, Search, ExternalLink, CircleCheck, CircleX, Clock, Circle, ChevronDown, Loader2, Eye } from 'lucide-solid'
 import { openUrl } from '@tauri-apps/plugin-opener'
 import * as ipc from '../lib/ipc'
 import { claudeSkills } from '../store/commands'
@@ -163,8 +163,8 @@ export const GitActions: Component<Props> = (props) => {
 
   const pushAction = (): GitAction =>
     fileCount() > 0
-      ? { icon: Upload, label: 'Commit & Push', message: 'commit all changes and push to remote' }
-      : { icon: Upload, label: 'Push', action: doPush }
+      ? { icon: ArrowUpFromLine, label: 'Commit & Push', message: 'commit all changes and push to remote' }
+      : { icon: ArrowUpFromLine, label: 'Push', action: doPush }
   const createPrAction = (): GitAction => ({ icon: GitPullRequest, label: 'Create PR', message: 'create a pull request with an appropriate title and description' })
   const draftPrAction = (): GitAction => ({ icon: GitPullRequest, label: 'Draft PR', message: 'create a draft pull request with an appropriate title and description' })
   const pullAction = (): GitAction => ({ icon: Download, label: 'Update Branch', message: 'this branch is behind the base branch. rebase onto the base branch to bring it up to date. Use git rebase, not merge.' })
@@ -393,47 +393,48 @@ export const GitActions: Component<Props> = (props) => {
       </Show>
 
       <Show when={mergePanelOpen()}>
-        <div class="absolute right-0 top-full mt-1 z-50 w-56 bg-surface-2 border border-slate-700 rounded-lg shadow-xl p-3 animate-in">
-          <Show when={mergeFailure()}>
-            <p class="text-[11px] text-red-400 mb-2">{mergeFailure()}</p>
-          </Show>
-
-          <label class="flex items-center gap-2 mb-3 cursor-pointer select-none">
+        <div class="absolute right-0 top-full mt-1 z-50 w-56 bg-surface-2 border border-slate-700 rounded-lg shadow-xl py-3 px-3 flex flex-col gap-2.5 animate-in">
+          <label class="flex items-center gap-2 cursor-pointer select-none">
             <input
               type="checkbox"
               checked={deleteBranch()}
               onChange={(e) => setDeleteBranch(e.currentTarget.checked)}
-              class="accent-blue-500 w-3.5 h-3.5"
+              class="accent-accent w-3.5 h-3.5"
             />
-            <span class="text-[11px] text-text-secondary">Delete branch</span>
+            <span class="text-[13px] text-text-secondary">Delete branch</span>
           </label>
 
-          <div class="flex items-center gap-1.5">
-            <Show when={mergeFailure()}>
-              <button
-                class="flex-1 flex items-center justify-center gap-1 px-2 py-1 rounded text-[11px] bg-red-500/15 text-red-400 hover:bg-red-500/25 transition-colors disabled:opacity-40"
-                onClick={() => doMerge(true)}
-                disabled={merging()}
-              >
-                <Show when={merging()} fallback={<>Force Merge</>}>
-                  <Loader2 size={11} class="animate-spin" />
-                  <span>Merging...</span>
-                </Show>
-              </button>
-            </Show>
-            <Show when={!mergeFailure()}>
-              <button
-                class="flex-1 flex items-center justify-center gap-1 px-2 py-1 rounded text-[11px] btn-primary transition-colors disabled:opacity-40"
-                onClick={() => doMerge()}
-                disabled={merging()}
-              >
-                <Show when={merging()} fallback={<>Merge</>}>
-                  <Loader2 size={11} class="animate-spin" />
-                  <span>Merging...</span>
-                </Show>
-              </button>
-            </Show>
-          </div>
+          <Show when={mergeFailure()} fallback={
+            <button
+              class="w-full h-7 flex items-center justify-center gap-1 px-2 rounded text-[11px] btn-primary transition-colors disabled:opacity-40"
+              onClick={() => doMerge()}
+              disabled={merging()}
+            >
+              <Show when={merging()} fallback={<>Merge</>}>
+                <Loader2 size={11} class="animate-spin" />
+                <span>Merging...</span>
+              </Show>
+            </button>
+          }>
+            <button
+              class="w-full h-7 flex items-center justify-center gap-1 px-2 rounded text-[11px] bg-red-500/15 text-red-400 hover:bg-red-500/25 transition-colors disabled:opacity-40"
+              onClick={() => doMerge(true)}
+              disabled={merging()}
+            >
+              <Show when={merging()} fallback={<>Force Merge</>}>
+                <Loader2 size={11} class="animate-spin" />
+                <span>Merging...</span>
+              </Show>
+            </button>
+          </Show>
+
+          <Show when={mergeFailure()}>
+            <p class="text-[11px] text-red-400 m-0">
+              {mergeFailure()!.toLowerCase().includes('policy') || mergeFailure()!.toLowerCase().includes('protection')
+                ? 'Branch protection is blocking this merge. Use force merge to bypass.'
+                : `Merge failed. Use force merge to retry with admin privileges.`}
+            </p>
+          </Show>
         </div>
       </Show>
     </div>

--- a/src/components/GitActions.tsx
+++ b/src/components/GitActions.tsx
@@ -403,7 +403,7 @@ export const GitActions: Component<Props> = (props) => {
               type="checkbox"
               checked={deleteBranch()}
               onChange={(e) => setDeleteBranch(e.currentTarget.checked)}
-              class="accent-blue-500 w-3 h-3"
+              class="accent-blue-500 w-3.5 h-3.5"
             />
             <span class="text-[11px] text-text-secondary">Delete branch</span>
           </label>

--- a/src/components/GitActions.tsx
+++ b/src/components/GitActions.tsx
@@ -7,8 +7,6 @@ import { sendMessage } from '../store/sessions'
 import { addToast } from '../store/ui'
 import { taskGit, refreshTaskGit, invalidateRemote } from '../store/git'
 import { registerDismissable } from '../lib/dismissable'
-import { Dialog } from './Dialog'
-import { DialogFooter } from './DialogFooter'
 
 interface GitAction {
   icon: Component<{ size: number }>
@@ -39,10 +37,9 @@ export const GitActions: Component<Props> = (props) => {
   const [open, setOpen] = createSignal(false)
   const [confirming, setConfirming] = createSignal<string | null>(null)
   const [actionLoading, setActionLoading] = createSignal(false)
-  const [mergeDialogOpen, setMergeDialogOpen] = createSignal(false)
+  const [mergePanelOpen, setMergePanelOpen] = createSignal(false)
   const [mergeFailure, setMergeFailure] = createSignal<string | null>(null)
   const [deleteBranch, setDeleteBranch] = createSignal(false)
-  const [forceMerge, setForceMerge] = createSignal(false)
   const [merging, setMerging] = createSignal(false)
 
   // Read all git state from the centralized store
@@ -57,6 +54,7 @@ export const GitActions: Component<Props> = (props) => {
   createEffect(on(() => props.taskId, () => {
     setOpen(false)
     setConfirming(null)
+    closeMergePanel()
     refreshTaskGit(props.taskId)
   }))
 
@@ -101,15 +99,15 @@ export const GitActions: Component<Props> = (props) => {
     }
   }
 
-  const openMergeDialog = () => {
-    setMergeDialogOpen(true)
+  const openMergePanel = () => {
+    setOpen(false)
+    setMergePanelOpen(true)
     setDeleteBranch(false)
-    setForceMerge(false)
     setMergeFailure(null)
   }
 
-  const closeMergeDialog = () => {
-    setMergeDialogOpen(false)
+  const closeMergePanel = () => {
+    setMergePanelOpen(false)
     setMergeFailure(null)
   }
 
@@ -118,16 +116,15 @@ export const GitActions: Component<Props> = (props) => {
     try {
       await ipc.mergePullRequest(props.taskId, force, deleteBranch())
       addToast('PR merged', 'success')
-      closeMergeDialog()
+      closeMergePanel()
       invalidateRemote(props.taskId)
       await refreshTaskGit(props.taskId, { force: true })
     } catch (e: any) {
       if (!force) {
         setMergeFailure(String(e))
-        setForceMerge(false)
       } else {
         addToast(`Force merge failed: ${e}`, 'error')
-        closeMergeDialog()
+        closeMergePanel()
       }
     } finally {
       setMerging(false)
@@ -172,7 +169,7 @@ export const GitActions: Component<Props> = (props) => {
   const draftPrAction = (): GitAction => ({ icon: GitPullRequest, label: 'Draft PR', message: 'create a draft pull request with an appropriate title and description' })
   const pullAction = (): GitAction => ({ icon: Download, label: 'Update Branch', message: 'this branch is behind the base branch. rebase onto the base branch to bring it up to date. Use git rebase, not merge.' })
   const resolveConflictsAction = (): GitAction => ({ icon: Swords, label: 'Resolve conflicts', message: 'rebase this branch onto the base branch and resolve any conflicts. Use git rebase, not merge. If conflicts arise during rebase, resolve them and continue with git rebase --continue' })
-  const mergePrAction = (): GitAction => ({ icon: GitMerge, label: 'Merge PR', action: async () => openMergeDialog() })
+  const mergePrAction = (): GitAction => ({ icon: GitMerge, label: 'Merge PR', action: async () => openMergePanel() })
   const readyForReviewAction = (): GitAction => ({ icon: Eye, label: 'Ready for Review', action: doMarkReady })
 
   const isDraft = () => pr()?.isDraft ?? false
@@ -220,15 +217,17 @@ export const GitActions: Component<Props> = (props) => {
 
   // Close dropdown on outside click
   let containerRef: HTMLDivElement | undefined
+  const anyPanelOpen = () => open() || mergePanelOpen()
+  const closeAllPanels = () => { setOpen(false); closeMergePanel() }
   const handleClickOutside = (e: MouseEvent) => {
-    if (open() && containerRef && !containerRef.contains(e.target as Node)) {
-      setOpen(false)
+    if (anyPanelOpen() && containerRef && !containerRef.contains(e.target as Node)) {
+      closeAllPanels()
     }
   }
   createEffect(() => {
-    if (open()) {
+    if (anyPanelOpen()) {
       document.addEventListener('mousedown', handleClickOutside)
-      const unregister = registerDismissable(() => setOpen(false))
+      const unregister = registerDismissable(closeAllPanels)
       onCleanup(() => {
         document.removeEventListener('mousedown', handleClickOutside)
         unregister()
@@ -314,7 +313,7 @@ export const GitActions: Component<Props> = (props) => {
               class={`flex items-center px-1.5 transition-colors disabled:opacity-40 disabled:pointer-events-none ${
                 confirming() === primaryAction().label ? 'hover:bg-amber-500/10' : 'hover:bg-surface-2'
               }`}
-              onClick={() => { setConfirming(null); setOpen(!open()) }}
+              onClick={() => { setConfirming(null); closeMergePanel(); setOpen(!open()) }}
               disabled={props.isRunning || actionLoading()}
             >
               <ChevronDown size={11} />
@@ -393,59 +392,50 @@ export const GitActions: Component<Props> = (props) => {
       </Show>
       </Show>
 
-      <Dialog open={mergeDialogOpen()} onClose={closeMergeDialog} onConfirm={() => !mergeFailure() && doMerge()}>
-        <h2 class="text-base font-semibold text-text-primary mb-2">
-          {mergeFailure() ? 'Merge blocked' : 'Merge PR'}
-        </h2>
+      <Show when={mergePanelOpen()}>
+        <div class="absolute right-0 top-full mt-1 z-50 w-56 bg-surface-2 border border-slate-700 rounded-lg shadow-xl p-3 animate-in">
+          <Show when={mergeFailure()}>
+            <p class="text-[11px] text-red-400 mb-2">{mergeFailure()}</p>
+          </Show>
 
-        <Show when={mergeFailure()}>
-          <p class="text-sm text-text-muted mb-4">{mergeFailure()}</p>
-        </Show>
-
-        <label class="flex items-center gap-2 mb-2 cursor-pointer select-none">
-          <input
-            type="checkbox"
-            checked={deleteBranch()}
-            onChange={(e) => setDeleteBranch(e.currentTarget.checked)}
-            class="accent-blue-500 w-3.5 h-3.5"
-          />
-          <span class="text-sm text-text-secondary">Delete branch after merge</span>
-        </label>
-
-        <Show when={mergeFailure()}>
-          <label class="flex items-center gap-2 mb-2 cursor-pointer select-none">
+          <label class="flex items-center gap-2 mb-3 cursor-pointer select-none">
             <input
               type="checkbox"
-              checked={forceMerge()}
-              onChange={(e) => setForceMerge(e.currentTarget.checked)}
-              class="accent-amber-500 w-3.5 h-3.5"
+              checked={deleteBranch()}
+              onChange={(e) => setDeleteBranch(e.currentTarget.checked)}
+              class="accent-blue-500 w-3 h-3"
             />
-            <span class="text-sm text-amber-400">Force merge (bypass branch protection)</span>
+            <span class="text-[11px] text-text-secondary">Delete branch</span>
           </label>
-        </Show>
 
-        <div class="mt-4">
-          <Show when={mergeFailure()} fallback={
-            <DialogFooter
-              onCancel={closeMergeDialog}
-              onConfirm={() => doMerge()}
-              confirmLabel="Merge"
-              loading={merging()}
-              loadingLabel="Merging..."
-            />
-          }>
-            <DialogFooter
-              onCancel={closeMergeDialog}
-              onConfirm={() => doMerge(true)}
-              confirmLabel="Force Merge"
-              confirmClass="btn-danger border border-status-error/20"
-              disabled={!forceMerge()}
-              loading={merging()}
-              loadingLabel="Merging..."
-            />
-          </Show>
+          <div class="flex items-center gap-1.5">
+            <Show when={mergeFailure()}>
+              <button
+                class="flex-1 flex items-center justify-center gap-1 px-2 py-1 rounded text-[11px] bg-red-500/15 text-red-400 hover:bg-red-500/25 transition-colors disabled:opacity-40"
+                onClick={() => doMerge(true)}
+                disabled={merging()}
+              >
+                <Show when={merging()} fallback={<>Force Merge</>}>
+                  <Loader2 size={11} class="animate-spin" />
+                  <span>Merging...</span>
+                </Show>
+              </button>
+            </Show>
+            <Show when={!mergeFailure()}>
+              <button
+                class="flex-1 flex items-center justify-center gap-1 px-2 py-1 rounded text-[11px] btn-primary transition-colors disabled:opacity-40"
+                onClick={() => doMerge()}
+                disabled={merging()}
+              >
+                <Show when={merging()} fallback={<>Merge</>}>
+                  <Loader2 size={11} class="animate-spin" />
+                  <span>Merging...</span>
+                </Show>
+              </button>
+            </Show>
+          </div>
         </div>
-      </Dialog>
+      </Show>
     </div>
   )
 }

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -191,8 +191,8 @@ export const getPullRequest = (taskId: string) =>
 export const markPrReady = (taskId: string) =>
   invoke<void>('mark_pr_ready', { taskId })
 
-export const mergePullRequest = (taskId: string) =>
-  invoke<void>('merge_pull_request', { taskId })
+export const mergePullRequest = (taskId: string, force?: boolean, deleteBranch?: boolean) =>
+  invoke<void>('merge_pull_request', { taskId, force, deleteBranch })
 
 export const gitShip = (taskId: string, commitMessage: string, prTitle: string, prBody: string, base: string) =>
   invoke<PrInfo>('git_ship', { taskId, commitMessage, prTitle, prBody, base })


### PR DESCRIPTION
## Summary
- Replace click-twice merge confirmation with a proper dialog
- Add "Delete branch after merge" checkbox that passes `--delete-branch` to `gh pr merge`
- Add "Force merge (bypass branch protection)" checkbox that passes `--admin`, shown only when a normal merge fails
- Thread `force` and `delete_branch` params through the full stack: `github.rs` -> `ipc.rs` -> `ipc.ts` -> `GitActions.tsx`

## Test plan
- [ ] Click "Merge PR" and verify the dialog opens with the "Delete branch" checkbox
- [ ] Merge without checking "Delete branch" and confirm remote branch is preserved
- [ ] Merge with "Delete branch" checked and confirm remote branch is removed
- [ ] Trigger a merge failure (e.g. branch protection) and verify the force merge checkbox appears
- [ ] Force merge with both checkboxes and confirm both flags work together