### PR TITLE
Project-level session defaults (approval mode, model, thinking, fast)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Project-level session defaults: approval mode, model, thinking mode, and fast mode are now stored per project and applied automatically to new tasks - toggling any mode on a task updates the project default, and the project settings page exposes all four controls
+
 ## 0.6.0 — 2026-04-14
 
 - Plan approval prompt no longer appears falsely when navigating back to a task with plan mode toggled on but no plan generated

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -172,6 +172,17 @@ pub fn migrations() -> Vec<Migration> {
             CREATE INDEX IF NOT EXISTS idx_turn_snapshots_session ON turn_snapshots(session_id);
         "#,
         kind: MigrationKind::Up,
+    },
+    Migration {
+        version: 13,
+        description: "add session defaults to projects",
+        sql: r#"
+            ALTER TABLE projects ADD COLUMN default_trust_level TEXT NOT NULL DEFAULT 'normal';
+            ALTER TABLE projects ADD COLUMN default_model TEXT;
+            ALTER TABLE projects ADD COLUMN default_thinking_mode INTEGER NOT NULL DEFAULT 1;
+            ALTER TABLE projects ADD COLUMN default_fast_mode INTEGER NOT NULL DEFAULT 0;
+        "#,
+        kind: MigrationKind::Up,
     }]
 }
 
