### PR TITLE
fix: plan viewer content missing after restart, simplify plan state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ## Unreleased
 
+- Plan approval prompt no longer appears falsely when navigating back to a task with plan mode toggled on but no plan generated
 - CMD+P now correctly focuses an already-open file tab even when the session view is active
 - Hide copy and fork buttons on the currently streaming assistant message - completed turns still show their buttons
 - Fix messages rendering with the wrong role (user as agent, agent as user) when switching between sessions/tasks with similar output lengths - ChatView block rebuild now tracks session ID, not just item count

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 Parallel Claude Code session orchestrator for macOS.
 
+## Communication Style
+
+- Extremely concise replies. A few sentences max. No preamble, no restating, no over-explaining. User is highly technical.
+
 ## Data Model
 
 projects (1) → tasks (many) → sessions (many) → output_lines (many)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,6 +14,7 @@ Track progress and discuss priorities in [Issues](https://github.com/SoftwareSav
 
 ## Planned
 
+- **Start command terminal + MCP integration** - surface errors from the project start command terminal and expose them via MCP so Claude can read logs, diagnose failures, and interact with the running process
 - **Better plan mode** - richer plan review and editing experience
 - **Customizable keybindings** - rebind any shortcut
 - **Error recovery** - guided messages instead of raw technical errors

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2579,6 +2579,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29a16783dd1a47849b8c8133c9cd3eb2112cfbc6901670af3dba47c8bbfb07d3"
+dependencies = [
+ "cc",
+ "objc2",
+ "objc2-foundation",
+ "time",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2794,6 +2806,20 @@ dependencies = [
  "notify",
  "notify-types",
  "tempfile",
+]
+
+[[package]]
+name = "notify-rust"
+version = "4.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b2c9bc1689653cfbc04400b8719f2562638ff9c545bbd48cc58c657a14526df"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
 ]
 
 [[package]]
@@ -3405,7 +3431,7 @@ checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.13.1",
- "quick-xml",
+ "quick-xml 0.38.4",
  "serde",
  "time",
 ]
