### PR TITLE
Change add & arm shortcut to Cmd+Shift+Enter

### DIFF
--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -1179,8 +1179,8 @@ export const MessageInput: Component<Props> = (props) => {
       }
     }
 
-    // Cmd+Enter
-    if (e.key === 'Enter' && e.metaKey) {
+    // Cmd+Enter (without Shift)
+    if (e.key === 'Enter' && e.metaKey && !e.shiftKey) {
       e.preventDefault()
       if (props.isRunning) {
         handleSteer() // abort + send immediately
@@ -1190,8 +1190,8 @@ export const MessageInput: Component<Props> = (props) => {
       return
     }
 
-    // Shift+Enter while running = add armed step
-    if (e.key === 'Enter' && e.shiftKey && props.isRunning) {
+    // Cmd+Shift+Enter while running = add armed step
+    if (e.key === 'Enter' && e.shiftKey && e.metaKey && props.isRunning) {
       e.preventDefault()
       handleAddStep(true)
       return
@@ -1921,7 +1921,7 @@ export const MessageInput: Component<Props> = (props) => {
       <Show when={props.isRunning && editingMessageIdx() === null && editingStepId() === null && (message().trim() || attachments().length > 0)}>
         <div class="px-3 pb-0.5">
           <span class="text-[10px] text-text-dim">
-            Enter to add next step · Shift+Enter to add & arm · Cmd+Enter to redirect
+            Enter to add next step · Cmd+Shift+Enter to add & arm · Cmd+Enter to redirect
           </span>
         </div>
       </Show>


### PR DESCRIPTION
## Summary
- Changes the "add & arm step" shortcut from Shift+Enter to Cmd+Shift+Enter to avoid conflicting with the common newline expectation
- Adds `!e.shiftKey` guard to the Cmd+Enter handler so it doesn't intercept the new combo
- Updates the hint text shown below the composer

## Test plan
- [ ] While a session is running, type a message and press Cmd+Shift+Enter - should add an armed step
- [ ] Cmd+Enter still redirects/fires next step as before
- [ ] Plain Enter still adds a non-armed step
- [ ] Hint text below the composer shows the updated shortcut