### PR TITLE
feat: show start command running indicator in sidebar

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -39,6 +39,7 @@ import {
   markTaskWindowed,
 } from "../store/ui";
 import { sessionsForTask, loadSessions } from "../store/sessions";
+import { isStartCommandRunning } from "../store/terminals";
 import { deleteProject } from "../store/projects";
 import { ConfirmDialog } from "./ConfirmDialog";
 import { NewTaskDialog } from "./NewTaskDialog";
@@ -59,6 +60,7 @@ import {
   CircleX,
   Archive,
   Settings,
+  Play,
 } from "lucide-solid";
 import { clsx } from "clsx";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
@@ -465,6 +467,9 @@ export const Sidebar: Component = () => {
                                   <GitBranch size={9} class="shrink-0 text-text-dim/70" />
                                 </Show>
                                 {task.branch}
+                                <Show when={isStartCommandRunning(task.id)}>
+                                  <Play size={9} class="shrink-0 text-green-400 fill-green-400 animate-pulse" />
+                                </Show>
                                 <Show when={isTaskWindowed(task.id)}>
                                   <ExternalLink size={9} class="shrink-0 text-accent/60" />
                                 </Show>


### PR DESCRIPTION
## Summary
- Adds a pulsing green play icon next to the branch name in the sidebar when a task's start command (F5) is running
- Uses the existing `isStartCommandRunning` reactive state from the terminals store
- Provides quick visual feedback without conflating session status with dev server status

## Test plan
- [ ] Start a task's dev server with F5 and verify the play icon appears next to the branch name
- [ ] Stop the dev server and verify the icon disappears
- [ ] Confirm the pulse animation is subtle and not distracting
- [ ] Verify existing status indicators (attention dot, unread dot, windowed icon) still render correctly