### PR TITLE
fix: archive from GitActions button now closes the task panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Normal mode now blocks gh repo/release delete and detects dangerous commands inside shell re-invocations
 - `git worktree prune/remove` and `rm` targeting `.verun` directories are now hard-blocked regardless of trust level - Verun manages worktree lifecycle, not Claude
 - Policy engine now strips `git -C <path>` flags to detect cross-repo worktree attacks
+- Fix archiving a task from the GitActions replacement button not closing the task panel - deselection now happens inside `archiveTask` so all callers get it
 - Demo mode: set `VITE_DEMO_MODE=true` to populate the app with dummy projects, tasks, sessions, and a realistic chat conversation for screenshots
 - Fix message role corruption when switching between tasks - clear stale output data before reloading and use reactive Switch/Match for block type rendering so reconcile merges can't produce wrong role display
 - Fix "delete branch with merge" failing because `gh pr merge --delete-branch` tries to checkout main, which conflicts with the main worktree - now deletes the remote branch separately after merge

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -579,7 +579,6 @@ export const Sidebar: Component = () => {
         onConfirm={() => {
           const target = archiveTaskTarget();
           if (target) {
-            if (selectedTaskId() === target) setSelectedTaskId(null)
             archiveTask(target)
           }
           setArchiveTaskTarget(null);

--- a/src/store/tasks.ts
+++ b/src/store/tasks.ts
@@ -181,6 +181,9 @@ export async function archiveTask(id: string, skipDestroyHook = false) {
     cleanupTaskStorage(id)
     await ipc.archiveTask(id, skipDestroyHook)
     setTasks(t => t.id === id, 'archived', true)
+    import('./ui').then(({ selectedTaskId, setSelectedTaskId }) => {
+      if (selectedTaskId() === id) setSelectedTaskId(null)
+    })
   } finally {
     removeArchiving(id)
   }


### PR DESCRIPTION
Closes #53

## Summary
- Moved task deselection into `archiveTask()` so all callers (GitActions button, Sidebar context menu) automatically close the panel after archiving
- Removed the now-redundant `setSelectedTaskId(null)` from Sidebar's archive confirm dialog

## Test plan
- [ ] Archive a task via the GitActions replacement button (appears when PR is merged + working tree clean) - task panel should close
- [ ] Archive a task via the Sidebar right-click menu - task panel should close
- [ ] Verify archived tasks appear in the Archived page