### PR TITLE
Scroll-to-bottom button in chat session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - CMD+P now correctly focuses an already-open file tab even when the session view is active
 - Git action messages (rebase, PR creation) now use the project's configured base branch instead of letting Claude default to main
 - Git actions show "Archive" as the primary action when a PR is merged, replacing the empty button area
+- Scroll-to-bottom button appears in the bottom-right corner of the session when scrolled up
 - Hide copy and fork buttons on the currently streaming assistant message - completed turns still show their buttons
 - Fix messages rendering with the wrong role (user as agent, agent as user) when switching between sessions/tasks with similar output lengths - ChatView block rebuild now tracks session ID, not just item count
 - Plan review overlay now stays within the session pane instead of overflowing behind the sidebar and right panel

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -601,6 +601,9 @@ export const ChatView: Component<Props> = (props) => {
   // Image viewer state
   const [viewerImage, setViewerImage] = createSignal<{ mimeType: string; data: Uint8Array } | null>(null)
 
+  // Scroll to bottom button visibility
+  const [isAtBottom, setIsAtBottom] = createSignal(true)
+
   // Search state
   const [showSearch, setShowSearch] = createSignal(false)
   const [searchQuery, setSearchQuery] = createSignal('')
@@ -672,6 +675,7 @@ export const ChatView: Component<Props> = (props) => {
       const saved = savedScrollPositions.get(sid)
       if (saved) {
         autoScroll = saved.autoScroll
+        setIsAtBottom(saved.autoScroll)
         pendingScrollRestore = saved
       }
     }
@@ -768,10 +772,19 @@ export const ChatView: Component<Props> = (props) => {
     })
   }
 
+  const scrollToBottom = () => {
+    if (!containerRef) return
+    containerRef.scrollTo({ top: containerRef.scrollHeight, behavior: 'smooth' })
+    autoScroll = true
+    setIsAtBottom(true)
+  }
+
   const handleScroll = () => {
     if (!containerRef || scrollRafPending) return
     const { scrollTop, scrollHeight, clientHeight } = containerRef
-    autoScroll = scrollHeight - scrollTop - clientHeight < 30
+    const distFromBottom = scrollHeight - scrollTop - clientHeight
+    autoScroll = distFromBottom < 30
+    setIsAtBottom(distFromBottom < 200)
   }
 
   const handleLinkClick = (e: MouseEvent) => handleMarkdownLinkClick(e, props.taskId)
@@ -953,6 +966,15 @@ export const ChatView: Component<Props> = (props) => {
         </Show>
       </div>
       </div>
+      <Show when={!isAtBottom()}>
+        <button
+          class="absolute bottom-4 right-4 z-10 w-7 h-7 flex items-center justify-center rounded-full bg-surface-2 ring-1 ring-white/10 shadow-lg text-text-dim hover:text-text-secondary hover:ring-white/20 transition-colors"
+          onClick={scrollToBottom}
+          title="Scroll to bottom"
+        >
+          <ChevronDown size={15} />
+        </button>
+      </Show>
       <Show when={viewerImage()}>
         {(img) => (
           <ImageViewer


### PR DESCRIPTION
## Summary
- Adds a floating ChevronDown button in the bottom-right corner of the chat session view
- Button appears after scrolling 200px+ from the bottom, smooth-scrolls back down on click
- Re-enables auto-scroll on click; state is preserved across tab switches via `savedScrollPositions`

## Test plan
- [ ] Scroll up in a session with enough output - button should appear after ~200px
- [ ] Click the button - should smooth-scroll to bottom and hide
- [ ] Verify auto-scroll resumes after clicking (new output keeps view at bottom)
- [ ] Switch tabs and back - button visibility should persist correctly
- [ ] Scroll to near-bottom (<200px) - button should not appear