### PR TITLE
fix: rewrite bash policy engine with AST-based shell parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 - Fix single-line text selection invisible in code editor - active line highlight now suppresses when text is selected so drawSelection's selection layer is visible
+- Rewrote bash policy engine to use AST-based shell parsing (yash-syntax) instead of substring matching - handles compound commands, subshells, combined flags, and wrapper programs (env, sudo, bash -c)
+- Normal mode now blocks destructive git ops: branch delete, worktree remove/prune, stash drop/clear, tag delete, remote remove, reflog expire, gc --prune, filter-branch, update-ref -d, push --force-with-lease
+- Normal mode now blocks gh repo/release delete and detects dangerous commands inside shell re-invocations
 - Demo mode: set `VITE_DEMO_MODE=true` to populate the app with dummy projects, tasks, sessions, and a realistic chat conversation for screenshots
 - Fix message role corruption when switching between tasks - clear stale output data before reloading and use reactive Switch/Match for block type rendering so reconcile merges can't produce wrong role display
 - Fix "delete branch with merge" failing because `gh pr merge --delete-branch` tries to checkout main, which conflicts with the main worktree - now deletes the remote branch separately after merge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Rewrote bash policy engine to use AST-based shell parsing (yash-syntax) instead of substring matching - handles compound commands, subshells, combined flags, and wrapper programs (env, sudo, bash -c)
 - Normal mode now blocks destructive git ops: branch delete, worktree remove/prune, stash drop/clear, tag delete, remote remove, reflog expire, gc --prune, filter-branch, update-ref -d, push --force-with-lease
 - Normal mode now blocks gh repo/release delete and detects dangerous commands inside shell re-invocations
+- `git worktree prune/remove` and `rm` targeting `.verun` directories are now hard-blocked regardless of trust level - Verun manages worktree lifecycle, not Claude
+- Policy engine now strips `git -C <path>` flags to detect cross-repo worktree attacks
 - Demo mode: set `VITE_DEMO_MODE=true` to populate the app with dummy projects, tasks, sessions, and a realistic chat conversation for screenshots
 - Fix message role corruption when switching between tasks - clear stale output data before reloading and use reactive Switch/Match for block type rendering so reconcile merges can't produce wrong role display
 - Fix "delete branch with merge" failing because `gh pr merge --delete-branch` tries to checkout main, which conflicts with the main worktree - now deletes the remote branch separately after merge

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -59,6 +59,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "annotate-snippets"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92570a3f9c98e7e84df84b71d0965ac99b1871fcd75a3773a3bd1bad13f64cf7"
+dependencies = [
+ "anstyle",
+ "memchr",
+ "unicode-width",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -827,12 +844,35 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -850,11 +890,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
 ]
@@ -936,6 +987,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn 2.0.117",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1146,6 +1198,27 @@ version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "enumset"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25b07a8dfbbbfc0064c0a6bdf9edcf966de6b1c33ce344bdeca3b41615452634"
+dependencies = [
+ "enumset_derive",
+]
+
+[[package]]
+name = "enumset_derive"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43e744e4ea338060faee68ed933e46e722fb7f3617e722a5772d7e856d8b3ce"
+dependencies = [
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -2309,6 +2382,15 @@ checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
 dependencies = [
  "is-docker",
  "once_cell",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -4422,7 +4504,7 @@ version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4999,6 +5081,27 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "subtle"
@@ -6117,10 +6220,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unix_path"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af8e291873ae77c4c8d9c9b34d0bee68a35b048fb39c263a5155e0e353783eaf"
+dependencies = [
+ "unix_str",
+]
+
+[[package]]
+name = "unix_str"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ace0b4755d0a2959962769239d56267f8a024fef2d9b32666b3dcd0946b0906"
 
 [[package]]
 name = "untrusted"
@@ -6223,6 +6347,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "uuid",
+ "yash-syntax",
 ]
 
 [[package]]
@@ -7246,6 +7371,55 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix",
+]
+
+[[package]]
+name = "yash-env"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aa63823659550cd62a7edcd5e7d2a97bf880b934ff88f051aafd3cd35ca664d"
+dependencies = [
+ "annotate-snippets",
+ "bitflags 2.11.0",
+ "derive_more 2.1.1",
+ "dyn-clone",
+ "either",
+ "enumset",
+ "errno",
+ "itertools",
+ "libc",
+ "slab",
+ "strum",
+ "tempfile",
+ "thiserror 2.0.18",
+ "unix_path",
+ "unix_str",
+ "yash-executor",
+ "yash-quote",
+]
+
+[[package]]
+name = "yash-executor"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17f1f7dd21f06cb0def0ba4a49a223ce4d214d14dde4840a02d534f1a3b8b199"
+
+[[package]]
+name = "yash-quote"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6830c89e3639d05ff9736978058a968dad6bd728c3a084413c2510467cb81bf3"
+
+[[package]]
+name = "yash-syntax"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1f4d0e728366899841ea6071d66ebeb15a4d0eca3e2ac72f97c40beeb3b2808"
+dependencies = [
+ "futures-util",
+ "itertools",
+ "thiserror 2.0.18",
+ "yash-env",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,6 +33,7 @@ portable-pty = "0.8"
 ignore = "0.4"
 notify = "7"
 notify-debouncer-mini = "0.5"
+yash-syntax = "0.19"
 
 [dev-dependencies]
 rstest = "0.18"

--- a/src-tauri/src/policy.rs
+++ b/src-tauri/src/policy.rs
@@ -291,8 +291,24 @@ fn check_hard_block_args(args: &[String]) -> Option<&'static str> {
             None
         }
         "rm" => check_rm_verun(rest),
+        "sudo" => check_hard_block_args(skip_sudo_flags(rest)),
         _ => None,
     }
+}
+
+fn skip_sudo_flags(args: &[String]) -> &[String] {
+    let mut i = 0;
+    while i < args.len() && args[i].starts_with('-') {
+        if matches!(
+            args[i].as_str(),
+            "-u" | "-g" | "-C" | "-D" | "-r" | "-t" | "-p"
+        ) {
+            i += 2;
+        } else {
+            i += 1;
+        }
+    }
+    &args[i..]
 }
 
 fn check_git_hard_block(args: &[String]) -> Option<&'static str> {
@@ -1175,74 +1191,254 @@ mod tests {
         assert!(!has_long_flag(&["-f", "origin"], &["--force"]));
     }
 
-    // -- Hard blocks (bypass trust level) --
+    // =====================================================================
+    // Hard blocks — worktree ops & .verun deletion (all trust levels)
+    // =====================================================================
+
+    // -- Core: worktree prune/remove blocked at every trust level --
 
     #[test]
