### PR TITLE
fix: use configured base branch in git action messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ## Unreleased
 
 - CMD+P now correctly focuses an already-open file tab even when the session view is active
+- Git action messages (rebase, PR creation) now use the project's configured base branch instead of letting Claude default to main
 - Hide copy and fork buttons on the currently streaming assistant message - completed turns still show their buttons
 - Fix messages rendering with the wrong role (user as agent, agent as user) when switching between sessions/tasks with similar output lengths - ChatView block rebuild now tracks session ID, not just item count
 - Plan review overlay now stays within the session pane instead of overflowing behind the sidebar and right panel

--- a/src/components/GitActions.tsx
+++ b/src/components/GitActions.tsx
@@ -6,6 +6,8 @@ import { claudeSkills } from '../store/commands'
 import { sendMessage } from '../store/sessions'
 import { addToast } from '../store/ui'
 import { taskGit, refreshTaskGit, invalidateRemote } from '../store/git'
+import { taskById } from '../store/tasks'
+import { projectById } from '../store/projects'
 import { registerDismissable } from '../lib/dismissable'
 
 interface GitAction {
@@ -44,6 +46,10 @@ export const GitActions: Component<Props> = (props) => {
 
   // Read all git state from the centralized store
   const git = () => taskGit(props.taskId)
+  const baseBranch = () => {
+    const task = taskById(props.taskId)
+    return task ? (projectById(task.projectId)?.baseBranch ?? 'main') : 'main'
+  }
   const pr = () => git().pr
   const checks = () => git().checks
   const behind = () => git().branchStatus.behind
@@ -165,10 +171,10 @@ export const GitActions: Component<Props> = (props) => {
     fileCount() > 0
       ? { icon: ArrowUpFromLine, label: 'Commit & Push', message: 'commit all changes and push to remote' }
       : { icon: ArrowUpFromLine, label: 'Push', action: doPush }
-  const createPrAction = (): GitAction => ({ icon: GitPullRequest, label: 'Create PR', message: 'create a pull request with an appropriate title and description' })
-  const draftPrAction = (): GitAction => ({ icon: GitPullRequest, label: 'Draft PR', message: 'create a draft pull request with an appropriate title and description' })
-  const pullAction = (): GitAction => ({ icon: Download, label: 'Update Branch', message: 'this branch is behind the base branch. rebase onto the base branch to bring it up to date. Use git rebase, not merge.' })
-  const resolveConflictsAction = (): GitAction => ({ icon: Swords, label: 'Resolve conflicts', message: 'rebase this branch onto the base branch and resolve any conflicts. Use git rebase, not merge. If conflicts arise during rebase, resolve them and continue with git rebase --continue' })
+  const createPrAction = (): GitAction => ({ icon: GitPullRequest, label: 'Create PR', message: `create a pull request targeting ${baseBranch()} with an appropriate title and description` })
+  const draftPrAction = (): GitAction => ({ icon: GitPullRequest, label: 'Draft PR', message: `create a draft pull request targeting ${baseBranch()} with an appropriate title and description` })
+  const pullAction = (): GitAction => ({ icon: Download, label: 'Update Branch', message: `this branch is behind ${baseBranch()}. rebase onto ${baseBranch()} to bring it up to date. Use git rebase, not merge.` })
+  const resolveConflictsAction = (): GitAction => ({ icon: Swords, label: 'Resolve conflicts', message: `rebase this branch onto ${baseBranch()} and resolve any conflicts. Use git rebase, not merge. If conflicts arise during rebase, resolve them and continue with git rebase --continue` })
   const mergePrAction = (): GitAction => ({ icon: GitMerge, label: 'Merge PR', action: async () => openMergePanel() })
   const readyForReviewAction = (): GitAction => ({ icon: Eye, label: 'Ready for Review', action: doMarkReady })
 


### PR DESCRIPTION
## Summary
- Git action messages (rebase, PR creation, conflict resolution) now include the project's configured base branch name instead of generic "the base branch" text
- Previously Claude would default to `main` when the message didn't specify a branch, ignoring the user's selection (e.g. `development`)
- Resolves by looking up `task -> project -> baseBranch` reactively in `GitActions.tsx` and interpolating it into all 4 affected message templates

Closes #32

## Test plan
- [ ] Set a project's base branch to something other than `main` (e.g. `development`)
- [ ] Click "Update Branch" when behind - verify the message sent to Claude contains the actual branch name
- [ ] Click "Create PR" / "Draft PR" - verify the message includes `targeting <branch>`
- [ ] Click "Resolve conflicts" - verify the message includes the actual branch name
- [ ] Verify rebase and PR creation target the correct branch