### PR TITLE
fix: single-line text selection not visible in editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix single-line text selection invisible in code editor - active line highlight now suppresses when text is selected so drawSelection's selection layer is visible
 - Demo mode: set `VITE_DEMO_MODE=true` to populate the app with dummy projects, tasks, sessions, and a realistic chat conversation for screenshots
 - Fix message role corruption when switching between tasks - clear stale output data before reloading and use reactive Switch/Match for block type rendering so reconcile merges can't produce wrong role display
 - Fix "delete branch with merge" failing because `gh pr merge --delete-branch` tries to checkout main, which conflicts with the main worktree - now deletes the remote branch separately after merge

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -1,5 +1,5 @@
 import { Component, createEffect, on, createSignal, Show, onCleanup, onMount } from 'solid-js'
-import { EditorView, keymap, lineNumbers, highlightActiveLine, highlightActiveLineGutter, drawSelection, dropCursor, rectangularSelection, crosshairCursor, highlightSpecialChars, showTooltip, hoverTooltip, tooltips, Decoration, type DecorationSet, type Tooltip } from '@codemirror/view'
+import { EditorView, keymap, lineNumbers, ViewPlugin, GutterMarker, gutterLineClass, drawSelection, dropCursor, rectangularSelection, crosshairCursor, highlightSpecialChars, showTooltip, hoverTooltip, tooltips, Decoration, type DecorationSet, type Tooltip } from '@codemirror/view'
 import { linter, forEachDiagnostic, type Diagnostic } from '@codemirror/lint'
 import { EditorState, StateField, StateEffect, RangeSet, Facet, type Extension } from '@codemirror/state'
 import { setChatPrefillRequest } from '../store/ui'
@@ -32,6 +32,60 @@ import * as ipc from '../lib/ipc'
 import { setTabDirty, getCachedContent, setCachedContent, getCachedOriginal, setCachedOriginal, pendingGoToLine, consumeGoToLine, onTabClose, onTaskCleanup } from '../store/files'
 import { reloadNonce, checkBeforeSave } from '../store/fileSync'
 import { getLspClient, isLspSupported, registerEditorView, unregisterEditorView } from '../lib/lsp'
+
+// Selection-aware active line: suppresses highlight when text is selected
+// so single-line selections remain visible through drawSelection()'s z-index layer.
+const activeLineDeco = Decoration.line({ class: 'cm-activeLine' })
+
+export function selectionAwareActiveLine() {
+  return ViewPlugin.fromClass(class {
+    decorations: DecorationSet
+    constructor(view: EditorView) {
+      this.decorations = this.getDeco(view)
+    }
+    update(update: { docChanged: boolean, selectionSet: boolean, view: EditorView }) {
+      if (update.docChanged || update.selectionSet)
+        this.decorations = this.getDeco(update.view)
+    }
+    getDeco(view: EditorView): DecorationSet {
+      if (view.state.selection.ranges.some(r => !r.empty))
+        return Decoration.none
+      let lastLineStart = -1
+      const deco: ReturnType<typeof activeLineDeco.range>[] = []
+      for (const r of view.state.selection.ranges) {
+        const line = view.lineBlockAt(r.head)
+        if (line.from > lastLineStart) {
+          deco.push(activeLineDeco.range(line.from))
+          lastLineStart = line.from
+        }
+      }
+      return Decoration.set(deco)
+    }
+  }, {
+    decorations: v => v.decorations
+  })
+}
+
+const activeLineGutterDeco = new class extends GutterMarker {
+  elementClass = 'cm-activeLineGutter'
+}
+
+function selectionAwareActiveLineGutter() {
+  return gutterLineClass.compute(['selection'], state => {
+    if (state.selection.ranges.some(r => !r.empty))
+      return RangeSet.empty
+    const marks: ReturnType<typeof activeLineGutterDeco.range>[] = []
+    let last = -1
+    for (const range of state.selection.ranges) {
+      const linePos = state.doc.lineAt(range.head).from
+      if (linePos > last) {
+        last = linePos
+        marks.push(activeLineGutterDeco.range(linePos))
+      }
+    }
+    return RangeSet.of(marks)
+  })
+}
 
 interface Props {
   taskId: string
@@ -640,8 +694,8 @@ function buildExtensions(taskId: string, path: string, onDocChange: (content: st
 
     // Core editor features
     lineNumbers(),
-    highlightActiveLine(),
-    highlightActiveLineGutter(),
+    selectionAwareActiveLine(),
+    selectionAwareActiveLineGutter(),
     highlightSpecialChars(),
     drawSelection(),
     dropCursor(),

--- a/src/components/DiffEditor.tsx
+++ b/src/components/DiffEditor.tsx
@@ -1,7 +1,7 @@
 import { Component, createSignal, createEffect, on, onCleanup, Show } from 'solid-js'
 import { MergeView, unifiedMergeView } from '@codemirror/merge'
 import { EditorState, type Extension } from '@codemirror/state'
-import { EditorView, lineNumbers, highlightActiveLine, drawSelection, highlightSpecialChars, keymap } from '@codemirror/view'
+import { EditorView, lineNumbers, drawSelection, highlightSpecialChars, keymap } from '@codemirror/view'
 import { defaultKeymap, history, historyKeymap } from '@codemirror/commands'
 import { syntaxHighlighting, foldGutter, bracketMatching, indentOnInput } from '@codemirror/language'
 import { search, searchKeymap } from '@codemirror/search'
@@ -10,7 +10,7 @@ import { Loader2, AlertCircle, Columns2, Rows2, FileText } from 'lucide-solid'
 import * as ipc from '../lib/ipc'
 import type { DiffContents } from '../types'
 import { openFilePinned, type DiffSource } from '../store/files'
-import { langFromExt, verunTheme, verunHighlightStyle } from './CodeEditor'
+import { langFromExt, verunTheme, verunHighlightStyle, selectionAwareActiveLine } from './CodeEditor'
 import { BreadcrumbBar } from './BreadcrumbBar'
 import { createSearchPanel, searchPanelTheme } from './SearchPanel'
 
@@ -70,7 +70,7 @@ function buildSideExtensions(path: string, readOnly: boolean): Extension[] {
     syntaxHighlighting(verunHighlightStyle),
     syntaxHighlighting(oneDarkHighlightStyle, { fallback: true }),
     lineNumbers(),
-    highlightActiveLine(),
+    selectionAwareActiveLine(),
     highlightSpecialChars(),
     drawSelection(),
     indentOnInput(),


### PR DESCRIPTION
## Summary

- Replace `highlightActiveLine()` / `highlightActiveLineGutter()` with selection-aware variants that suppress the active line decoration when any selection range is non-empty
- `drawSelection()` renders the selection layer at `z-index: -2` (behind content), so `.cm-activeLine`'s opaque `#2c313a` background completely hides single-line selections
- Applied to both `CodeEditor` and `DiffEditor` (shares the same theme)

Closes #44

## Test plan

- [ ] Open a file in the code editor
- [ ] Select text within a single line - selection highlight should now be visible
- [ ] Select text across multiple lines - still works as before
- [ ] Verify active line highlight still shows when cursor is a blinking caret (no selection)
- [ ] Verify the diff editor also shows single-line selections correctly