### PR TITLE
Fix sticky black gap between chat and composer

### DIFF
--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -827,7 +827,7 @@ export const ChatView: Component<Props> = (props) => {
         onScroll={handleScroll}
         onClick={handleLinkClick}
       >
-      <div ref={contentRef} class="flex flex-col gap-2 py-4">
+      <div ref={contentRef} class="flex flex-col gap-2 pt-4 pb-6">
         <Show when={props.sessionStatus === 'error'}>
           <div class="mx-5 flex items-center gap-2 px-3 py-2 rounded-lg bg-status-error/8 border border-status-error/15">
             <AlertTriangle size={14} class="text-status-error shrink-0" />

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -1513,7 +1513,7 @@ export const MessageInput: Component<Props> = (props) => {
 
   return (
     <div
-      class="px-4 py-3 min-w-0"
+      class="px-4 pb-3 min-w-0"
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}


### PR DESCRIPTION
## Summary
- Remove top padding from the MessageInput wrapper that was rendering as a thick black bar (the `bg-surface-0` parent showing through)
- Move that spacing into the scrollable ChatView content as bottom padding, so it scrolls with the chat instead of staying fixed

## Test plan
- [ ] Open a task with session output - no black bar visible between chat and input
- [ ] Scroll to the bottom of a long session - content has breathing room above the composer
- [ ] Verify StepList still looks correct when steps are present