@@ -3584,6 +3610,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -5337,6 +5372,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec9491977d0a3a5903bec9ff1fa989233014f37b923008f4994062e1275586b6"
 dependencies = [
  "log",
+ "notify-rust",
  "rand 0.10.1",
  "serde",
  "serde_json",
@@ -5555,6 +5591,18 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
+name = "tauri-winrt-notification"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+dependencies = [
+ "quick-xml 0.37.5",
+ "thiserror 2.0.18",
+ "windows",
+ "windows-version",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,7 +19,7 @@ tauri-plugin-shell = "2"
 tauri-plugin-sql = { version = "2", features = ["sqlite"] }
 tauri-plugin-fs = "2"
 tauri-plugin-dialog = "2"
-tauri-plugin-notifications = { version = "0.4", default-features = false }
+tauri-plugin-notifications = { version = "0.4", default-features = false, features = ["notify-rust"] }
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
 tokio = { version = "1", features = ["full"] }

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -259,7 +259,7 @@ const ForkButton: Component<{ sessionId: string; messageUuid: string }> = (props
     try {
       const session = await ipc.forkSessionInTask(props.sessionId, props.messageUuid)
       setSessions(produce(s => { if (!s.find(x => x.id === session.id)) s.push(session) }))
-      await loadOutputLines(session.id, session.taskId)
+      await loadOutputLines(session.id)
       setSelectedSessionId(session.id)
       addToast('Forked in this task', 'success')
       close()
@@ -276,7 +276,7 @@ const ForkButton: Component<{ sessionId: string; messageUuid: string }> = (props
       const tws = await ipc.forkSessionToNewTask(props.sessionId, props.messageUuid, worktreeState)
       setTasks(produce(t => { if (!t.find(x => x.id === tws.task.id)) t.unshift(tws.task) }))
       setSessions(produce(s => { if (!s.find(x => x.id === tws.session.id)) s.push(tws.session) }))
-      await loadOutputLines(tws.session.id, tws.task.id)
+      await loadOutputLines(tws.session.id)
       setSelectedTaskId(tws.task.id)
       setSelectedSessionId(tws.session.id)
       addToast('Forked to new task', 'success')

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -457,8 +457,7 @@ export const MessageInput: Component<Props> = (props) => {
     return sid ? (autoApprovedCounts[sid] || 0) : 0
   }
 
-  // Plan mode — per-session state, backed by the persisted store
-  const [planResponseSession, setPlanResponseSession] = createSignal<string | null>(null)
+  // Plan mode
   const [planFeedback, setPlanFeedback] = createSignal('')
 
   const planMode = () => {
@@ -495,46 +494,19 @@ export const MessageInput: Component<Props> = (props) => {
   }
 
   const showPlanResponse = () => {
-    const sid = props.sessionId
-    // Don't show the simple panel when the full plan viewer is active
+    const tid = selectedTaskId()
+    if (!tid || props.isRunning) return false
     if (showPlanViewer() && planContent()) return false
-    return sid !== null && planResponseSession() === sid && !currentApproval()
+    if (currentApproval()) return false
+    return !!taskPlanFilePath[tid]
   }
-
-  const setShowPlanResponse = (show: boolean) => {
-    if (show) {
-      setPlanResponseSession(props.sessionId)
-    } else {
-      // Only clear if it matches the current session
-      if (planResponseSession() === props.sessionId) {
-        setPlanResponseSession(null)
-      }
-    }
-  }
-
-  // Detect when plan response should show:
-  // 1. Running → idle transition with plan mode on
-  // 2. Session loaded (e.g. app restart) with plan mode on and already idle
-  createEffect(on(
-    () => [props.isRunning, planMode(), props.sessionId] as const,
-    ([running, plan, sid], prev) => {
-      if (!plan || !sid) return
-      // Was running, now idle → show plan response
-      if (prev && prev[0] && !running) {
-        setPlanResponseSession(sid)
-      }
-      // Session just selected, already idle, plan mode on → show plan response
-      if (!running && (!prev || prev[2] !== sid)) {
-        setPlanResponseSession(sid)
-      }
-    }
-  ))
 
   const handleApprovePlan = () => {
     const sid = props.sessionId
     if (!sid) return
+    const tid = selectedTaskId()
+    if (tid) setTaskPlanFilePath(tid, null)
     setPlanMode(false)
-    setShowPlanResponse(false)
     sendMessage(sid, 'The plan is approved. Please implement it now.', undefined, currentModel(), false)
   }
 
@@ -568,7 +540,6 @@ export const MessageInput: Component<Props> = (props) => {
     if (!text) return
     const sid = props.sessionId
     if (!sid) return
-    setShowPlanResponse(false)
     setPlanFeedback('')
     sendMessage(sid, text, undefined, currentModel(), true)
   }
@@ -599,7 +570,10 @@ export const MessageInput: Component<Props> = (props) => {
 
   // Load plan file content — from live approval or persisted path
   createEffect(on(
-    () => [isExitPlanMode(), props.sessionId, planMode()] as const,
+    () => {
+      const tid = selectedTaskId()
+      return [isExitPlanMode(), props.sessionId, planMode(), tid ? taskPlanFilePath[tid] : null] as const
+    },
     async ([isExit, _sid]) => {
       // From live ExitPlanMode approval
       if (isExit) {
@@ -1373,7 +1347,7 @@ export const MessageInput: Component<Props> = (props) => {
         }
         if (e.key === 'Escape') {
           e.preventDefault()
-          setShowPlanResponse(false)
+          { const tid = selectedTaskId(); if (tid) setTaskPlanFilePath(tid, null) }
           return
         }
         return
@@ -1852,7 +1826,7 @@ export const MessageInput: Component<Props> = (props) => {
             <div class="flex items-center gap-1.5">
               <button
                 class="p-1 rounded-md text-text-dim hover:text-text-secondary hover:bg-surface-2 transition-colors"
-                onClick={() => setShowPlanResponse(false)}
+                onClick={() => { { const tid = selectedTaskId(); if (tid) setTaskPlanFilePath(tid, null) } }}
                 title="Dismiss (Esc)"
               >
                 <X size={14} />
@@ -2079,10 +2053,7 @@ export const MessageInput: Component<Props> = (props) => {
                   : 'text-text-muted hover:text-text-secondary hover:bg-surface-2',
                 'disabled:opacity-30'
               )}
-              onClick={() => {
-                setPlanMode(!planMode())
-                if (!planMode()) setShowPlanResponse(false)
-              }}
+              onClick={() => setPlanMode(!planMode())}
               disabled={!props.sessionId || props.isRunning}
               title="Plan mode — Claude will plan before acting"
             >

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -562,9 +562,9 @@ export const MessageInput: Component<Props> = (props) => {
     // Never show while session is running (implementing)
     if (props.isRunning && !isExitPlanMode()) return false
     if (isExitPlanMode()) return true
-    // No live approval, but plan mode on + idle + have plan file → show viewer
+    // No live approval — show viewer when plan file is pending and content is loaded
     const tid = selectedTaskId()
-    if (tid && planMode() && !props.isRunning && taskPlanFilePath[tid] && planFileContent()) return true
+    if (tid && !props.isRunning && taskPlanFilePath[tid] && planFileContent()) return true
     return false
   }
 
@@ -572,7 +572,7 @@ export const MessageInput: Component<Props> = (props) => {
   createEffect(on(
     () => {
       const tid = selectedTaskId()
-      return [isExitPlanMode(), props.sessionId, planMode(), tid ? taskPlanFilePath[tid] : null] as const
+      return [isExitPlanMode(), props.sessionId, tid ? taskPlanFilePath[tid] : null] as const
     },
     async ([isExit, _sid]) => {
       // From live ExitPlanMode approval
@@ -581,6 +581,8 @@ export const MessageInput: Component<Props> = (props) => {
         if (!approval) return
         const inlinePlan = approval.toolInput.plan as string | undefined
         const filePath = approval.toolInput.planFilePath as string | undefined
+        const tid = selectedTaskId()
+        if (tid && filePath) setTaskPlanFilePath(tid, filePath)
         setPlanFilePathSignal(filePath || null)
         if (inlinePlan) {
           setPlanFileContent(inlinePlan)
@@ -594,9 +596,9 @@ export const MessageInput: Component<Props> = (props) => {
         }
         return
       }
-      // From persisted plan file path (e.g. after restart)
+      // From persisted plan file path
       const tid = selectedTaskId()
-      if (tid && planMode()) {
+      if (tid) {
         const filePath = taskPlanFilePath[tid]
         if (filePath) {
           setPlanFilePathSignal(filePath)
@@ -604,7 +606,7 @@ export const MessageInput: Component<Props> = (props) => {
             const content = await invoke<string>('read_text_file', { path: filePath })
             setPlanFileContent(content)
           } catch {
-            setPlanFileContent(null)
+            setPlanFileContent(`*Plan file not found:* \`${filePath}\``)
           }
           return
         }
@@ -1347,7 +1349,8 @@ export const MessageInput: Component<Props> = (props) => {
         }
         if (e.key === 'Escape') {
           e.preventDefault()
-          { const tid = selectedTaskId(); if (tid) setTaskPlanFilePath(tid, null) }
+          const tid = selectedTaskId()
+          if (tid) setTaskPlanFilePath(tid, null)
           return
         }
         return
@@ -1826,7 +1829,7 @@ export const MessageInput: Component<Props> = (props) => {
             <div class="flex items-center gap-1.5">
               <button
                 class="p-1 rounded-md text-text-dim hover:text-text-secondary hover:bg-surface-2 transition-colors"
-                onClick={() => { { const tid = selectedTaskId(); if (tid) setTaskPlanFilePath(tid, null) } }}
+                onClick={() => { const tid = selectedTaskId(); if (tid) setTaskPlanFilePath(tid, null) }}
                 title="Dismiss (Esc)"
               >
                 <X size={14} />

--- a/src/components/TaskPanel.tsx
+++ b/src/components/TaskPanel.tsx
@@ -171,8 +171,7 @@ export const TaskPanel: Component = () => {
   createEffect(on(selectedSessionId, async (sessionId) => {
     if (sessionId) {
       clearSessionUnread(sessionId)
-      const tid = selectedTaskId()
-      await loadOutputLines(sessionId, tid ?? sessionId)
+      await loadOutputLines(sessionId)
       await loadSteps(sessionId)
     }
   }))

--- a/src/store/sessions.ts
+++ b/src/store/sessions.ts
@@ -36,7 +36,16 @@ export function setTaskFastMode(taskId: string, v: boolean) {
   _setTaskFastMode(taskId, v)
   localStorage.setItem(`verun:fastMode:${taskId}`, String(v))
 }
-export const [taskPlanFilePath, setTaskPlanFilePath] = createStore<Record<string, string | null>>({})
+const [_taskPlanFilePath, _setTaskPlanFilePath] = createStore<Record<string, string | null>>({})
+export const taskPlanFilePath = _taskPlanFilePath
+export function setTaskPlanFilePath(taskId: string, path: string | null) {
+  _setTaskPlanFilePath(taskId, path)
+  if (path) {
+    localStorage.setItem(`verun:planFilePath:${taskId}`, path)
+  } else {
+    localStorage.removeItem(`verun:planFilePath:${taskId}`)
+  }
+}
 
 export async function loadSessions(taskId: string) {
   const list = await ipc.listSessions(taskId)
@@ -53,6 +62,8 @@ export async function loadSessions(taskId: string) {
   if (savedPlan !== null) _setTaskPlanMode(taskId, savedPlan === 'true')
   if (savedThinking !== null) _setTaskThinkingMode(taskId, savedThinking === 'true')
   if (savedFast !== null) _setTaskFastMode(taskId, savedFast === 'true')
+  const savedPlanFilePath = localStorage.getItem(`verun:planFilePath:${taskId}`)
+  if (savedPlanFilePath) _setTaskPlanFilePath(taskId, savedPlanFilePath)
 }
 
 export async function createSession(taskId: string): Promise<Session> {
@@ -150,33 +161,14 @@ export async function closeSession(sessionId: string) {
   await ipc.closeSession(sessionId)
 }
 
-export async function loadOutputLines(sessionId: string, taskId: string) {
+export async function loadOutputLines(sessionId: string, _taskId: string) {
   const lines = await ipc.getOutputLines(sessionId)
   const items: OutputItem[] = []
-  let planFilePath: string | null = null
-  let hadMessageAfterPlan = false
   for (const l of lines) {
-    try {
-      const v = JSON.parse(l.line)
-      if (v.type === 'control_request') {
-        const req = v.request as Record<string, unknown> | undefined
-        if (req?.tool_name === 'ExitPlanMode') {
-          const input = req.input as Record<string, unknown> | undefined
-          if (input?.planFilePath) {
-            planFilePath = input.planFilePath as string
-            hadMessageAfterPlan = false
-          }
-        }
-      }
-      if (v.type === 'verun_user_message' && planFilePath) {
-        hadMessageAfterPlan = true
-      }
-    } catch { /* ignore */ }
     const parsed = parseNdjsonLine(l.line, l.emittedAt)
     if (parsed) items.push(...parsed)
   }
   setOutputItems(sessionId, items)
-  setTaskPlanFilePath(taskId, hadMessageAfterPlan ? null : planFilePath)
   // Accumulate costs + tokens from replayed output
   let replayCost = 0
   let replayInputTokens = 0
@@ -488,7 +480,7 @@ export async function initSessionListeners() {
 }
 
 export function clearPlanState(taskId: string) {
-  setTaskPlanFilePath(taskId, null)
+  setTaskPlanFilePath(taskId, null) // also clears localStorage via wrapper
   _setTaskPlanMode(taskId, false)
   localStorage.removeItem(`verun:planMode:${taskId}`)
 }
@@ -499,6 +491,7 @@ export function cleanupTaskModeStorage(taskId: string) {
     `verun:thinkingMode:${taskId}`,
     `verun:fastMode:${taskId}`,
     `verun:task-model:${taskId}`,
+    `verun:planFilePath:${taskId}`,
   ]
   for (const k of keys) localStorage.removeItem(k)
 }

--- a/src/store/sessions.ts
+++ b/src/store/sessions.ts
@@ -46,7 +46,7 @@ export async function loadSessions(taskId: string) {
   for (const s of list) {
     if (s.totalCost > 0) setSessionCosts(s.id, s.totalCost)
   }
-  // Restore mode switches from localStorage (output_lines parsing may override these later)
+  // Restore mode switches from localStorage (authoritative source for toggles)
   const savedPlan = localStorage.getItem(`verun:planMode:${taskId}`)
   const savedThinking = localStorage.getItem(`verun:thinkingMode:${taskId}`)
   const savedFast = localStorage.getItem(`verun:fastMode:${taskId}`)
@@ -153,42 +153,30 @@ export async function closeSession(sessionId: string) {
 export async function loadOutputLines(sessionId: string, taskId: string) {
   const lines = await ipc.getOutputLines(sessionId)
   const items: OutputItem[] = []
-  let lastPlanMode = false
-  let lastThinkingMode = true
-  let lastFastMode = false
   let planFilePath: string | null = null
+  let hadMessageAfterPlan = false
   for (const l of lines) {
     try {
       const v = JSON.parse(l.line)
-      // Check plan_mode on user messages for persistence
-      if (v.type === 'verun_user_message' && typeof v.plan_mode === 'boolean') {
-        lastPlanMode = v.plan_mode
-      }
-      if (v.type === 'verun_user_message' && typeof v.thinking_mode === 'boolean') {
-        lastThinkingMode = v.thinking_mode
-      }
-      if (v.type === 'verun_user_message' && typeof v.fast_mode === 'boolean') {
-        lastFastMode = v.fast_mode
-      }
-      // Extract plan file path from ExitPlanMode control_request
       if (v.type === 'control_request') {
         const req = v.request as Record<string, unknown> | undefined
         if (req?.tool_name === 'ExitPlanMode') {
           const input = req.input as Record<string, unknown> | undefined
           if (input?.planFilePath) {
             planFilePath = input.planFilePath as string
+            hadMessageAfterPlan = false
           }
         }
+      }
+      if (v.type === 'verun_user_message' && planFilePath) {
+        hadMessageAfterPlan = true
       }
     } catch { /* ignore */ }
     const parsed = parseNdjsonLine(l.line, l.emittedAt)
     if (parsed) items.push(...parsed)
   }
   setOutputItems(sessionId, items)
-  setTaskPlanMode(taskId, lastPlanMode)
-  setTaskThinkingMode(taskId, lastThinkingMode)
-  setTaskFastMode(taskId, lastFastMode)
-  setTaskPlanFilePath(taskId, planFilePath)
+  setTaskPlanFilePath(taskId, hadMessageAfterPlan ? null : planFilePath)
   // Accumulate costs + tokens from replayed output
   let replayCost = 0
   let replayInputTokens = 0
@@ -376,7 +364,6 @@ export async function initSessionListeners() {
         store[sessionId] = [...items]
       }
     }))
-    // Accumulate cost + tokens from turnEnd events
     for (const item of items) {
       if (item.kind === 'turnEnd') {
         if (item.cost) {
@@ -498,4 +485,25 @@ export async function initSessionListeners() {
   } catch {
     // getPendingApprovals may not be available yet during startup
   }
+}
+
+export function clearPlanState(taskId: string) {
+  setTaskPlanFilePath(taskId, null)
+  _setTaskPlanMode(taskId, false)
+  localStorage.removeItem(`verun:planMode:${taskId}`)
+}
+
+export function cleanupTaskModeStorage(taskId: string) {
+  const keys = [
+    `verun:planMode:${taskId}`,
+    `verun:thinkingMode:${taskId}`,
+    `verun:fastMode:${taskId}`,
+    `verun:task-model:${taskId}`,
+  ]
+  for (const k of keys) localStorage.removeItem(k)
+}
+
+export function cleanupSessionStorage(sessionId: string) {
+  localStorage.removeItem(`verun:draft-msg:${sessionId}`)
+  localStorage.removeItem(`verun:draft-att:${sessionId}`)
 }

--- a/src/store/sessions.ts
+++ b/src/store/sessions.ts
@@ -161,7 +161,7 @@ export async function closeSession(sessionId: string) {
   await ipc.closeSession(sessionId)
 }
 
-export async function loadOutputLines(sessionId: string, _taskId: string) {
+export async function loadOutputLines(sessionId: string) {
   const lines = await ipc.getOutputLines(sessionId)
   const items: OutputItem[] = []
   for (const l of lines) {

--- a/src/store/tasks.ts
+++ b/src/store/tasks.ts
@@ -6,7 +6,7 @@ import { closeTerminalsForTask } from './terminals'
 import { clearTaskGitState } from './git'
 import { clearProblemsForTask } from './problems'
 import { fireTaskCleanup } from './files'
-import { sessionsForTask } from './sessions'
+import { sessionsForTask, cleanupTaskModeStorage, cleanupSessionStorage } from './sessions'
 
 // Dynamic-imported on first use: static import would pull lib/lsp.ts's
 // module-level `listen(...)` side effects into test evaluation for any file
@@ -199,17 +199,9 @@ export const taskById = (id: string) =>
 
 /** Remove all localStorage keys associated with a task */
 export function cleanupTaskStorage(id: string) {
-  const keys = [
-    `verun:planMode:${id}`,
-    `verun:thinkingMode:${id}`,
-    `verun:fastMode:${id}`,
-    `verun:task-model:${id}`,
-  ]
-  for (const k of keys) localStorage.removeItem(k)
-  // Drafts are keyed by sessionId — clean up every session that belonged to this task
+  cleanupTaskModeStorage(id)
   for (const s of sessionsForTask(id)) {
-    localStorage.removeItem(`verun:draft-msg:${s.id}`)
-    localStorage.removeItem(`verun:draft-att:${s.id}`)
+    cleanupSessionStorage(s.id)
   }
   if (localStorage.getItem('verun:selectedTaskId') === id) {
     localStorage.removeItem('verun:selectedTaskId')

--- a/src/store/tasks.ts
+++ b/src/store/tasks.ts
@@ -6,7 +6,7 @@ import { closeTerminalsForTask } from './terminals'
 import { clearTaskGitState } from './git'
 import { clearProblemsForTask } from './problems'
 import { fireTaskCleanup } from './files'
-import { sessionsForTask, cleanupTaskModeStorage, cleanupSessionStorage } from './sessions'
+import { sessionsForTask, cleanupTaskModeStorage, cleanupSessionStorage, clearPlanState } from './sessions'
 
 // Dynamic-imported on first use: static import would pull lib/lsp.ts's
 // module-level `listen(...)` side effects into test evaluation for any file
@@ -163,6 +163,7 @@ export async function deleteTask(id: string, deleteBranch = true, skipDestroyHoo
   closeTerminalsForTask(id)
   clearTaskGitState(id)
   clearProblemsForTask(id)
+  clearPlanState(id)
   fireTaskCleanup(id)
   cleanupTaskStorage(id)
   await ipc.deleteTask(id, deleteBranch, skipDestroyHook)
@@ -176,6 +177,7 @@ export async function archiveTask(id: string, skipDestroyHook = false) {
     closeTerminalsForTask(id)
     clearTaskGitState(id)
     clearProblemsForTask(id)
+    clearPlanState(id)
     cleanupTaskStorage(id)
     await ipc.archiveTask(id, skipDestroyHook)
     setTasks(t => t.id === id, 'archived', true)


### PR DESCRIPTION
## Summary

- Plan viewer showed empty "Plan ready" banner after app restart because `taskPlanFilePath` wasn't in the effect's dependency array
- Removed `sessionPlanResponsePending` boolean and `_lastSentPlanMode` - `taskPlanFilePath[tid]` non-null is now the sole pending-plan indicator
- Centralized localStorage key cleanup into `cleanupTaskModeStorage` and `cleanupSessionStorage` in sessions.ts (ref #33)

## Test plan

- [ ] Send a plan-mode message, get a plan with ExitPlanMode, quit app, reopen - plan viewer should show with content
- [ ] Approve a plan, quit app, reopen - no plan viewer should show
- [ ] Dismiss plan via Escape or X - plan viewer disappears
- [ ] Navigate between tasks - no false plan prompts on empty tasks
- [ ] Delete/archive a task - no orphaned localStorage keys