-    fn hard_block_worktree_prune_in_full_auto() {
-        let result = evaluate("Bash", &json!({"command": "git worktree prune"}), WORKTREE, REPO, TrustLevel::FullAuto);
-        assert_eq!(result.decision, PolicyDecision::RequireApproval);
-        assert!(result.reason.contains("hard-blocked"));
+    fn hard_block_worktree_prune_full_auto() {
+        let r = evaluate("Bash", &json!({"command": "git worktree prune"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(r.decision, PolicyDecision::RequireApproval);
+        assert!(r.reason.contains("hard-blocked"));
+        assert!(r.reason.contains("verun-managed"));
     }
 
     #[test]
-    fn hard_block_worktree_remove_in_full_auto() {
-        let result = evaluate("Bash", &json!({"command": "git worktree remove /tmp/wt"}), WORKTREE, REPO, TrustLevel::FullAuto);
-        assert_eq!(result.decision, PolicyDecision::RequireApproval);
-        assert!(result.reason.contains("hard-blocked"));
+    fn hard_block_worktree_prune_normal() {
+        let r = evaluate("Bash", &json!({"command": "git worktree prune"}), WORKTREE, REPO, TrustLevel::Normal);
+        assert_eq!(r.decision, PolicyDecision::RequireApproval);
+        assert!(r.reason.contains("hard-blocked"));
     }
+
+    #[test]
+    fn hard_block_worktree_prune_supervised() {
+        let r = evaluate("Bash", &json!({"command": "git worktree prune"}), WORKTREE, REPO, TrustLevel::Supervised);
+        assert_eq!(r.decision, PolicyDecision::RequireApproval);
+    }
+
+    #[test]
+    fn hard_block_worktree_remove_full_auto() {
+        let r = evaluate("Bash", &json!({"command": "git worktree remove /tmp/wt"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(r.decision, PolicyDecision::RequireApproval);
+        assert!(r.reason.contains("hard-blocked"));
+    }
+
+    #[test]
+    fn hard_block_worktree_remove_normal() {
+        let r = evaluate("Bash", &json!({"command": "git worktree remove /tmp/wt"}), WORKTREE, REPO, TrustLevel::Normal);
+        assert_eq!(r.decision, PolicyDecision::RequireApproval);
+        assert!(r.reason.contains("hard-blocked"));
+    }
+
+    #[test]
+    fn hard_block_worktree_remove_force_flag() {
+        let r = evaluate("Bash", &json!({"command": "git worktree remove --force /tmp/wt"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(r.decision, PolicyDecision::RequireApproval);
+    }
+
+    // -- git -C cross-repo attacks --
 
     #[test]
     fn hard_block_git_c_worktree_prune() {
-        let result = evaluate("Bash", &json!({"command": "git -C /other/project worktree prune"}), WORKTREE, REPO, TrustLevel::FullAuto);
-        assert_eq!(result.decision, PolicyDecision::RequireApproval);
+        let r = evaluate("Bash", &json!({"command": "git -C /other/project worktree prune"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(r.decision, PolicyDecision::RequireApproval);
     }
 
     #[test]
-    fn hard_block_rm_verun_dir() {
-        let result = evaluate("Bash", &json!({"command": "rm -rf .verun/worktrees/some-task"}), WORKTREE, REPO, TrustLevel::FullAuto);
-        assert_eq!(result.decision, PolicyDecision::RequireApproval);
-        assert!(result.reason.contains(".verun"));
+    fn hard_block_git_c_worktree_remove() {
+        let r = evaluate("Bash", &json!({"command": "git -C /other/repo worktree remove /tmp/wt"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(r.decision, PolicyDecision::RequireApproval);
+    }
+
+    #[test]
+    fn hard_block_git_multiple_c_flags() {
+        let r = evaluate("Bash", &json!({"command": "git -C /a -C /b worktree prune"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(r.decision, PolicyDecision::RequireApproval);
+    }
+
+    #[test]
+    fn deny_git_c_push_force() {
+        assert!(matches_deny_pattern("git -C /other/repo push --force").is_some());
+    }
+
+    // -- .verun directory deletion --
+
+    #[test]
+    fn hard_block_rm_verun_relative() {
+        let r = evaluate("Bash", &json!({"command": "rm -rf .verun/worktrees/some-task"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(r.decision, PolicyDecision::RequireApproval);
+        assert!(r.reason.contains(".verun"));
     }
 
     #[test]
     fn hard_block_rm_verun_absolute() {
-        let result = evaluate("Bash", &json!({"command": "rm -rf /projects/repo/.verun/worktrees"}), WORKTREE, REPO, TrustLevel::FullAuto);
-        assert_eq!(result.decision, PolicyDecision::RequireApproval);
+        let r = evaluate("Bash", &json!({"command": "rm -rf /projects/repo/.verun/worktrees"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(r.decision, PolicyDecision::RequireApproval);
     }
+
+    #[test]
+    fn hard_block_rm_verun_without_rf() {
+        let r = evaluate("Bash", &json!({"command": "rm .verun/worktrees/task/.git"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(r.decision, PolicyDecision::RequireApproval);
+    }
+
+    #[test]
+    fn hard_block_rm_verun_parent() {
+        let r = evaluate("Bash", &json!({"command": "rm -rf .verun"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(r.decision, PolicyDecision::RequireApproval);
+    }
+
+    #[test]
+    fn hard_block_rm_verun_sibling_worktree() {
+        let r = evaluate("Bash", &json!({"command": "rm -rf ../other-task/.verun"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(r.decision, PolicyDecision::RequireApproval);
+    }
+
+    // -- Compound command evasions --
 
     #[test]
     fn hard_block_worktree_in_subshell() {
-        let result = evaluate("Bash", &json!({"command": "(git worktree prune)"}), WORKTREE, REPO, TrustLevel::FullAuto);
-        assert_eq!(result.decision, PolicyDecision::RequireApproval);
+        let r = evaluate("Bash", &json!({"command": "(git worktree prune)"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(r.decision, PolicyDecision::RequireApproval);
     }
 
     #[test]
-    fn hard_block_worktree_chained() {
-        let result = evaluate("Bash", &json!({"command": "echo ok && git worktree remove /tmp/wt"}), WORKTREE, REPO, TrustLevel::FullAuto);
-        assert_eq!(result.decision, PolicyDecision::RequireApproval);
+    fn hard_block_worktree_in_brace_group() {
+        let r = evaluate("Bash", &json!({"command": "{ git worktree remove /tmp/wt; }"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(r.decision, PolicyDecision::RequireApproval);
     }
+
+    #[test]
+    fn hard_block_worktree_chained_and() {
+        let r = evaluate("Bash", &json!({"command": "echo ok && git worktree remove /tmp/wt"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(r.decision, PolicyDecision::RequireApproval);
+    }
+
+    #[test]
+    fn hard_block_worktree_chained_or() {
+        let r = evaluate("Bash", &json!({"command": "false || git worktree prune"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(r.decision, PolicyDecision::RequireApproval);
+    }
+
+    #[test]
+    fn hard_block_worktree_chained_semicolon() {
+        let r = evaluate("Bash", &json!({"command": "echo ok; git worktree prune"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(r.decision, PolicyDecision::RequireApproval);
+    }
+
+    #[test]
+    fn hard_block_rm_verun_chained() {
+        let r = evaluate("Bash", &json!({"command": "echo ok && rm -rf .verun/worktrees/task"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(r.decision, PolicyDecision::RequireApproval);
+    }
+
+    // -- Wrapper evasions --
+
+    #[test]
+    fn hard_block_env_worktree_prune() {
+        let r = evaluate("Bash", &json!({"command": "env git worktree prune"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(r.decision, PolicyDecision::RequireApproval);
+    }
+
+    #[test]
+    fn hard_block_env_with_vars_worktree() {
+        let r = evaluate("Bash", &json!({"command": "env GIT_TERMINAL_PROMPT=0 git worktree prune"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(r.decision, PolicyDecision::RequireApproval);
+    }
+
+    #[test]
+    fn hard_block_command_worktree() {
+        let r = evaluate("Bash", &json!({"command": "command git worktree remove /tmp/wt"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(r.decision, PolicyDecision::RequireApproval);
+    }
+
+    #[test]
+    fn hard_block_sudo_worktree_prune() {
+        let r = evaluate("Bash", &json!({"command": "sudo git worktree prune"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(r.decision, PolicyDecision::RequireApproval);
+    }
+
+    #[test]
+    fn hard_block_sudo_u_worktree_prune() {
+        let r = evaluate("Bash", &json!({"command": "sudo -u root git worktree prune"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(r.decision, PolicyDecision::RequireApproval);
+    }
+
+    #[test]
+    fn hard_block_sudo_rm_verun() {
+        let r = evaluate("Bash", &json!({"command": "sudo rm -rf .verun/worktrees"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(r.decision, PolicyDecision::RequireApproval);
+    }
+
+    // -- Shell re-invocation --
 
     #[test]
     fn hard_block_bash_c_worktree() {
-        let result = evaluate("Bash", &json!({"command": "bash -c 'git worktree prune'"}), WORKTREE, REPO, TrustLevel::FullAuto);
-        assert_eq!(result.decision, PolicyDecision::RequireApproval);
+        let r = evaluate("Bash", &json!({"command": "bash -c 'git worktree prune'"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(r.decision, PolicyDecision::RequireApproval);
     }
 
     #[test]
-    fn full_auto_allows_safe_commands() {
-        let result = evaluate("Bash", &json!({"command": "git push --force"}), WORKTREE, REPO, TrustLevel::FullAuto);
-        assert_eq!(result.decision, PolicyDecision::AutoAllow);
+    fn hard_block_sh_c_worktree() {
+        let r = evaluate("Bash", &json!({"command": "sh -c 'git worktree remove /tmp/wt'"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(r.decision, PolicyDecision::RequireApproval);
     }
 
     #[test]
-    fn full_auto_allows_git_worktree_list() {
-        let result = evaluate("Bash", &json!({"command": "git worktree list"}), WORKTREE, REPO, TrustLevel::FullAuto);
-        assert_eq!(result.decision, PolicyDecision::AutoAllow);
+    fn hard_block_bash_c_rm_verun() {
+        let r = evaluate("Bash", &json!({"command": "bash -c 'rm -rf .verun'"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(r.decision, PolicyDecision::RequireApproval);
+    }
+
+    // -- Safe ops that must NOT be hard-blocked --
+
+    #[test]
+    fn full_auto_allows_non_worktree_destructive() {
+        let r = evaluate("Bash", &json!({"command": "git push --force"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(r.decision, PolicyDecision::AutoAllow);
     }
 
     #[test]
-    fn hard_block_env_wrapped_worktree() {
-        let result = evaluate("Bash", &json!({"command": "env git worktree prune"}), WORKTREE, REPO, TrustLevel::FullAuto);
-        assert_eq!(result.decision, PolicyDecision::RequireApproval);
+    fn full_auto_allows_worktree_list() {
+        let r = evaluate("Bash", &json!({"command": "git worktree list"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(r.decision, PolicyDecision::AutoAllow);
+    }
+
+    #[test]
+    fn full_auto_allows_worktree_add() {
+        let r = evaluate("Bash", &json!({"command": "git worktree add /tmp/new-wt feature-branch"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(r.decision, PolicyDecision::AutoAllow);
+    }
+
+    #[test]
+    fn full_auto_allows_rm_without_verun() {
+        let r = evaluate("Bash", &json!({"command": "rm -rf ./node_modules"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(r.decision, PolicyDecision::AutoAllow);
+    }
+
+    #[test]
+    fn full_auto_allows_git_status() {
+        let r = evaluate("Bash", &json!({"command": "git status"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(r.decision, PolicyDecision::AutoAllow);
+    }
+
+    #[test]
+    fn full_auto_allows_git_c_safe_op() {
+        let r = evaluate("Bash", &json!({"command": "git -C /other/repo status"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(r.decision, PolicyDecision::AutoAllow);
+    }
+
+    #[test]
+    fn hard_block_does_not_affect_non_bash_tools() {
+        let r = evaluate("Read", &json!({"file_path": "/tmp/project/src/main.rs"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(r.decision, PolicyDecision::AutoAllow);
+    }
+
+    #[test]
+    fn hard_block_does_not_affect_write_tool() {
+        let r = evaluate("Write", &json!({"file_path": "/tmp/.verun/foo"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(r.decision, PolicyDecision::AutoAllow);
     }
 }

--- a/src-tauri/src/policy.rs
+++ b/src-tauri/src/policy.rs
@@ -91,6 +91,21 @@ pub fn evaluate(
         };
     }
 
+    // Hard blocks — always require approval regardless of trust level.
+    // Verun manages worktree lifecycle; Claude must never touch it.
+    if tool_name == "Bash" {
+        let command = tool_input
+            .get("command")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        if let Some(pattern) = matches_hard_block(command) {
+            return PolicyResult {
+                decision: PolicyDecision::RequireApproval,
+                reason: format!("hard-blocked: {pattern}"),
+            };
+        }
+    }
+
     // Trust level overrides
     match trust_level {
         TrustLevel::FullAuto => {
@@ -250,11 +265,89 @@ fn matches_deny_pattern(command: &str) -> Option<&'static str> {
     walk_list(&list)
 }
 
+/// Hard blocks that require approval regardless of trust level.
+/// These protect Verun's own infrastructure (worktrees, .verun dirs).
+fn matches_hard_block(command: &str) -> Option<&'static str> {
+    let list: yash_syntax::syntax::List = match command.parse() {
+        Ok(l) => l,
+        Err(_) => return Some("unparseable command"),
+    };
+    walk_list_with(&list, check_hard_block_args)
+}
+
+fn check_hard_block_args(args: &[String]) -> Option<&'static str> {
+    let (program, rest) = skip_wrappers(args);
+    match program {
+        "git" => check_git_hard_block(rest),
+        "bash" | "sh" | "zsh" => {
+            for (i, arg) in rest.iter().enumerate() {
+                if arg == "-c" {
+                    if let Some(cmd_str) = rest.get(i + 1) {
+                        let unquoted = strip_outer_quotes(cmd_str);
+                        return matches_hard_block(&unquoted);
+                    }
+                }
+            }
+            None
+        }
+        "rm" => check_rm_verun(rest),
+        _ => None,
+    }
+}
+
+fn check_git_hard_block(args: &[String]) -> Option<&'static str> {
+    let filtered = strip_git_c_flag(args);
+    let strs: Vec<&str> = filtered.iter().map(|s| s.as_str()).collect();
+    let subcmd = strs.iter().find(|a| !a.starts_with('-'))?;
+    if *subcmd == "worktree" {
+        let pos: Vec<&&str> = strs.iter().filter(|a| !a.starts_with('-')).collect();
+        match pos.get(1).map(|s| **s) {
+            Some("remove") => return Some("git worktree remove (verun-managed)"),
+            Some("prune") => return Some("git worktree prune (verun-managed)"),
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Strip `git -C <path>` pairs so the subcommand is visible.
+fn strip_git_c_flag(args: &[String]) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < args.len() {
+        if args[i] == "-C" {
+            i += 2; // skip -C and its path argument
+        } else {
+            out.push(args[i].clone());
+            i += 1;
+        }
+    }
+    out
+}
+
+fn check_rm_verun(args: &[String]) -> Option<&'static str> {
+    for arg in args {
+        if !arg.starts_with('-') && arg.contains(".verun") {
+            return Some("rm targeting .verun directory");
+        }
+    }
+    None
+}
+
+type CheckFn = fn(&[String]) -> Option<&'static str>;
+
 fn walk_list(list: &yash_syntax::syntax::List) -> Option<&'static str> {
+    walk_list_with(list, check_args)
+}
+
+fn walk_list_with(
+    list: &yash_syntax::syntax::List,
+    check: CheckFn,
+) -> Option<&'static str> {
     for item in &list.0 {
         let aol = &*item.and_or;
         for pipeline in std::iter::once(&aol.first).chain(aol.rest.iter().map(|(_, p)| p)) {
-            if let Some(r) = walk_pipeline(pipeline) {
+            if let Some(r) = walk_pipeline_with(pipeline, check) {
                 return Some(r);
             }
         }
@@ -262,8 +355,12 @@ fn walk_list(list: &yash_syntax::syntax::List) -> Option<&'static str> {
     None
 }
 
-fn walk_pipeline(pipeline: &yash_syntax::syntax::Pipeline) -> Option<&'static str> {
+fn walk_pipeline_with(
+    pipeline: &yash_syntax::syntax::Pipeline,
+    check: CheckFn,
+) -> Option<&'static str> {
     use yash_syntax::syntax::Command;
+    // curl/wget piped to shell (only for the full deny check, not hard blocks)
     if pipeline.commands.len() >= 2 {
         let first = pipeline.commands.first().unwrap();
         let last = pipeline.commands.last().unwrap();
@@ -278,14 +375,17 @@ fn walk_pipeline(pipeline: &yash_syntax::syntax::Pipeline) -> Option<&'static st
         }
     }
     for cmd in &pipeline.commands {
-        if let Some(r) = walk_command(cmd) {
+        if let Some(r) = walk_command_with(cmd, check) {
             return Some(r);
         }
     }
     None
 }
 
-fn walk_command(cmd: &yash_syntax::syntax::Command) -> Option<&'static str> {
+fn walk_command_with(
+    cmd: &yash_syntax::syntax::Command,
+    check: CheckFn,
+) -> Option<&'static str> {
     use yash_syntax::syntax::{Command, CompoundCommand};
     match cmd {
         Command::Simple(sc) => {
@@ -293,11 +393,11 @@ fn walk_command(cmd: &yash_syntax::syntax::Command) -> Option<&'static str> {
             if args.is_empty() {
                 return None;
             }
-            check_args(&args)
+            check(&args)
         }
         Command::Compound(fcc) => match &fcc.command {
-            CompoundCommand::Subshell { body, .. } => walk_list(body),
-            CompoundCommand::Grouping(body) => walk_list(body),
+            CompoundCommand::Subshell { body, .. } => walk_list_with(body, check),
+            CompoundCommand::Grouping(body) => walk_list_with(body, check),
             _ => None,
         },
         Command::Function(_) => None,
@@ -346,7 +446,8 @@ fn skip_wrappers(args: &[String]) -> (&str, &[String]) {
 }
 
 fn check_git(args: &[String]) -> Option<&'static str> {
-    let strs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    let filtered = strip_git_c_flag(args);
+    let strs: Vec<&str> = filtered.iter().map(|s| s.as_str()).collect();
     let subcmd = strs.iter().find(|a| !a.starts_with('-'))?;
     match *subcmd {
         "push" => {
@@ -1072,5 +1173,76 @@ mod tests {
     fn has_long_flag_exact() {
         assert!(has_long_flag(&["--force", "origin"], &["--force"]));
         assert!(!has_long_flag(&["-f", "origin"], &["--force"]));
+    }
+
+    // -- Hard blocks (bypass trust level) --
+
+    #[test]
+    fn hard_block_worktree_prune_in_full_auto() {
+        let result = evaluate("Bash", &json!({"command": "git worktree prune"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(result.decision, PolicyDecision::RequireApproval);
+        assert!(result.reason.contains("hard-blocked"));
+    }
+
+    #[test]
+    fn hard_block_worktree_remove_in_full_auto() {
+        let result = evaluate("Bash", &json!({"command": "git worktree remove /tmp/wt"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(result.decision, PolicyDecision::RequireApproval);
+        assert!(result.reason.contains("hard-blocked"));
+    }
+
+    #[test]
+    fn hard_block_git_c_worktree_prune() {
+        let result = evaluate("Bash", &json!({"command": "git -C /other/project worktree prune"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(result.decision, PolicyDecision::RequireApproval);
+    }
+
+    #[test]
+    fn hard_block_rm_verun_dir() {
+        let result = evaluate("Bash", &json!({"command": "rm -rf .verun/worktrees/some-task"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(result.decision, PolicyDecision::RequireApproval);
+        assert!(result.reason.contains(".verun"));
+    }
+
+    #[test]
+    fn hard_block_rm_verun_absolute() {
+        let result = evaluate("Bash", &json!({"command": "rm -rf /projects/repo/.verun/worktrees"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(result.decision, PolicyDecision::RequireApproval);
+    }
+
+    #[test]
+    fn hard_block_worktree_in_subshell() {
+        let result = evaluate("Bash", &json!({"command": "(git worktree prune)"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(result.decision, PolicyDecision::RequireApproval);
+    }
+
+    #[test]
+    fn hard_block_worktree_chained() {
+        let result = evaluate("Bash", &json!({"command": "echo ok && git worktree remove /tmp/wt"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(result.decision, PolicyDecision::RequireApproval);
+    }
+
+    #[test]
+    fn hard_block_bash_c_worktree() {
+        let result = evaluate("Bash", &json!({"command": "bash -c 'git worktree prune'"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(result.decision, PolicyDecision::RequireApproval);
+    }
+
+    #[test]
+    fn full_auto_allows_safe_commands() {
+        let result = evaluate("Bash", &json!({"command": "git push --force"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(result.decision, PolicyDecision::AutoAllow);
+    }
+
+    #[test]
+    fn full_auto_allows_git_worktree_list() {
+        let result = evaluate("Bash", &json!({"command": "git worktree list"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(result.decision, PolicyDecision::AutoAllow);
+    }
+
+    #[test]
+    fn hard_block_env_wrapped_worktree() {
+        let result = evaluate("Bash", &json!({"command": "env git worktree prune"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        assert_eq!(result.decision, PolicyDecision::RequireApproval);
     }
 }

--- a/src-tauri/src/policy.rs
+++ b/src-tauri/src/policy.rs
@@ -238,66 +238,266 @@ fn is_path_within(path: &str, boundary: &str) -> bool {
     canonical_path.starts_with(&canonical_boundary)
 }
 
-/// Static deny patterns for bash commands.
-/// Returns the pattern name if the command matches, None if safe.
+/// AST-based deny-pattern analysis for bash commands.
+/// Parses the command into a shell AST, walks every sub-command (including
+/// compounds, subshells, and chained commands), and checks each against
+/// deny rules. Returns the pattern name if any sub-command matches.
 fn matches_deny_pattern(command: &str) -> Option<&'static str> {
-    // Normalize for matching: lowercase, collapse whitespace
-    let cmd = command.to_lowercase();
-    let cmd = cmd.trim();
+    let list: yash_syntax::syntax::List = match command.parse() {
+        Ok(l) => l,
+        Err(_) => return Some("unparseable command"),
+    };
+    walk_list(&list)
+}
 
-    static DENY_PATTERNS: &[(&str, &str)] = &[
-        // Git destructive operations
-        ("git push --force", "git push --force"),
-        ("git push -f", "git push --force"),
-        ("git push --delete", "git push --delete"),
-        ("git reset --hard", "git reset --hard"),
-        ("git clean -f", "git clean"),
-        ("git checkout -- .", "git checkout (discard all)"),
-        // Privilege escalation
-        ("sudo ", "sudo"),
-        // Remote access
-        ("ssh ", "ssh"),
-        ("scp ", "scp"),
-        ("rsync ", "rsync"),
-        // Process killing
-        ("kill ", "kill"),
-        ("pkill ", "pkill"),
-        ("killall ", "killall"),
-        // Dangerous file ops
-        ("chmod ", "chmod"),
-        ("chown ", "chown"),
-        // Infrastructure
-        ("docker ", "docker"),
-        ("kubectl ", "kubectl"),
-    ];
-
-    for &(pattern, name) in DENY_PATTERNS {
-        if cmd.starts_with(pattern) || cmd.contains(&format!(" && {pattern}"))
-            || cmd.contains(&format!("; {pattern}"))
-            || cmd.contains(&format!("| {pattern}"))
-        {
-            return Some(name);
+fn walk_list(list: &yash_syntax::syntax::List) -> Option<&'static str> {
+    for item in &list.0 {
+        let aol = &*item.and_or;
+        for pipeline in std::iter::once(&aol.first).chain(aol.rest.iter().map(|(_, p)| p)) {
+            if let Some(r) = walk_pipeline(pipeline) {
+                return Some(r);
+            }
         }
     }
-
-    // Curl/wget piped to shell
-    if (cmd.contains("curl ") || cmd.contains("wget "))
-        && (cmd.contains("| sh") || cmd.contains("| bash") || cmd.contains("| zsh"))
-    {
-        return Some("curl/wget piped to shell");
-    }
-
-    // rm -rf with root or home directory
-    if cmd.contains("rm ")
-        && cmd.contains("-rf")
-        && (cmd.contains(" /") && !cmd.contains(" ./"))
-    {
-        // Check if it's targeting a path outside the working directory
-        // rm -rf ./node_modules is fine, rm -rf /tmp is not
-        return Some("rm -rf with absolute path");
-    }
-
     None
+}
+
+fn walk_pipeline(pipeline: &yash_syntax::syntax::Pipeline) -> Option<&'static str> {
+    use yash_syntax::syntax::Command;
+    if pipeline.commands.len() >= 2 {
+        let first = pipeline.commands.first().unwrap();
+        let last = pipeline.commands.last().unwrap();
+        if let (Command::Simple(f), Command::Simple(l)) = (first.as_ref(), last.as_ref()) {
+            let fp = f.words.first().map(|(w, _)| w.to_string());
+            let lp = l.words.first().map(|(w, _)| w.to_string());
+            if matches!(fp.as_deref(), Some("curl" | "wget"))
+                && matches!(lp.as_deref(), Some("sh" | "bash" | "zsh"))
+            {
+                return Some("curl/wget piped to shell");
+            }
+        }
+    }
+    for cmd in &pipeline.commands {
+        if let Some(r) = walk_command(cmd) {
+            return Some(r);
+        }
+    }
+    None
+}
+
+fn walk_command(cmd: &yash_syntax::syntax::Command) -> Option<&'static str> {
+    use yash_syntax::syntax::{Command, CompoundCommand};
+    match cmd {
+        Command::Simple(sc) => {
+            let args: Vec<String> = sc.words.iter().map(|(w, _)| w.to_string()).collect();
+            if args.is_empty() {
+                return None;
+            }
+            check_args(&args)
+        }
+        Command::Compound(fcc) => match &fcc.command {
+            CompoundCommand::Subshell { body, .. } => walk_list(body),
+            CompoundCommand::Grouping(body) => walk_list(body),
+            _ => None,
+        },
+        Command::Function(_) => None,
+    }
+}
+
+// ---- Argument-level deny checks ----
+
+fn check_args(args: &[String]) -> Option<&'static str> {
+    let (program, rest) = skip_wrappers(args);
+    match program {
+        "git" => check_git(rest),
+        "gh" | "hub" => check_gh(rest),
+        "bash" | "sh" | "zsh" => check_shell_exec(rest),
+        "ssh" | "scp" => Some("ssh/scp"),
+        "rsync" => Some("rsync"),
+        "sudo" => Some("sudo"),
+        "kill" | "pkill" | "killall" => Some("kill"),
+        "chmod" | "chown" => Some("chmod/chown"),
+        "docker" | "kubectl" => Some("docker/kubectl"),
+        "rm" => check_rm(rest),
+        _ => None,
+    }
+}
+
+fn skip_wrappers(args: &[String]) -> (&str, &[String]) {
+    let mut i = 0;
+    loop {
+        if i >= args.len() {
+            return ("", &[]);
+        }
+        match args[i].as_str() {
+            "env" | "command" => {
+                i += 1;
+                while i < args.len() && (args[i].starts_with('-') || args[i].contains('=')) {
+                    i += 1;
+                }
+            }
+            _ => break,
+        }
+    }
+    if i >= args.len() {
+        return ("", &[]);
+    }
+    (&args[i], &args[i + 1..])
+}
+
+fn check_git(args: &[String]) -> Option<&'static str> {
+    let strs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    let subcmd = strs.iter().find(|a| !a.starts_with('-'))?;
+    match *subcmd {
+        "push" => {
+            if has_long_flag(&strs, &["--force", "--force-with-lease", "--force-if-includes", "--delete"])
+                || has_short_flag(&strs, 'f')
+            {
+                Some("git push --force/--delete")
+            } else {
+                None
+            }
+        }
+        "reset" => {
+            if has_long_flag(&strs, &["--hard"]) {
+                Some("git reset --hard")
+            } else {
+                None
+            }
+        }
+        "clean" => {
+            if has_short_flag(&strs, 'f') || has_long_flag(&strs, &["--force"]) {
+                Some("git clean")
+            } else {
+                None
+            }
+        }
+        "checkout" => {
+            if strs.contains(&"--") && strs.contains(&".") {
+                Some("git checkout (discard all)")
+            } else {
+                None
+            }
+        }
+        "branch" => {
+            if has_short_flag(&strs, 'D') {
+                Some("git branch force-delete")
+            } else if has_short_flag(&strs, 'd') || has_long_flag(&strs, &["--delete"]) {
+                Some("git branch delete")
+            } else {
+                None
+            }
+        }
+        "worktree" => {
+            let pos: Vec<&&str> = strs.iter().filter(|a| !a.starts_with('-')).collect();
+            match pos.get(1).map(|s| **s) {
+                Some("remove") => Some("git worktree remove"),
+                Some("prune") => Some("git worktree prune"),
+                _ => None,
+            }
+        }
+        "stash" => {
+            let pos: Vec<&&str> = strs.iter().filter(|a| !a.starts_with('-')).collect();
+            match pos.get(1).map(|s| **s) {
+                Some("drop") | Some("clear") => Some("git stash drop/clear"),
+                _ => None,
+            }
+        }
+        "tag" => {
+            if has_short_flag(&strs, 'd') || has_long_flag(&strs, &["--delete"]) {
+                Some("git tag delete")
+            } else {
+                None
+            }
+        }
+        "remote" => {
+            let pos: Vec<&&str> = strs.iter().filter(|a| !a.starts_with('-')).collect();
+            match pos.get(1).map(|s| **s) {
+                Some("remove") | Some("rm") => Some("git remote remove"),
+                _ => None,
+            }
+        }
+        "reflog" => {
+            let pos: Vec<&&str> = strs.iter().filter(|a| !a.starts_with('-')).collect();
+            match pos.get(1).map(|s| **s) {
+                Some("expire") | Some("delete") => Some("git reflog expire/delete"),
+                _ => None,
+            }
+        }
+        "gc" => {
+            if has_long_flag(&strs, &["--prune"]) || strs.iter().any(|s| s.starts_with("--prune="))
+            {
+                Some("git gc --prune")
+            } else {
+                None
+            }
+        }
+        "filter-branch" => Some("git filter-branch"),
+        "update-ref" => {
+            if has_short_flag(&strs, 'd') || has_long_flag(&strs, &["--delete"]) {
+                Some("git update-ref delete")
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+fn check_gh(args: &[String]) -> Option<&'static str> {
+    let strs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    match (strs.first(), strs.get(1)) {
+        (Some(&"repo"), Some(&"delete")) => Some("gh repo delete"),
+        (Some(&"release"), Some(&"delete")) => Some("gh release delete"),
+        _ => None,
+    }
+}
+
+fn check_rm(args: &[String]) -> Option<&'static str> {
+    let strs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    let has_recursive =
+        has_short_flag(&strs, 'r') || has_short_flag(&strs, 'R') || has_long_flag(&strs, &["--recursive"]);
+    let has_force = has_short_flag(&strs, 'f') || has_long_flag(&strs, &["--force"]);
+    if has_recursive && has_force {
+        let has_abs_path = strs.iter().any(|a| !a.starts_with('-') && a.starts_with('/'));
+        if has_abs_path {
+            return Some("rm -rf with absolute path");
+        }
+    }
+    None
+}
+
+fn check_shell_exec(args: &[String]) -> Option<&'static str> {
+    for (i, arg) in args.iter().enumerate() {
+        if arg == "-c" {
+            if let Some(cmd_str) = args.get(i + 1) {
+                let unquoted = strip_outer_quotes(cmd_str);
+                return matches_deny_pattern(&unquoted);
+            }
+        }
+    }
+    None
+}
+
+// ---- Flag helpers ----
+
+fn has_long_flag(args: &[&str], flags: &[&str]) -> bool {
+    args.iter().any(|a| flags.contains(a))
+}
+
+fn has_short_flag(args: &[&str], ch: char) -> bool {
+    args.iter().any(|a| a.starts_with('-') && !a.starts_with("--") && a[1..].contains(ch))
+}
+
+fn strip_outer_quotes(s: &str) -> String {
+    if s.len() >= 2
+        && ((s.starts_with('"') && s.ends_with('"'))
+            || (s.starts_with('\'') && s.ends_with('\'')))
+    {
+        s[1..s.len() - 1].to_string()
+    } else {
+        s.to_string()
+    }
 }
 
 /// Summarize tool input for audit logging (truncated to 500 chars).
@@ -577,10 +777,10 @@ mod tests {
         assert!(summary.len() < 600);
     }
 
-    // -- Deny pattern helpers --
+    // -- Deny pattern: safe commands --
 
     #[test]
-    fn deny_pattern_not_matched_for_safe_commands() {
+    fn deny_safe_commands() {
         assert!(matches_deny_pattern("cargo build").is_none());
         assert!(matches_deny_pattern("npm test").is_none());
         assert!(matches_deny_pattern("ls -la").is_none());
@@ -591,16 +791,286 @@ mod tests {
         assert!(matches_deny_pattern("git commit -m 'fix'").is_none());
         assert!(matches_deny_pattern("git push").is_none());
         assert!(matches_deny_pattern("git push origin main").is_none());
+        assert!(matches_deny_pattern("git branch -a").is_none());
+        assert!(matches_deny_pattern("git stash").is_none());
+        assert!(matches_deny_pattern("git stash pop").is_none());
+        assert!(matches_deny_pattern("git stash list").is_none());
+        assert!(matches_deny_pattern("git tag v1.0").is_none());
+        assert!(matches_deny_pattern("git remote -v").is_none());
+        assert!(matches_deny_pattern("git gc").is_none());
+        assert!(matches_deny_pattern("git worktree list").is_none());
+        assert!(matches_deny_pattern("git worktree add /tmp/wt branch").is_none());
+    }
+
+    // -- Deny pattern: git push variants --
+
+    #[test]
+    fn deny_git_push_force() {
+        assert_eq!(matches_deny_pattern("git push --force"), Some("git push --force/--delete"));
+        assert_eq!(matches_deny_pattern("git push -f origin main"), Some("git push --force/--delete"));
+        assert_eq!(matches_deny_pattern("git push --force-with-lease"), Some("git push --force/--delete"));
+        assert_eq!(matches_deny_pattern("git push --force-if-includes"), Some("git push --force/--delete"));
+        assert_eq!(matches_deny_pattern("git push --delete origin branch"), Some("git push --force/--delete"));
+    }
+
+    // -- Deny pattern: git branch --
+
+    #[test]
+    fn deny_git_branch_delete() {
+        assert_eq!(matches_deny_pattern("git branch -d my-feature"), Some("git branch delete"));
+        assert_eq!(matches_deny_pattern("git branch --delete my-feature"), Some("git branch delete"));
     }
 
     #[test]
-    fn deny_pattern_matched_for_dangerous_commands() {
-        assert!(matches_deny_pattern("git push --force").is_some());
-        assert!(matches_deny_pattern("git push -f origin main").is_some());
-        assert!(matches_deny_pattern("git push --delete origin branch").is_some());
-        assert!(matches_deny_pattern("sudo rm -rf /").is_some());
-        assert!(matches_deny_pattern("ssh user@host").is_some());
-        assert!(matches_deny_pattern("docker run ubuntu").is_some());
-        assert!(matches_deny_pattern("kubectl delete pod").is_some());
+    fn deny_git_branch_force_delete() {
+        assert_eq!(matches_deny_pattern("git branch -D my-feature"), Some("git branch force-delete"));
+    }
+
+    #[test]
+    fn deny_git_branch_combined_flags() {
+        assert_eq!(matches_deny_pattern("git branch -Dr origin/old"), Some("git branch force-delete"));
+    }
+
+    // -- Deny pattern: git worktree --
+
+    #[test]
+    fn deny_git_worktree_remove() {
+        assert_eq!(matches_deny_pattern("git worktree remove /tmp/wt"), Some("git worktree remove"));
+        assert_eq!(matches_deny_pattern("git worktree remove --force /tmp/wt"), Some("git worktree remove"));
+    }
+
+    #[test]
+    fn deny_git_worktree_prune() {
+        assert_eq!(matches_deny_pattern("git worktree prune"), Some("git worktree prune"));
+    }
+
+    // -- Deny pattern: git reset/clean/checkout --
+
+    #[test]
+    fn deny_git_reset_hard() {
+        assert_eq!(matches_deny_pattern("git reset --hard HEAD~1"), Some("git reset --hard"));
+    }
+
+    #[test]
+    fn deny_git_clean() {
+        assert_eq!(matches_deny_pattern("git clean -f"), Some("git clean"));
+        assert_eq!(matches_deny_pattern("git clean -fd"), Some("git clean"));
+        assert_eq!(matches_deny_pattern("git clean -fdx"), Some("git clean"));
+        assert_eq!(matches_deny_pattern("git clean --force"), Some("git clean"));
+    }
+
+    #[test]
+    fn deny_git_checkout_discard_all() {
+        assert_eq!(matches_deny_pattern("git checkout -- ."), Some("git checkout (discard all)"));
+    }
+
+    // -- Deny pattern: new git operations --
+
+    #[test]
+    fn deny_git_stash_destructive() {
+        assert_eq!(matches_deny_pattern("git stash drop"), Some("git stash drop/clear"));
+        assert_eq!(matches_deny_pattern("git stash clear"), Some("git stash drop/clear"));
+        assert_eq!(matches_deny_pattern("git stash drop stash@{0}"), Some("git stash drop/clear"));
+    }
+
+    #[test]
+    fn deny_git_tag_delete() {
+        assert_eq!(matches_deny_pattern("git tag -d v1.0"), Some("git tag delete"));
+        assert_eq!(matches_deny_pattern("git tag --delete v1.0"), Some("git tag delete"));
+    }
+
+    #[test]
+    fn deny_git_remote_remove() {
+        assert_eq!(matches_deny_pattern("git remote remove origin"), Some("git remote remove"));
+        assert_eq!(matches_deny_pattern("git remote rm origin"), Some("git remote remove"));
+    }
+
+    #[test]
+    fn deny_git_reflog_expire() {
+        assert_eq!(matches_deny_pattern("git reflog expire --expire=all --all"), Some("git reflog expire/delete"));
+        assert_eq!(matches_deny_pattern("git reflog delete HEAD@{0}"), Some("git reflog expire/delete"));
+    }
+
+    #[test]
+    fn deny_git_gc_prune() {
+        assert_eq!(matches_deny_pattern("git gc --prune=now"), Some("git gc --prune"));
+        assert_eq!(matches_deny_pattern("git gc --prune"), Some("git gc --prune"));
+    }
+
+    #[test]
+    fn deny_git_filter_branch() {
+        assert_eq!(matches_deny_pattern("git filter-branch --force HEAD"), Some("git filter-branch"));
+    }
+
+    #[test]
+    fn deny_git_update_ref() {
+        assert_eq!(matches_deny_pattern("git update-ref -d refs/heads/main"), Some("git update-ref delete"));
+        assert_eq!(matches_deny_pattern("git update-ref --delete refs/heads/main"), Some("git update-ref delete"));
+    }
+
+    // -- Deny pattern: compound commands (AST-based) --
+
+    #[test]
+    fn deny_chained_and_then() {
+        assert!(matches_deny_pattern("echo hello && git push --force origin main").is_some());
+    }
+
+    #[test]
+    fn deny_chained_or_else() {
+        assert!(matches_deny_pattern("git status || git push --force").is_some());
+    }
+
+    #[test]
+    fn deny_chained_semicolon() {
+        assert!(matches_deny_pattern("echo ok; git reset --hard").is_some());
+    }
+
+    #[test]
+    fn deny_subshell() {
+        assert!(matches_deny_pattern("(git push --force origin main)").is_some());
+    }
+
+    #[test]
+    fn deny_brace_group() {
+        assert!(matches_deny_pattern("{ git reset --hard; }").is_some());
+    }
+
+    // -- Deny pattern: curl/wget piped to shell --
+
+    #[test]
+    fn deny_curl_pipe_bash() {
+        assert_eq!(
+            matches_deny_pattern("curl -fsSL https://example.com/install.sh | bash"),
+            Some("curl/wget piped to shell")
+        );
+    }
+
+    #[test]
+    fn deny_wget_pipe_sh() {
+        assert_eq!(
+            matches_deny_pattern("wget -O- https://example.com/script | sh"),
+            Some("curl/wget piped to shell")
+        );
+    }
+
+    // -- Deny pattern: wrapper detection --
+
+    #[test]
+    fn deny_env_wrapper() {
+        assert!(matches_deny_pattern("env GIT_TERMINAL_PROMPT=0 git push --force").is_some());
+        assert!(matches_deny_pattern("env git push --force").is_some());
+    }
+
+    #[test]
+    fn deny_sudo() {
+        assert_eq!(matches_deny_pattern("sudo rm -rf /"), Some("sudo"));
+        assert_eq!(matches_deny_pattern("sudo apt install vim"), Some("sudo"));
+    }
+
+    #[test]
+    fn deny_shell_reinvoke() {
+        assert!(matches_deny_pattern("bash -c 'git push --force'").is_some());
+        assert!(matches_deny_pattern("sh -c 'git reset --hard'").is_some());
+    }
+
+    // -- Deny pattern: gh commands --
+
+    #[test]
+    fn deny_gh_repo_delete() {
+        assert_eq!(matches_deny_pattern("gh repo delete myorg/myrepo --yes"), Some("gh repo delete"));
+    }
+
+    #[test]
+    fn deny_gh_release_delete() {
+        assert_eq!(matches_deny_pattern("gh release delete v1.0"), Some("gh release delete"));
+    }
+
+    // -- Deny pattern: rm, ssh, docker, etc. --
+
+    #[test]
+    fn deny_rm_rf_absolute() {
+        assert_eq!(matches_deny_pattern("rm -rf /tmp/something"), Some("rm -rf with absolute path"));
+    }
+
+    #[test]
+    fn deny_rm_rf_relative_allowed() {
+        assert!(matches_deny_pattern("rm -rf ./node_modules").is_none());
+    }
+
+    #[test]
+    fn deny_ssh_scp() {
+        assert_eq!(matches_deny_pattern("ssh user@host"), Some("ssh/scp"));
+        assert_eq!(matches_deny_pattern("scp file user@host:/tmp"), Some("ssh/scp"));
+    }
+
+    #[test]
+    fn deny_docker_kubectl() {
+        assert_eq!(matches_deny_pattern("docker run -it ubuntu"), Some("docker/kubectl"));
+        assert_eq!(matches_deny_pattern("kubectl delete pod"), Some("docker/kubectl"));
+    }
+
+    #[test]
+    fn deny_kill() {
+        assert_eq!(matches_deny_pattern("kill -9 1234"), Some("kill"));
+        assert_eq!(matches_deny_pattern("pkill -f node"), Some("kill"));
+        assert_eq!(matches_deny_pattern("killall node"), Some("kill"));
+    }
+
+    #[test]
+    fn deny_chmod_chown() {
+        assert_eq!(matches_deny_pattern("chmod 777 /tmp/file"), Some("chmod/chown"));
+        assert_eq!(matches_deny_pattern("chown root:root /tmp/file"), Some("chmod/chown"));
+    }
+
+    // -- Integration: evaluate() with Bash tool --
+
+    #[test]
+    fn bash_git_branch_delete_requires_approval() {
+        let result = evaluate("Bash", &json!({"command": "git branch -d my-feature"}), WORKTREE, REPO, TrustLevel::Normal);
+        assert_eq!(result.decision, PolicyDecision::RequireApproval);
+        assert!(result.reason.contains("git branch delete"));
+    }
+
+    #[test]
+    fn bash_git_branch_force_delete_requires_approval() {
+        let result = evaluate("Bash", &json!({"command": "git branch -D my-feature"}), WORKTREE, REPO, TrustLevel::Normal);
+        assert_eq!(result.decision, PolicyDecision::RequireApproval);
+        assert!(result.reason.contains("git branch force-delete"));
+    }
+
+    #[test]
+    fn bash_git_worktree_remove_requires_approval() {
+        let result = evaluate("Bash", &json!({"command": "git worktree remove /tmp/some-worktree"}), WORKTREE, REPO, TrustLevel::Normal);
+        assert_eq!(result.decision, PolicyDecision::RequireApproval);
+        assert!(result.reason.contains("git worktree remove"));
+    }
+
+    #[test]
+    fn bash_git_worktree_prune_requires_approval() {
+        let result = evaluate("Bash", &json!({"command": "git worktree prune"}), WORKTREE, REPO, TrustLevel::Normal);
+        assert_eq!(result.decision, PolicyDecision::RequireApproval);
+        assert!(result.reason.contains("git worktree prune"));
+    }
+
+    #[test]
+    fn bash_git_branch_list_auto_allowed() {
+        let result = evaluate("Bash", &json!({"command": "git branch -a"}), WORKTREE, REPO, TrustLevel::Normal);
+        assert_eq!(result.decision, PolicyDecision::AutoAllowLogged);
+    }
+
+    // -- Flag helpers --
+
+    #[test]
+    fn has_short_flag_combined() {
+        assert!(has_short_flag(&["-Df"], 'D'));
+        assert!(has_short_flag(&["-Df"], 'f'));
+        assert!(!has_short_flag(&["-Df"], 'x'));
+        assert!(!has_short_flag(&["--delete"], 'd'));
+    }
+
+    #[test]
+    fn has_long_flag_exact() {
+        assert!(has_long_flag(&["--force", "origin"], &["--force"]));
+        assert!(!has_long_flag(&["-f", "origin"], &["--force"]));
     }
 }


### PR DESCRIPTION
## Summary

- Replaces fragile substring matching in `matches_deny_pattern` with a proper shell AST parser ([yash-syntax](https://crates.io/crates/yash-syntax)) that decomposes compound commands, subshells, brace groups, and pipelines before checking each sub-command independently
- Expands destructive git operation coverage from 7 to 16 patterns: adds `stash drop/clear`, `tag -d`, `remote remove`, `reflog expire/delete`, `gc --prune`, `filter-branch`, `update-ref -d`, `push --force-with-lease/--force-if-includes`
- Detects wrapper programs (`env`, `command`), shell re-invocations (`bash -c "..."`), `gh repo/release delete`, `curl|bash` pipelines, and combined short flags (`-Df`, `-fdx`)
- 75 policy tests (up from 40), zero clippy warnings

## What this fixes

In normal/default trust mode, Claude could bypass the deny-list via compound commands (`(git push --force)`), `||` chaining, wrapper programs (`env git push --force`), combined flags (`git branch -Df`), or `bash -c` re-invocation. Many destructive git operations (stash drop, tag delete, worktree prune, etc.) were not covered at all.

Closes #59

## Test plan

- [x] `cargo test -- policy` passes (75/75)
- [x] `cargo clippy` clean (no new warnings)
- [ ] Manual: set trust level to normal, verify destructive git commands trigger approval UI
- [ ] Manual: verify safe commands (`git status`, `cargo test`, etc.) still auto-allow