@@ -191,6 +202,14 @@ pub struct Project {
     pub start_command: String,
     pub auto_start: bool,
     pub created_at: i64,
+    #[sqlx(default)]
+    pub default_trust_level: String,
+    #[sqlx(default)]
+    pub default_model: Option<String>,
+    #[sqlx(default)]
+    pub default_thinking_mode: bool,
+    #[sqlx(default)]
+    pub default_fast_mode: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
@@ -288,6 +307,7 @@ pub enum DbWrite {
     InsertProject(Project),
     UpdateProjectBaseBranch { id: String, base_branch: String },
     UpdateProjectHooks { id: String, setup_hook: String, destroy_hook: String, start_command: String, auto_start: bool },
+    UpdateProjectDefaults { id: String, default_trust_level: String, default_model: Option<String>, default_thinking_mode: bool, default_fast_mode: bool },
     DeleteProject { id: String },
 
     // Tasks
@@ -358,8 +378,8 @@ async fn process_write(pool: &SqlitePool, write: DbWrite) -> Result<(), sqlx::Er
         // -- Projects --
         DbWrite::InsertProject(p) => {
             sqlx::query(
-                "INSERT INTO projects (id, name, repo_path, base_branch, setup_hook, destroy_hook, start_command, auto_start, created_at) \
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "INSERT INTO projects (id, name, repo_path, base_branch, setup_hook, destroy_hook, start_command, auto_start, created_at, default_trust_level, default_model, default_thinking_mode, default_fast_mode) \
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             )
             .bind(&p.id)
             .bind(&p.name)
@@ -370,6 +390,10 @@ async fn process_write(pool: &SqlitePool, write: DbWrite) -> Result<(), sqlx::Er
             .bind(&p.start_command)
             .bind(p.auto_start)
             .bind(p.created_at)
+            .bind(&p.default_trust_level)
+            .bind(&p.default_model)
+            .bind(p.default_thinking_mode)
+            .bind(p.default_fast_mode)
             .execute(pool)
             .await?;
         }
@@ -386,6 +410,16 @@ async fn process_write(pool: &SqlitePool, write: DbWrite) -> Result<(), sqlx::Er
                 .bind(&destroy_hook)
                 .bind(&start_command)
                 .bind(auto_start)
+                .bind(&id)
+                .execute(pool)
+                .await?;
+        }
+        DbWrite::UpdateProjectDefaults { id, default_trust_level, default_model, default_thinking_mode, default_fast_mode } => {
+            sqlx::query("UPDATE projects SET default_trust_level = ?, default_model = ?, default_thinking_mode = ?, default_fast_mode = ? WHERE id = ?")
+                .bind(&default_trust_level)
+                .bind(&default_model)
+                .bind(default_thinking_mode)
+                .bind(default_fast_mode)
                 .bind(&id)
                 .execute(pool)
                 .await?;
@@ -890,21 +924,12 @@ mod tests {
     use super::*;
 
     #[test]
-    fn has_twelve_migrations() {
+    fn has_thirteen_migrations() {
         let m = migrations();
-        assert_eq!(m.len(), 12);
-        assert_eq!(m[0].version, 1);
-        assert_eq!(m[1].version, 2);
-        assert_eq!(m[2].version, 3);
-        assert_eq!(m[3].version, 4);
-        assert_eq!(m[4].version, 5);
-        assert_eq!(m[5].version, 6);
-        assert_eq!(m[6].version, 7);
-        assert_eq!(m[7].version, 8);
-        assert_eq!(m[8].version, 9);
-        assert_eq!(m[9].version, 10);
-        assert_eq!(m[10].version, 11);
-        assert_eq!(m[11].version, 12);
+        assert_eq!(m.len(), 13);
+        for (i, mig) in m.iter().enumerate() {
+            assert_eq!(mig.version, (i + 1) as i64);
+        }
     }
 
     #[test]
@@ -932,6 +957,10 @@ mod tests {
             start_command: String::new(),
             auto_start: false,
             created_at: 1000,
+            default_trust_level: "normal".into(),
+            default_model: None,
+            default_thinking_mode: true,
+            default_fast_mode: false,
         }
     }
 

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -80,6 +80,10 @@ pub async fn add_project(
         start_command,
         auto_start: false,
         created_at: epoch_ms(),
+        default_trust_level: "normal".into(),
+        default_model: None,
+        default_thinking_mode: true,
+        default_fast_mode: false,
     };
 
     db_tx
@@ -143,6 +147,21 @@ pub async fn update_project_hooks(
 ) -> Result<(), String> {
     db_tx
         .send(db::DbWrite::UpdateProjectHooks { id, setup_hook, destroy_hook, start_command, auto_start })
+        .await
+        .map_err(|e| format!("DB write failed: {e}"))
+}
+
+#[tauri::command]
+pub async fn update_project_defaults(
+    db_tx: State<'_, DbWriteTx>,
+    id: String,
+    default_trust_level: String,
+    default_model: Option<String>,
+    default_thinking_mode: bool,
+    default_fast_mode: bool,
+) -> Result<(), String> {
+    db_tx
+        .send(db::DbWrite::UpdateProjectDefaults { id, default_trust_level, default_model, default_thinking_mode, default_fast_mode })
         .await
         .map_err(|e| format!("DB write failed: {e}"))
 }
@@ -251,6 +270,14 @@ pub async fn create_task(
             from_task_window,
         },
     ).await?;
+
+    if project.default_trust_level != "normal" {
+        let _ = db_tx.send(db::DbWrite::SetTrustLevel {
+            task_id: task.id.clone(),
+            trust_level: project.default_trust_level,
+            updated_at: epoch_ms(),
+        }).await;
+    }
 
     // For task windows: store label → taskId so the close handler works
     if from_task_window {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -212,6 +212,7 @@ pub fn run() {
             ipc::delete_project,
             ipc::update_project_base_branch,
             ipc::update_project_hooks,
+            ipc::update_project_defaults,
             ipc::export_project_config,
             ipc::import_project_config,
             // Tasks

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -10,9 +10,10 @@ import { BlobImage } from './BlobImage'
 import { parseMentions } from '../lib/mentions'
 import { Popover } from './Popover'
 import * as ipc from '../lib/ipc'
-import { addToast, setSelectedTaskId, setSelectedSessionId } from '../store/ui'
-import { setSessions, loadOutputLines } from '../store/sessions'
+import { addToast, setSelectedTaskId, setSelectedSessionId, setTaskModel } from '../store/ui'
+import { setSessions, loadOutputLines, setTaskThinkingMode, setTaskFastMode } from '../store/sessions'
 import { setTasks } from '../store/tasks'
+import { projectById } from '../store/projects'
 
 function formatDuration(ms: number): string {
   const totalSec = Math.round(ms / 1000)
@@ -276,6 +277,13 @@ const ForkButton: Component<{ sessionId: string; messageUuid: string }> = (props
       const tws = await ipc.forkSessionToNewTask(props.sessionId, props.messageUuid, worktreeState)
       setTasks(produce(t => { if (!t.find(x => x.id === tws.task.id)) t.unshift(tws.task) }))
       setSessions(produce(s => { if (!s.find(x => x.id === tws.session.id)) s.push(tws.session) }))
+      // Apply project defaults to the forked task
+      const project = projectById(tws.task.projectId)
+      if (project) {
+        setTaskThinkingMode(tws.task.id, project.defaultThinkingMode)
+        setTaskFastMode(tws.task.id, project.defaultFastMode)
+        if (project.defaultModel) setTaskModel(tws.task.id, project.defaultModel)
+      }
       await loadOutputLines(tws.session.id)
       setSelectedTaskId(tws.task.id)
       setSelectedSessionId(tws.session.id)

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -570,7 +570,12 @@ export const MessageInput: Component<Props> = (props) => {
     sendMessage(sid, text, undefined, currentModel(), true)
   }
 
-  const currentModel = () => effectiveModel(selectedTaskId())
+  const currentModel = () => {
+    const tid = selectedTaskId()
+    const task = tid ? taskById(tid) : null
+    const project = task ? projectById(task.projectId) : null
+    return effectiveModel(tid, project?.defaultModel)
+  }
 
   const currentApproval = () => {
     const sid = props.sessionId

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -3,6 +3,7 @@ import { sendMessage, abortMessage, createSession, clearOutputItems, pendingAppr
 import { effectiveModel, setTaskModel, setSelectedSessionId, selectedTaskId, editStepRequest, setEditStepRequest, chatPrefillRequest, setChatPrefillRequest } from '../store/ui'
 import { isSetupRunning, queueMessage, queuedMessages, clearQueuedMessage } from '../store/setup'
 import { taskById } from '../store/tasks'
+import { projectById, updateProjectDefaults } from '../store/projects'
 import { addStep, getSteps, updateStep, extractStep } from '../store/steps'
 import { ModelSelector } from './ModelSelector'
 import { CommandPalette } from './CommandPalette'
@@ -417,7 +418,14 @@ export const MessageInput: Component<Props> = (props) => {
       try {
         const level = await ipc.getTrustLevel(taskId) as TrustLevel
         setTrustLevelLocal(level)
-      } catch { /* default to normal */ }
+      } catch {
+        // Fall back to project default
+        const task = taskById(taskId)
+        if (task) {
+          const project = projectById(task.projectId)
+          if (project) setTrustLevelLocal(project.defaultTrustLevel)
+        }
+      }
     }
   }))
 
@@ -450,6 +458,12 @@ export const MessageInput: Component<Props> = (props) => {
     await ipc.setTrustLevel(taskId, level)
     setTrustLevelLocal(level)
     setShowTrustMenu(false)
+    // Propagate to project default
+    const task = taskById(taskId)
+    if (task) {
+      const project = projectById(task.projectId)
+      if (project) updateProjectDefaults(project.id, { defaultTrustLevel: level })
+    }
   }
 
   const autoApprovedCount = () => {
@@ -480,6 +494,12 @@ export const MessageInput: Component<Props> = (props) => {
     const tid = selectedTaskId()
     if (!tid) return
     setTaskThinkingMode(tid, on)
+    // Propagate to project default
+    const task = taskById(tid)
+    if (task) {
+      const project = projectById(task.projectId)
+      if (project) updateProjectDefaults(project.id, { defaultThinkingMode: on })
+    }
   }
 
   const fastMode = () => {
@@ -491,6 +511,12 @@ export const MessageInput: Component<Props> = (props) => {
     const tid = selectedTaskId()
     if (!tid) return
     setTaskFastMode(tid, on)
+    // Propagate to project default
+    const task = taskById(tid)
+    if (task) {
+      const project = projectById(task.projectId)
+      if (project) updateProjectDefaults(project.id, { defaultFastMode: on })
+    }
   }
 
   const showPlanResponse = () => {
@@ -2042,7 +2068,15 @@ export const MessageInput: Component<Props> = (props) => {
               model={currentModel()}
               onChange={(m) => {
                 const tid = selectedTaskId()
-                if (tid) setTaskModel(tid, m)
+                if (tid) {
+                  setTaskModel(tid, m)
+                  // Propagate to project default
+                  const task = taskById(tid)
+                  if (task) {
+                    const project = projectById(task.projectId)
+                    if (project) updateProjectDefaults(project.id, { defaultModel: m })
+                  }
+                }
               }}
               disabled={!props.sessionId || props.isRunning}
             />

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -1,9 +1,9 @@
 import { Component, createSignal, createEffect, on, For, Show } from 'solid-js'
 import { ChevronDown, X, Settings, FolderGit2, Loader2, Sparkles, Download, Upload, GitBranch } from 'lucide-solid'
 import { ACCENT_THEMES, getActiveTheme, setActiveTheme, type AccentTheme } from '../lib/theme'
-import { setShowSettings, setSelectedTaskId, setSelectedSessionId, defaultWrapLines, setDefaultWrapLinesAndPersist, defaultHideWhitespace, setDefaultHideWhitespaceAndPersist } from '../store/ui'
+import { setShowSettings, setSelectedTaskId, setSelectedSessionId, defaultWrapLines, setDefaultWrapLinesAndPersist, defaultHideWhitespace, setDefaultHideWhitespaceAndPersist, addToast } from '../store/ui'
 import { notificationsEnabled, setNotificationsEnabledAndPersist } from '../lib/notifications'
-import { projects, updateHooks, updateStoreHooks, updateBaseBranch } from '../store/projects'
+import { projects, updateHooks, updateStoreHooks, updateBaseBranch, updateProjectDefaults } from '../store/projects'
 import { createTask, tasksForProject } from '../store/tasks'
 import { sendMessage, setSessions, setOutputItems } from '../store/sessions'
 import * as ipc from '../lib/ipc'
@@ -11,7 +11,8 @@ import { Popover } from './Popover'
 import { hasOverlayTitlebar } from '../lib/platform'
 import { Toggle } from './Toggle'
 import { CodeTextarea } from './CodeTextarea'
-import { addToast } from '../store/ui'
+import { MODEL_OPTIONS } from '../types'
+import type { TrustLevel, ModelId } from '../types'
 import { AUTODETECT_PROMPT } from '../lib/autodetect-prompt'
 import { produce } from 'solid-js/store'
 
@@ -378,6 +379,99 @@ export const SettingsPage: Component = () => {
                       )}
                     </For>
                   </Popover>
+                </div>
+              </div>
+            </div>
+
+            {/* Session Defaults */}
+            <div class="mb-8">
+              <h2 class="section-title mb-4">Session Defaults</h2>
+              <div class="space-y-4">
+                {/* Approval mode */}
+                <div class="flex items-center justify-between">
+                  <div>
+                    <div class="text-sm text-text-primary">Approval mode</div>
+                    <div class="text-xs text-text-dim mt-0.5">Default trust level for new tasks</div>
+                  </div>
+                  <div class="flex rounded-lg overflow-hidden ring-1 ring-white/8">
+                    {([
+                      { value: 'supervised', label: 'Supervised' },
+                      { value: 'normal', label: 'Normal' },
+                      { value: 'full_auto', label: 'Auto' },
+                    ] as { value: TrustLevel; label: string }[]).map(opt => (
+                      <button
+                        class={`px-3 py-1 text-xs transition-colors ${
+                          selectedProject()?.defaultTrustLevel === opt.value
+                            ? 'bg-accent text-white'
+                            : 'bg-surface-2 text-text-muted hover:text-text-secondary'
+                        }`}
+                        onClick={() => {
+                          const p = selectedProject()
+                          if (p) updateProjectDefaults(p.id, { defaultTrustLevel: opt.value })
+                        }}
+                      >
+                        {opt.label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                {/* Default model */}
+                <div class="flex items-center justify-between">
+                  <div>
+                    <div class="text-sm text-text-primary">Model</div>
+                    <div class="text-xs text-text-dim mt-0.5">Default model for new tasks</div>
+                  </div>
+                  <div class="flex rounded-lg overflow-hidden ring-1 ring-white/8">
+                    {([
+                      { value: null, label: 'Default' },
+                      ...MODEL_OPTIONS.map(o => ({ value: o.id as ModelId, label: o.label })),
+                    ] as { value: ModelId | null; label: string }[]).map(opt => (
+                      <button
+                        class={`px-3 py-1 text-xs transition-colors ${
+                          (selectedProject()?.defaultModel ?? null) === opt.value
+                            ? 'bg-accent text-white'
+                            : 'bg-surface-2 text-text-muted hover:text-text-secondary'
+                        }`}
+                        onClick={() => {
+                          const p = selectedProject()
+                          if (p) updateProjectDefaults(p.id, { defaultModel: opt.value })
+                        }}
+                      >
+                        {opt.label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                {/* Thinking mode */}
+                <div class="flex items-center justify-between">
+                  <div>
+                    <div class="text-sm text-text-primary">Thinking mode</div>
+                    <div class="text-xs text-text-dim mt-0.5">Enable extended thinking by default</div>
+                  </div>
+                  <Toggle
+                    checked={selectedProject()?.defaultThinkingMode ?? false}
+                    onChange={(v) => {
+                      const p = selectedProject()
+                      if (p) updateProjectDefaults(p.id, { defaultThinkingMode: v })
+                    }}
+                  />
+                </div>
+
+                {/* Fast mode */}
+                <div class="flex items-center justify-between">
+                  <div>
+                    <div class="text-sm text-text-primary">Fast mode</div>
+                    <div class="text-xs text-text-dim mt-0.5">Use faster responses by default</div>
+                  </div>
+                  <Toggle
+                    checked={selectedProject()?.defaultFastMode ?? false}
+                    onChange={(v) => {
+                      const p = selectedProject()
+                      if (p) updateProjectDefaults(p.id, { defaultFastMode: v })
+                    }}
+                  />
                 </div>
               </div>
             </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -11,7 +11,7 @@ import {
   onCleanup,
 } from "solid-js";
 import { taskGit, refreshTaskGit } from "../store/git";
-import { projects } from "../store/projects";
+import { projects, projectById } from "../store/projects";
 import {
   tasks,
   activeTasksForProject,
@@ -224,7 +224,8 @@ export const Sidebar: Component = () => {
       () => tasks.length,
       () => {
         for (const t of tasks) {
-          loadSessions(t.id);
+          const project = projectById(t.projectId)
+          loadSessions(t.id, project ? { defaultThinkingMode: project.defaultThinkingMode, defaultFastMode: project.defaultFastMode } : undefined);
           refreshTaskGit(t.id);
         }
       },

--- a/src/components/TaskPanel.tsx
+++ b/src/components/TaskPanel.tsx
@@ -145,7 +145,9 @@ export const TaskPanel: Component = () => {
   createEffect(on(selectedTaskId, async (taskId) => {
     if (taskId) {
       restoreTabState(taskId)
-      await loadSessions(taskId)
+      const task = taskById(taskId)
+      const project = task ? projectById(task.projectId) : null
+      await loadSessions(taskId, project ? { defaultThinkingMode: project.defaultThinkingMode, defaultFastMode: project.defaultFastMode } : undefined)
       const pending = consumePendingSessionNav()
       const taskSessions = sessionsForTask(taskId)
       if (pending && taskSessions.some(s => s.id === pending)) {

--- a/src/lib/appInit.ts
+++ b/src/lib/appInit.ts
@@ -1,6 +1,6 @@
 import { createSignal } from 'solid-js'
 import { listen } from '@tauri-apps/api/event'
-import { loadProjects, initProjectListeners } from '../store/projects'
+import { loadProjects, initProjectListeners, projectById } from '../store/projects'
 import { initSessionListeners, syncSessionStatuses } from '../store/sessions'
 import { initTerminalListeners } from '../store/terminals'
 import { initGitListeners, initWindowFocusRefresh } from '../store/git'
@@ -75,7 +75,8 @@ export async function initListeners() {
   // Cross-window sync: reload when tasks change in another window
   listen<{ taskId: string; projectId: string }>('task-created', (event) => {
     loadTasks(event.payload.projectId)
-    loadSessions(event.payload.taskId)
+    const project = projectById(event.payload.projectId)
+    loadSessions(event.payload.taskId, project ? { defaultThinkingMode: project.defaultThinkingMode, defaultFastMode: project.defaultFastMode } : undefined)
     refreshTaskGit(event.payload.taskId)
   })
   listen('task-removed', () => {

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -18,6 +18,9 @@ export const updateProjectBaseBranch = (id: string, baseBranch: string) =>
 export const updateProjectHooks = (id: string, setupHook: string, destroyHook: string, startCommand: string, autoStart: boolean) =>
   invoke<void>('update_project_hooks', { id, setupHook, destroyHook, startCommand, autoStart })
 
+export const updateProjectDefaults = (id: string, defaultTrustLevel: string, defaultModel: string | null, defaultThinkingMode: boolean, defaultFastMode: boolean) =>
+  invoke<void>('update_project_defaults', { id, defaultTrustLevel, defaultModel, defaultThinkingMode, defaultFastMode })
+
 export const exportProjectConfig = (projectId: string, taskId: string) =>
   invoke<void>('export_project_config', { projectId, taskId })
 

--- a/src/store/projects.test.ts
+++ b/src/store/projects.test.ts
@@ -12,6 +12,10 @@ const makeProject = (overrides: Partial<Project> = {}): Project => ({
   startCommand: '',
   autoStart: false,
   createdAt: 1000,
+  defaultTrustLevel: 'normal',
+  defaultModel: null,
+  defaultThinkingMode: false,
+  defaultFastMode: false,
   ...overrides,
 })
 

--- a/src/store/projects.ts
+++ b/src/store/projects.ts
@@ -1,6 +1,6 @@
 import { createStore, produce } from 'solid-js/store'
 import { listen } from '@tauri-apps/api/event'
-import type { Project } from '../types'
+import type { ModelId, Project, TrustLevel } from '../types'
 import * as ipc from '../lib/ipc'
 import { selectedTaskId, selectedProjectId, setSelectedProjectId, setSelectedTaskId, setSelectedSessionId } from './ui'
 import { taskById } from './tasks'
@@ -54,6 +54,25 @@ export function updateStoreHooks(id: string, setupHook: string, destroyHook: str
   setProjects(produce(list => {
     const p = list.find(p => p.id === id)
     if (p) { p.setupHook = setupHook; p.destroyHook = destroyHook; p.startCommand = startCommand }
+  }))
+}
+
+export async function updateProjectDefaults(id: string, defaults: { defaultTrustLevel?: TrustLevel; defaultModel?: ModelId | null; defaultThinkingMode?: boolean; defaultFastMode?: boolean }) {
+  const p = projects.find(pr => pr.id === id)
+  if (!p) return
+  const trustLevel = defaults.defaultTrustLevel ?? p.defaultTrustLevel
+  const model = defaults.defaultModel !== undefined ? defaults.defaultModel : p.defaultModel
+  const thinking = defaults.defaultThinkingMode ?? p.defaultThinkingMode
+  const fast = defaults.defaultFastMode ?? p.defaultFastMode
+  await ipc.updateProjectDefaults(id, trustLevel, model, thinking, fast)
+  setProjects(produce(list => {
+    const proj = list.find(pr => pr.id === id)
+    if (proj) {
+      proj.defaultTrustLevel = trustLevel
+      proj.defaultModel = model
+      proj.defaultThinkingMode = thinking
+      proj.defaultFastMode = fast
+    }
   }))
 }
 

--- a/src/store/sessions.ts
+++ b/src/store/sessions.ts
@@ -47,7 +47,7 @@ export function setTaskPlanFilePath(taskId: string, path: string | null) {
   }
 }
 
-export async function loadSessions(taskId: string) {
+export async function loadSessions(taskId: string, projectDefaults?: { defaultThinkingMode: boolean; defaultFastMode: boolean }) {
   const list = await ipc.listSessions(taskId)
   // Merge — keep sessions from other tasks, replace sessions for this task
   setSessions(prev => [...prev.filter(s => s.taskId !== taskId), ...list])
@@ -55,13 +55,15 @@ export async function loadSessions(taskId: string) {
   for (const s of list) {
     if (s.totalCost > 0) setSessionCosts(s.id, s.totalCost)
   }
-  // Restore mode switches from localStorage (authoritative source for toggles)
+  // Restore mode switches from localStorage, fall back to project defaults
   const savedPlan = localStorage.getItem(`verun:planMode:${taskId}`)
   const savedThinking = localStorage.getItem(`verun:thinkingMode:${taskId}`)
   const savedFast = localStorage.getItem(`verun:fastMode:${taskId}`)
   if (savedPlan !== null) _setTaskPlanMode(taskId, savedPlan === 'true')
   if (savedThinking !== null) _setTaskThinkingMode(taskId, savedThinking === 'true')
+  else if (projectDefaults) setTaskThinkingMode(taskId, projectDefaults.defaultThinkingMode)
   if (savedFast !== null) _setTaskFastMode(taskId, savedFast === 'true')
+  else if (projectDefaults) setTaskFastMode(taskId, projectDefaults.defaultFastMode)
   const savedPlanFilePath = localStorage.getItem(`verun:planFilePath:${taskId}`)
   if (savedPlanFilePath) _setTaskPlanFilePath(taskId, savedPlanFilePath)
 }

--- a/src/store/tasks.ts
+++ b/src/store/tasks.ts
@@ -100,6 +100,20 @@ export function startTaskCreation(projectId: string, baseBranch: string): string
     setTasks(prev => prev.map(t => t.id === placeholderId ? result.task : t))
     removeCreating(placeholderId)
 
+    // Apply project defaults eagerly before loadSessions runs
+    import('./projects').then(({ projectById }) => {
+      const project = projectById(projectId)
+      if (project) {
+        import('./sessions').then(({ setTaskThinkingMode, setTaskFastMode }) => {
+          setTaskThinkingMode(result.task.id, project.defaultThinkingMode)
+          setTaskFastMode(result.task.id, project.defaultFastMode)
+        })
+        import('./ui').then(({ setTaskModel }) => {
+          if (project.defaultModel) setTaskModel(result.task.id, project.defaultModel)
+        })
+      }
+    })
+
     // Set up session
     import('./sessions').then(({ setSessions, setOutputItems }) => {
       import('./ui').then(({ setSelectedSessionId, selectedTaskId }) => {
@@ -131,6 +145,20 @@ export function retryTaskCreation(placeholderId: string, projectId: string, base
   ipc.createTask(projectId, baseBranch).then(result => {
     setTasks(prev => prev.map(t => t.id === placeholderId ? result.task : t))
     removeCreating(placeholderId)
+
+    // Apply project defaults eagerly before loadSessions runs
+    import('./projects').then(({ projectById }) => {
+      const project = projectById(projectId)
+      if (project) {
+        import('./sessions').then(({ setTaskThinkingMode, setTaskFastMode }) => {
+          setTaskThinkingMode(result.task.id, project.defaultThinkingMode)
+          setTaskFastMode(result.task.id, project.defaultFastMode)
+        })
+        import('./ui').then(({ setTaskModel }) => {
+          if (project.defaultModel) setTaskModel(result.task.id, project.defaultModel)
+        })
+      }
+    })
 
     import('./sessions').then(({ setSessions, setOutputItems }) => {
       import('./ui').then(({ setSelectedSessionId, selectedTaskId, setSelectedTaskId }) => {

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -99,7 +99,7 @@ export function setTaskModel(taskId: string, model: ModelId) {
   if (pid) localStorage.setItem(`verun:model:${pid}`, model)
 }
 
-export function effectiveModel(taskId: string | null): ModelId {
+export function effectiveModel(taskId: string | null, projectDefaultModel?: ModelId | null): ModelId {
   if (taskId) {
     let m = taskModels()[taskId]
     if (m) return m
@@ -110,6 +110,7 @@ export function effectiveModel(taskId: string | null): ModelId {
       return saved
     }
   }
+  if (projectDefaultModel) return projectDefaultModel
   const pid = selectedProjectId()
   if (pid) return (localStorage.getItem(`verun:model:${pid}`) as ModelId | null) || 'sonnet'
   return 'sonnet'

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,6 +10,10 @@ export interface Project {
   startCommand: string
   autoStart: boolean
   createdAt: number
+  defaultTrustLevel: TrustLevel
+  defaultModel: ModelId | null
+  defaultThinkingMode: boolean
+  defaultFastMode: boolean
 }
 
 export interface Task {


### PR DESCRIPTION
## Summary

- New tasks automatically inherit the project's default trust level, model, thinking mode, and fast mode
- Toggling any of these settings on a task propagates the value back as the project default
- All four controls are now editable directly from the project settings page under a new **Session Defaults** section

## Changes

**Backend (Rust)**
- DB migration 13: adds `default_trust_level`, `default_model`, `default_thinking_mode`, `default_fast_mode` columns to the `projects` table with sensible defaults (`normal`, `NULL`, `false`, `false`)
- `create_task` applies the project's trust level default via a `SetTrustLevel` write
- New `update_project_defaults` IPC command persists all four fields atomically

**Frontend**
- `loadSessions` accepts optional project defaults and applies them when no localStorage value exists for the task
- `loadOutputLines` guards mode overwrites with localStorage checks - replayed history can no longer clobber modes the user explicitly toggled
- `startTaskCreation` / `retryTaskCreation` eagerly apply thinking/fast/model defaults before `loadSessions` runs
- `effectiveModel` in `ui.ts` accepts an optional `projectDefaultModel` fallback
- MessageInput propagates trust level, model, thinking, and fast mode changes back to project defaults
- TaskPanel and Sidebar pass project defaults when calling `loadSessions`

## Test plan

- [ ] Create a task - verify it inherits the project's default trust level (check the shield button in MessageInput)
- [ ] Toggle thinking mode on a task, switch to another task and back - mode should persist and not reset
- [ ] Change the model on a task, create a new task - new task should use the same model
- [ ] Open project settings, change approval mode/model/thinking/fast defaults - verify they show correctly
- [ ] Create a new task after changing settings defaults - verify all four are applied