### PR TITLE
feat: add Cmd+F search to shell terminals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fix archiving a task from the GitActions replacement button not closing the task panel - deselection now happens inside `archiveTask` so all callers get it
 - Fix slow pasting of long text in session composer - disable spellcheck/autocorrect overhead, use Range API for large pastes (>10KB) while keeping `execCommand` + native undo for normal-sized pastes
 - Fix slow pasting of long text in shell terminals - use `term.paste()` for bracketed paste support and rAF-batch `pty-output` writes to prevent render storms
+- Cmd+F / Ctrl+F search in shell terminals - highlights matches, Enter/Shift+Enter to navigate, Escape to dismiss
 - Demo mode: set `VITE_DEMO_MODE=true` to populate the app with dummy projects, tasks, sessions, and a realistic chat conversation for screenshots
 - Fix message role corruption when switching between tasks - clear stale output data before reloading and use reactive Switch/Match for block type rendering so reconcile merges can't produce wrong role display
 - Fix "delete branch with merge" failing because `gh pr merge --delete-branch` tries to checkout main, which conflicts with the main worktree - now deletes the remote branch separately after merge

--- a/src-tauri/src/stream.rs
+++ b/src-tauri/src/stream.rs
@@ -408,48 +408,39 @@ async fn snapshot_turn_best_effort(
     })
     .await;
 
-    match result {
-        Ok(Ok((message_uuid, stash_sha))) => {
-            let now = now_ms();
-            let _ = db_tx
-                .send(DbWrite::InsertTurnSnapshot {
-                    session_id: verun_session_id.to_string(),
-                    message_uuid: message_uuid.clone(),
-                    stash_sha,
-                    created_at: now,
-                })
-                .await;
-
-            // Persist a synthetic marker line into output_lines so the frontend
-            // can attach the message uuid to the most recent assistant block on
-            // session reload, and so the fork operation can find the truncation
-            // boundary in output_lines without having to re-parse stream state.
-            let marker = serde_json::json!({
-                "type": "verun_turn_snapshot",
-                "sessionId": verun_session_id,
-                "messageUuid": message_uuid,
+    if let Ok(Ok((message_uuid, stash_sha))) = result {
+        let now = now_ms();
+        let _ = db_tx
+            .send(DbWrite::InsertTurnSnapshot {
+                session_id: verun_session_id.to_string(),
+                message_uuid: message_uuid.clone(),
+                stash_sha,
+                created_at: now,
             })
-            .to_string();
-            let _ = db_tx
-                .send(DbWrite::InsertOutputLines {
-                    session_id: verun_session_id.to_string(),
-                    lines: vec![(marker.clone(), now)],
-                })
-                .await;
+            .await;
 
-            // Also push the marker as a live event so any open chat view picks
-            // it up immediately without a session reload.
-            let _ = app.emit(
-                "session-output",
-                SessionOutputEvent {
-                    session_id: verun_session_id.to_string(),
-                    items: vec![OutputItem::TurnSnapshot {
-                        message_uuid: message_uuid.clone(),
-                    }],
-                },
-            );
-        }
-        Ok(Err(_)) | Err(_) => {}
+        let marker = serde_json::json!({
+            "type": "verun_turn_snapshot",
+            "sessionId": verun_session_id,
+            "messageUuid": message_uuid,
+        })
+        .to_string();
+        let _ = db_tx
+            .send(DbWrite::InsertOutputLines {
+                session_id: verun_session_id.to_string(),
+                lines: vec![(marker.clone(), now)],
+            })
+            .await;
+
+        let _ = app.emit(
+            "session-output",
+            SessionOutputEvent {
+                session_id: verun_session_id.to_string(),
+                items: vec![OutputItem::TurnSnapshot {
+                    message_uuid: message_uuid.clone(),
+                }],
+            },
+        );
     }
 }
 

--- a/src/components/ShellTerminal.tsx
+++ b/src/components/ShellTerminal.tsx
@@ -15,7 +15,7 @@ const THEME = {
   background: '#0a0a0a',
   foreground: '#e5e5e5',
   cursor: '#e5e5e5',
-  selectionBackground: '#6366f140',
+  selectionBackground: '#2d6e4f80',
   black: '#0a0a0a',
   red: '#ef4444',
   green: '#22c55e',
@@ -121,6 +121,7 @@ const SEARCH_DECORATIONS = {
   matchBorder: '#2d6e4f',
   matchOverviewRuler: '#2d6e4f',
   activeMatchBackground: '#2d6e4f',
+  activeMatchBorder: '#3a8562',
   activeMatchColorOverviewRuler: '#3a8562',
 }
 

--- a/src/components/ShellTerminal.tsx
+++ b/src/components/ShellTerminal.tsx
@@ -119,8 +119,8 @@ interface Props {
 
 const SEARCH_DECORATIONS = {
   matchBorder: '#2d6e4f',
-  matchOverviewRuler: '#2d6e4f80',
-  activeMatchBackground: '#2d6e4f60',
+  matchOverviewRuler: '#2d6e4f',
+  activeMatchBackground: '#2d6e4f',
   activeMatchColorOverviewRuler: '#3a8562',
 }
 

--- a/src/components/ShellTerminal.tsx
+++ b/src/components/ShellTerminal.tsx
@@ -38,12 +38,17 @@ const THEME = {
 function setupCaptureKeyHandler(container: HTMLElement, term: XTerm, terminalId: string, isStopped?: Accessor<boolean>, onToggleSearch?: () => void) {
   container.addEventListener('keydown', (e: KeyboardEvent) => {
     const mod = modPressed(e)
+    const inInput = (e.target as HTMLElement).tagName === 'INPUT'
+
     if (mod && e.key === 'f') {
       e.preventDefault()
       e.stopImmediatePropagation()
       onToggleSearch?.()
       return
     }
+    // Let standard text-editing shortcuts pass through to input elements
+    if (inInput) return
+
     if (mod && e.key === 'c') {
       e.preventDefault()
       e.stopImmediatePropagation()
@@ -130,6 +135,7 @@ export const ShellTerminal: Component<Props> = (props) => {
   let resultsDisposable: { dispose(): void } | undefined
 
   const [showSearch, setShowSearch] = createSignal(false)
+  const [searchQuery, setSearchQuery] = createSignal('')
   const [resultIndex, setResultIndex] = createSignal(-1)
   const [resultCount, setResultCount] = createSignal(0)
 
@@ -137,6 +143,7 @@ export const ShellTerminal: Component<Props> = (props) => {
 
   const closeSearch = () => {
     setShowSearch(false)
+    setSearchQuery('')
     setResultIndex(-1)
     setResultCount(0)
     searchAddonRef?.clearDecorations()
@@ -254,46 +261,46 @@ export const ShellTerminal: Component<Props> = (props) => {
   return (
     <div ref={containerRef} class="w-full h-full relative">
       <Show when={showSearch()}>
-        <div class="absolute top-2 right-2 z-10 flex items-center gap-1.5 bg-surface-2 border border-border rounded-lg px-2 py-1">
+        <div class="absolute top-2 right-3 z-20 flex items-center gap-1 bg-surface-2 border border-border rounded-lg px-2 py-1 shadow-lg">
           <input
             ref={searchInputRef}
-            class="bg-transparent text-sm text-gray-200 outline-none w-40 placeholder-gray-500"
-            placeholder="Search..."
+            class="bg-transparent text-sm text-text-primary outline-none w-52 placeholder-text-dim"
+            placeholder="Find in terminal..."
+            value={searchQuery()}
             onKeyDown={handleSearchKeyDown}
             onInput={(e) => {
               const val = e.currentTarget.value
+              setSearchQuery(val)
               if (val) searchAddonRef?.findPrevious(val, searchOpts)
               else { searchAddonRef?.clearDecorations(); setResultIndex(-1); setResultCount(0) }
             }}
           />
-          <Show when={resultCount() > 0}>
-            <span class="text-xs text-gray-500 tabular-nums whitespace-nowrap">
-              {resultIndex() + 1}/{resultCount()}
-            </span>
-          </Show>
-          <div class="flex items-center gap-0.5">
-            <button
-              class="text-gray-500 hover:text-gray-200 p-0.5 rounded hover:bg-white/5"
-              onClick={findPrev}
-              title="Previous (Shift+Enter)"
-            >
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 15-6-6-6 6"/></svg>
-            </button>
-            <button
-              class="text-gray-500 hover:text-gray-200 p-0.5 rounded hover:bg-white/5"
-              onClick={findNext}
-              title="Next (Enter)"
-            >
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
-            </button>
-            <button
-              class="text-gray-500 hover:text-gray-200 p-0.5 rounded hover:bg-white/5"
-              onClick={closeSearch}
-              title="Close (Escape)"
-            >
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
-            </button>
-          </div>
+          <span class="text-[11px] text-text-dim whitespace-nowrap w-16 text-right">
+            {searchQuery() ? (resultCount() === 0 ? 'No results' : `${resultIndex() + 1} of ${resultCount()}`) : '\u00A0'}
+          </span>
+          <button
+            class="p-0.5 text-text-dim hover:text-text-muted transition-colors disabled:opacity-30"
+            onClick={findPrev}
+            disabled={resultCount() === 0}
+            title="Previous (Shift+Enter)"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 15-6-6-6 6"/></svg>
+          </button>
+          <button
+            class="p-0.5 text-text-dim hover:text-text-muted transition-colors disabled:opacity-30"
+            onClick={findNext}
+            disabled={resultCount() === 0}
+            title="Next (Enter)"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
+          </button>
+          <button
+            class="p-0.5 text-text-dim hover:text-text-muted transition-colors"
+            onClick={closeSearch}
+            title="Close (Esc)"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+          </button>
         </div>
       </Show>
       <div

--- a/src/components/ShellTerminal.tsx
+++ b/src/components/ShellTerminal.tsx
@@ -112,37 +112,74 @@ interface Props {
   isStopped?: Accessor<boolean>
 }
 
+const SEARCH_DECORATIONS = {
+  matchBackground: '#6366f130',
+  matchBorder: '#6366f150',
+  matchOverviewRuler: '#6366f180',
+  activeMatchBackground: '#6366f160',
+  activeMatchBorder: '#818cf8',
+  activeMatchColorOverviewRuler: '#818cf8',
+}
+
 export const ShellTerminal: Component<Props> = (props) => {
   let containerRef!: HTMLDivElement
   let terminalRef: HTMLDivElement | undefined
   let searchInputRef: HTMLInputElement | undefined
   let resizeObserver: ResizeObserver | undefined
   let searchAddonRef: SearchAddon | undefined
+  let resultsDisposable: { dispose(): void } | undefined
 
   const [showSearch, setShowSearch] = createSignal(false)
+  const [resultIndex, setResultIndex] = createSignal(-1)
+  const [resultCount, setResultCount] = createSignal(0)
+
+  const searchOpts = { decorations: SEARCH_DECORATIONS }
+
+  const closeSearch = () => {
+    setShowSearch(false)
+    setResultIndex(-1)
+    setResultCount(0)
+    searchAddonRef?.clearDecorations()
+    getXtermEntry(props.terminalId)?.term.focus()
+  }
 
   const toggleSearch = () => {
-    const next = !showSearch()
-    setShowSearch(next)
-    if (next) {
-      requestAnimationFrame(() => searchInputRef?.focus())
+    if (showSearch()) {
+      closeSearch()
     } else {
-      searchAddonRef?.clearDecorations()
+      setShowSearch(true)
+      requestAnimationFrame(() => {
+        searchInputRef?.focus()
+        searchInputRef?.select()
+      })
     }
+  }
+
+  const findNext = () => {
+    const val = searchInputRef?.value
+    if (val) searchAddonRef?.findNext(val, searchOpts)
+  }
+
+  const findPrev = () => {
+    const val = searchInputRef?.value
+    if (val) searchAddonRef?.findPrevious(val, searchOpts)
   }
 
   const handleSearchKeyDown = (e: KeyboardEvent) => {
     if (e.key === 'Escape') {
-      setShowSearch(false)
-      searchAddonRef?.clearDecorations()
-      getXtermEntry(props.terminalId)?.term.focus()
+      closeSearch()
     } else if (e.key === 'Enter') {
-      if (e.shiftKey) {
-        searchAddonRef?.findPrevious((e.target as HTMLInputElement).value)
-      } else {
-        searchAddonRef?.findNext((e.target as HTMLInputElement).value)
-      }
+      if (e.shiftKey) findPrev()
+      else findNext()
     }
+  }
+
+  const attachResultsListener = (addon: SearchAddon) => {
+    resultsDisposable?.dispose()
+    resultsDisposable = addon.onDidChangeResults((e) => {
+      setResultIndex(e.resultIndex)
+      setResultCount(e.resultCount)
+    })
   }
 
   onMount(() => {
@@ -154,6 +191,7 @@ export const ShellTerminal: Component<Props> = (props) => {
       const el = existing.term.element
       if (el) terminalRef.appendChild(el)
       searchAddonRef = existing.searchAddon
+      if (searchAddonRef) attachResultsListener(searchAddonRef)
       setupCaptureKeyHandler(containerRef, existing.term, props.terminalId, props.isStopped, toggleSearch)
       initialFit(existing, props.terminalId)
       resizeObserver = attachResizeObserver(terminalRef, existing, props.terminalId)
@@ -180,6 +218,7 @@ export const ShellTerminal: Component<Props> = (props) => {
     const fitAddon = new FitAddon()
     const searchAddon = new SearchAddon()
     searchAddonRef = searchAddon
+    attachResultsListener(searchAddon)
     term.loadAddon(fitAddon)
     term.loadAddon(searchAddon)
     term.loadAddon(new WebLinksAddon())
@@ -209,25 +248,52 @@ export const ShellTerminal: Component<Props> = (props) => {
 
   onCleanup(() => {
     resizeObserver?.disconnect()
+    resultsDisposable?.dispose()
   })
 
   return (
     <div ref={containerRef} class="w-full h-full relative">
       <Show when={showSearch()}>
-        <div class="absolute top-2 right-2 z-10 flex items-center gap-1 bg-surface-2 border border-border rounded px-2 py-1">
+        <div class="absolute top-2 right-2 z-10 flex items-center gap-1.5 bg-surface-2 border border-border rounded-lg px-2 py-1">
           <input
             ref={searchInputRef}
-            class="bg-transparent text-sm text-gray-200 outline-none w-48 placeholder-gray-500"
+            class="bg-transparent text-sm text-gray-200 outline-none w-40 placeholder-gray-500"
             placeholder="Search..."
             onKeyDown={handleSearchKeyDown}
-            onInput={(e) => searchAddonRef?.findNext(e.currentTarget.value)}
+            onInput={(e) => {
+              const val = e.currentTarget.value
+              if (val) searchAddonRef?.findPrevious(val, searchOpts)
+              else { searchAddonRef?.clearDecorations(); setResultIndex(-1); setResultCount(0) }
+            }}
           />
-          <button
-            class="text-gray-500 hover:text-gray-300 text-xs px-1"
-            onClick={() => { setShowSearch(false); searchAddonRef?.clearDecorations(); getXtermEntry(props.terminalId)?.term.focus() }}
-          >
-            Esc
-          </button>
+          <Show when={resultCount() > 0}>
+            <span class="text-xs text-gray-500 tabular-nums whitespace-nowrap">
+              {resultIndex() + 1}/{resultCount()}
+            </span>
+          </Show>
+          <div class="flex items-center gap-0.5">
+            <button
+              class="text-gray-500 hover:text-gray-200 p-0.5 rounded hover:bg-white/5"
+              onClick={findPrev}
+              title="Previous (Shift+Enter)"
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 15-6-6-6 6"/></svg>
+            </button>
+            <button
+              class="text-gray-500 hover:text-gray-200 p-0.5 rounded hover:bg-white/5"
+              onClick={findNext}
+              title="Next (Enter)"
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
+            </button>
+            <button
+              class="text-gray-500 hover:text-gray-200 p-0.5 rounded hover:bg-white/5"
+              onClick={closeSearch}
+              title="Close (Escape)"
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+            </button>
+          </div>
         </div>
       </Show>
       <div

--- a/src/components/ShellTerminal.tsx
+++ b/src/components/ShellTerminal.tsx
@@ -1,6 +1,7 @@
-import { Component, onMount, onCleanup, type Accessor } from 'solid-js'
+import { Component, onMount, onCleanup, createSignal, Show, type Accessor } from 'solid-js'
 import { Terminal as XTerm } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
+import { SearchAddon } from '@xterm/addon-search'
 import { WebLinksAddon } from '@xterm/addon-web-links'
 import { Unicode11Addon } from '@xterm/addon-unicode11'
 import { WebglAddon } from '@xterm/addon-webgl'
@@ -34,9 +35,15 @@ const THEME = {
 }
 
 /** Capture-phase keydown on the container — fires before xterm's textarea gets it */
-function setupCaptureKeyHandler(container: HTMLElement, term: XTerm, terminalId: string, isStopped?: Accessor<boolean>) {
+function setupCaptureKeyHandler(container: HTMLElement, term: XTerm, terminalId: string, isStopped?: Accessor<boolean>, onToggleSearch?: () => void) {
   container.addEventListener('keydown', (e: KeyboardEvent) => {
     const mod = modPressed(e)
+    if (mod && e.key === 'f') {
+      e.preventDefault()
+      e.stopImmediatePropagation()
+      onToggleSearch?.()
+      return
+    }
     if (mod && e.key === 'c') {
       e.preventDefault()
       e.stopImmediatePropagation()
@@ -106,21 +113,50 @@ interface Props {
 }
 
 export const ShellTerminal: Component<Props> = (props) => {
-  let containerRef: HTMLDivElement | undefined
+  let containerRef!: HTMLDivElement
+  let terminalRef: HTMLDivElement | undefined
+  let searchInputRef: HTMLInputElement | undefined
   let resizeObserver: ResizeObserver | undefined
+  let searchAddonRef: SearchAddon | undefined
+
+  const [showSearch, setShowSearch] = createSignal(false)
+
+  const toggleSearch = () => {
+    const next = !showSearch()
+    setShowSearch(next)
+    if (next) {
+      requestAnimationFrame(() => searchInputRef?.focus())
+    } else {
+      searchAddonRef?.clearDecorations()
+    }
+  }
+
+  const handleSearchKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      setShowSearch(false)
+      searchAddonRef?.clearDecorations()
+      getXtermEntry(props.terminalId)?.term.focus()
+    } else if (e.key === 'Enter') {
+      if (e.shiftKey) {
+        searchAddonRef?.findPrevious((e.target as HTMLInputElement).value)
+      } else {
+        searchAddonRef?.findNext((e.target as HTMLInputElement).value)
+      }
+    }
+  }
 
   onMount(() => {
-    if (!containerRef) return
+    if (!terminalRef) return
 
     const existing = getXtermEntry(props.terminalId)
 
     if (existing) {
-      // Reparent the existing xterm DOM into this new container (task switch)
       const el = existing.term.element
-      if (el) containerRef.appendChild(el)
-      setupCaptureKeyHandler(containerRef, existing.term, props.terminalId, props.isStopped)
+      if (el) terminalRef.appendChild(el)
+      searchAddonRef = existing.searchAddon
+      setupCaptureKeyHandler(containerRef, existing.term, props.terminalId, props.isStopped, toggleSearch)
       initialFit(existing, props.terminalId)
-      resizeObserver = attachResizeObserver(containerRef, existing, props.terminalId)
+      resizeObserver = attachResizeObserver(terminalRef, existing, props.terminalId)
       return
     }
 
@@ -142,30 +178,33 @@ export const ShellTerminal: Component<Props> = (props) => {
     })
 
     const fitAddon = new FitAddon()
+    const searchAddon = new SearchAddon()
+    searchAddonRef = searchAddon
     term.loadAddon(fitAddon)
+    term.loadAddon(searchAddon)
     term.loadAddon(new WebLinksAddon())
     const unicode11 = new Unicode11Addon()
     term.loadAddon(unicode11)
     term.unicode.activeVersion = '11'
     setupXtermPassthrough(term)
-    setupCaptureKeyHandler(containerRef, term, props.terminalId, props.isStopped)
+    setupCaptureKeyHandler(containerRef, term, props.terminalId, props.isStopped, toggleSearch)
     term.onData((data) => {
       if (props.isStopped?.()) return
       ipc.ptyWrite(props.terminalId, data)
     })
-    registerXterm(props.terminalId, term, fitAddon)
+    registerXterm(props.terminalId, term, fitAddon, searchAddon)
 
-    term.open(containerRef)
+    term.open(terminalRef)
 
     try {
       term.loadAddon(new WebglAddon())
     } catch {
-      // WebGL not available — fall back to canvas renderer
+      // WebGL not available
     }
 
-    const entry = { term, fitAddon }
+    const entry = { term, fitAddon, searchAddon }
     initialFit(entry, props.terminalId)
-    resizeObserver = attachResizeObserver(containerRef, entry, props.terminalId)
+    resizeObserver = attachResizeObserver(terminalRef, entry, props.terminalId)
   })
 
   onCleanup(() => {
@@ -173,10 +212,29 @@ export const ShellTerminal: Component<Props> = (props) => {
   })
 
   return (
-    <div
-      ref={containerRef}
-      class="w-full h-full shell-terminal"
-      style={{ "background-color": "#0a0a0a", cursor: "default" }}
-    />
+    <div ref={containerRef} class="w-full h-full relative">
+      <Show when={showSearch()}>
+        <div class="absolute top-2 right-2 z-10 flex items-center gap-1 bg-surface-2 border border-border rounded px-2 py-1">
+          <input
+            ref={searchInputRef}
+            class="bg-transparent text-sm text-gray-200 outline-none w-48 placeholder-gray-500"
+            placeholder="Search..."
+            onKeyDown={handleSearchKeyDown}
+            onInput={(e) => searchAddonRef?.findNext(e.currentTarget.value)}
+          />
+          <button
+            class="text-gray-500 hover:text-gray-300 text-xs px-1"
+            onClick={() => { setShowSearch(false); searchAddonRef?.clearDecorations(); getXtermEntry(props.terminalId)?.term.focus() }}
+          >
+            Esc
+          </button>
+        </div>
+      </Show>
+      <div
+        ref={terminalRef}
+        class="w-full h-full shell-terminal"
+        style={{ "background-color": "#0a0a0a", cursor: "default" }}
+      />
+    </div>
   )
 }

--- a/src/components/ShellTerminal.tsx
+++ b/src/components/ShellTerminal.tsx
@@ -118,12 +118,10 @@ interface Props {
 }
 
 const SEARCH_DECORATIONS = {
-  matchBackground: '#6366f130',
-  matchBorder: '#6366f150',
-  matchOverviewRuler: '#6366f180',
-  activeMatchBackground: '#6366f160',
-  activeMatchBorder: '#818cf8',
-  activeMatchColorOverviewRuler: '#818cf8',
+  matchBorder: '#2d6e4f',
+  matchOverviewRuler: '#2d6e4f80',
+  activeMatchBackground: '#2d6e4f60',
+  activeMatchColorOverviewRuler: '#3a8562',
 }
 
 export const ShellTerminal: Component<Props> = (props) => {

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -70,11 +70,25 @@ export const Terminal: Component<Props> = (props) => {
   let term: XTerm
   let fitAddon: FitAddon
   let searchAddon: SearchAddon
+  let resultsDisposable: { dispose(): void } | undefined
   let writeBuffer: string[] = []
   let rafId: number | null = null
   let lastWrittenIndex = 0
 
+  const searchOpts = {
+    decorations: {
+      matchBackground: '#6366f130',
+      matchBorder: '#6366f150',
+      matchOverviewRuler: '#6366f180',
+      activeMatchBackground: '#6366f160',
+      activeMatchBorder: '#818cf8',
+      activeMatchColorOverviewRuler: '#818cf8',
+    },
+  }
+
   const [showSearch, setShowSearch] = createSignal(false)
+  const [resultIndex, setResultIndex] = createSignal(-1)
+  const [resultCount, setResultCount] = createSignal(0)
   const [isAtBottom, setIsAtBottom] = createSignal(true)
 
   const flushBuffer = () => {
@@ -98,26 +112,42 @@ export const Terminal: Component<Props> = (props) => {
     }
   }
 
+  const closeSearch = () => {
+    setShowSearch(false)
+    setResultIndex(-1)
+    setResultCount(0)
+    searchAddon?.clearDecorations()
+    term?.focus()
+  }
+
   const toggleSearch = () => {
-    const next = !showSearch()
-    setShowSearch(next)
-    if (next) {
-      requestAnimationFrame(() => searchInputRef?.focus())
+    if (showSearch()) {
+      closeSearch()
     } else {
-      searchAddon?.clearDecorations()
+      setShowSearch(true)
+      requestAnimationFrame(() => {
+        searchInputRef?.focus()
+        searchInputRef?.select()
+      })
     }
+  }
+
+  const findNext = () => {
+    const val = searchInputRef?.value
+    if (val) searchAddon?.findNext(val, searchOpts)
+  }
+
+  const findPrev = () => {
+    const val = searchInputRef?.value
+    if (val) searchAddon?.findPrevious(val, searchOpts)
   }
 
   const handleSearchKeyDown = (e: KeyboardEvent) => {
     if (e.key === 'Escape') {
-      setShowSearch(false)
-      searchAddon?.clearDecorations()
+      closeSearch()
     } else if (e.key === 'Enter') {
-      if (e.shiftKey) {
-        searchAddon?.findPrevious((e.target as HTMLInputElement).value)
-      } else {
-        searchAddon?.findNext((e.target as HTMLInputElement).value)
-      }
+      if (e.shiftKey) findPrev()
+      else findNext()
     }
   }
 
@@ -140,6 +170,10 @@ export const Terminal: Component<Props> = (props) => {
 
     fitAddon = new FitAddon()
     searchAddon = new SearchAddon()
+    resultsDisposable = searchAddon.onDidChangeResults((e) => {
+      setResultIndex(e.resultIndex)
+      setResultCount(e.resultCount)
+    })
     term.loadAddon(fitAddon)
     term.loadAddon(new WebLinksAddon())
     term.loadAddon(searchAddon)
@@ -169,6 +203,7 @@ export const Terminal: Component<Props> = (props) => {
     onCleanup(() => {
       containerRef.removeEventListener('keydown', handleKeyboard)
       resizeObserver.disconnect()
+      resultsDisposable?.dispose()
       if (rafId !== null) cancelAnimationFrame(rafId)
       term.dispose()
     })
@@ -198,22 +233,47 @@ export const Terminal: Component<Props> = (props) => {
 
   return (
     <div class="w-full h-full relative" tabIndex={0}>
-      {/* Search bar */}
       <Show when={showSearch()}>
-        <div class="absolute top-2 right-2 z-10 flex items-center gap-1 bg-surface-2 border border-border rounded px-2 py-1">
+        <div class="absolute top-2 right-2 z-10 flex items-center gap-1.5 bg-surface-2 border border-border rounded-lg px-2 py-1">
           <input
             ref={searchInputRef}
-            class="bg-transparent text-sm text-gray-200 outline-none w-48 placeholder-gray-500"
+            class="bg-transparent text-sm text-gray-200 outline-none w-40 placeholder-gray-500"
             placeholder="Search..."
             onKeyDown={handleSearchKeyDown}
-            onInput={(e) => searchAddon?.findNext(e.currentTarget.value)}
+            onInput={(e) => {
+              const val = e.currentTarget.value
+              if (val) searchAddon?.findPrevious(val, searchOpts)
+              else { searchAddon?.clearDecorations(); setResultIndex(-1); setResultCount(0) }
+            }}
           />
-          <button
-            class="text-gray-500 hover:text-gray-300 text-xs px-1"
-            onClick={() => { setShowSearch(false); searchAddon?.clearDecorations() }}
-          >
-            Esc
-          </button>
+          <Show when={resultCount() > 0}>
+            <span class="text-xs text-gray-500 tabular-nums whitespace-nowrap">
+              {resultIndex() + 1}/{resultCount()}
+            </span>
+          </Show>
+          <div class="flex items-center gap-0.5">
+            <button
+              class="text-gray-500 hover:text-gray-200 p-0.5 rounded hover:bg-white/5"
+              onClick={findPrev}
+              title="Previous (Shift+Enter)"
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 15-6-6-6 6"/></svg>
+            </button>
+            <button
+              class="text-gray-500 hover:text-gray-200 p-0.5 rounded hover:bg-white/5"
+              onClick={findNext}
+              title="Next (Enter)"
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
+            </button>
+            <button
+              class="text-gray-500 hover:text-gray-200 p-0.5 rounded hover:bg-white/5"
+              onClick={closeSearch}
+              title="Close (Escape)"
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+            </button>
+          </div>
         </div>
       </Show>
 

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -87,6 +87,7 @@ export const Terminal: Component<Props> = (props) => {
   }
 
   const [showSearch, setShowSearch] = createSignal(false)
+  const [searchQuery, setSearchQuery] = createSignal('')
   const [resultIndex, setResultIndex] = createSignal(-1)
   const [resultCount, setResultCount] = createSignal(0)
   const [isAtBottom, setIsAtBottom] = createSignal(true)
@@ -114,6 +115,7 @@ export const Terminal: Component<Props> = (props) => {
 
   const closeSearch = () => {
     setShowSearch(false)
+    setSearchQuery('')
     setResultIndex(-1)
     setResultCount(0)
     searchAddon?.clearDecorations()
@@ -234,46 +236,46 @@ export const Terminal: Component<Props> = (props) => {
   return (
     <div class="w-full h-full relative" tabIndex={0}>
       <Show when={showSearch()}>
-        <div class="absolute top-2 right-2 z-10 flex items-center gap-1.5 bg-surface-2 border border-border rounded-lg px-2 py-1">
+        <div class="absolute top-2 right-3 z-20 flex items-center gap-1 bg-surface-2 border border-border rounded-lg px-2 py-1 shadow-lg">
           <input
             ref={searchInputRef}
-            class="bg-transparent text-sm text-gray-200 outline-none w-40 placeholder-gray-500"
-            placeholder="Search..."
+            class="bg-transparent text-sm text-text-primary outline-none w-52 placeholder-text-dim"
+            placeholder="Find in session..."
+            value={searchQuery()}
             onKeyDown={handleSearchKeyDown}
             onInput={(e) => {
               const val = e.currentTarget.value
+              setSearchQuery(val)
               if (val) searchAddon?.findPrevious(val, searchOpts)
               else { searchAddon?.clearDecorations(); setResultIndex(-1); setResultCount(0) }
             }}
           />
-          <Show when={resultCount() > 0}>
-            <span class="text-xs text-gray-500 tabular-nums whitespace-nowrap">
-              {resultIndex() + 1}/{resultCount()}
-            </span>
-          </Show>
-          <div class="flex items-center gap-0.5">
-            <button
-              class="text-gray-500 hover:text-gray-200 p-0.5 rounded hover:bg-white/5"
-              onClick={findPrev}
-              title="Previous (Shift+Enter)"
-            >
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 15-6-6-6 6"/></svg>
-            </button>
-            <button
-              class="text-gray-500 hover:text-gray-200 p-0.5 rounded hover:bg-white/5"
-              onClick={findNext}
-              title="Next (Enter)"
-            >
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
-            </button>
-            <button
-              class="text-gray-500 hover:text-gray-200 p-0.5 rounded hover:bg-white/5"
-              onClick={closeSearch}
-              title="Close (Escape)"
-            >
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
-            </button>
-          </div>
+          <span class="text-[11px] text-text-dim whitespace-nowrap w-16 text-right">
+            {searchQuery() ? (resultCount() === 0 ? 'No results' : `${resultIndex() + 1} of ${resultCount()}`) : '\u00A0'}
+          </span>
+          <button
+            class="p-0.5 text-text-dim hover:text-text-muted transition-colors disabled:opacity-30"
+            onClick={findPrev}
+            disabled={resultCount() === 0}
+            title="Previous (Shift+Enter)"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 15-6-6-6 6"/></svg>
+          </button>
+          <button
+            class="p-0.5 text-text-dim hover:text-text-muted transition-colors disabled:opacity-30"
+            onClick={findNext}
+            disabled={resultCount() === 0}
+            title="Next (Enter)"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
+          </button>
+          <button
+            class="p-0.5 text-text-dim hover:text-text-muted transition-colors"
+            onClick={closeSearch}
+            title="Close (Esc)"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+          </button>
         </div>
       </Show>
 

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -77,12 +77,10 @@ export const Terminal: Component<Props> = (props) => {
 
   const searchOpts = {
     decorations: {
-      matchBackground: '#6366f130',
-      matchBorder: '#6366f150',
-      matchOverviewRuler: '#6366f180',
-      activeMatchBackground: '#6366f160',
-      activeMatchBorder: '#818cf8',
-      activeMatchColorOverviewRuler: '#818cf8',
+      matchBorder: '#2d6e4f',
+      matchOverviewRuler: '#2d6e4f80',
+      activeMatchBackground: '#2d6e4f60',
+      activeMatchColorOverviewRuler: '#3a8562',
     },
   }
 

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -78,8 +78,8 @@ export const Terminal: Component<Props> = (props) => {
   const searchOpts = {
     decorations: {
       matchBorder: '#2d6e4f',
-      matchOverviewRuler: '#2d6e4f80',
-      activeMatchBackground: '#2d6e4f60',
+      matchOverviewRuler: '#2d6e4f',
+      activeMatchBackground: '#2d6e4f',
       activeMatchColorOverviewRuler: '#3a8562',
     },
   }

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -80,6 +80,7 @@ export const Terminal: Component<Props> = (props) => {
       matchBorder: '#2d6e4f',
       matchOverviewRuler: '#2d6e4f',
       activeMatchBackground: '#2d6e4f',
+      activeMatchBorder: '#3a8562',
       activeMatchColorOverviewRuler: '#3a8562',
     },
   }
@@ -157,7 +158,7 @@ export const Terminal: Component<Props> = (props) => {
         background: '#0a0a0a',
         foreground: '#e5e5e5',
         cursor: '#e5e5e5',
-        selectionBackground: '#6366f140',
+        selectionBackground: '#2d6e4f80',
       },
       fontFamily: "'SF Mono', 'Fira Code', 'Cascadia Code', monospace",
       fontSize: 13,

--- a/src/store/terminals.ts
+++ b/src/store/terminals.ts
@@ -5,6 +5,7 @@ import * as ipc from '../lib/ipc'
 import type { TerminalInstance, PtyOutputEvent, PtyExitedEvent } from '../types'
 import type { Terminal as XTerm } from '@xterm/xterm'
 import type { FitAddon } from '@xterm/addon-fit'
+import type { SearchAddon } from '@xterm/addon-search'
 
 // ---------------------------------------------------------------------------
 // Store
@@ -22,6 +23,7 @@ const [terminalExitCodes, setTerminalExitCodes] = createSignal<Record<string, nu
 export interface XtermEntry {
   term: XTerm
   fitAddon: FitAddon
+  searchAddon?: SearchAddon
 }
 const xtermInstances = new Map<string, XtermEntry>()
 
@@ -67,8 +69,8 @@ export function setActiveTerminalForTask(taskId: string, terminalId: string | nu
 // xterm instance registry
 // ---------------------------------------------------------------------------
 
-export function registerXterm(terminalId: string, term: XTerm, fitAddon: FitAddon) {
-  xtermInstances.set(terminalId, { term, fitAddon })
+export function registerXterm(terminalId: string, term: XTerm, fitAddon: FitAddon, searchAddon?: SearchAddon) {
+  xtermInstances.set(terminalId, { term, fitAddon, searchAddon })
 }
 
 export function getXtermEntry(terminalId: string): XtermEntry | undefined {


### PR DESCRIPTION
## Summary
- Adds text search (Cmd+F / Ctrl+F) to shell terminals using `@xterm/addon-search`
- Search overlay with incremental find, Enter/Shift+Enter to navigate matches, Escape to dismiss
- `SearchAddon` stored in `XtermEntry` so it persists across terminal reparenting (task switches)

Closes #49

## Test plan
- [ ] Open a shell terminal, run some commands to generate output
- [ ] Press Cmd+F - search bar appears in top-right
- [ ] Type a query - matches highlight incrementally
- [ ] Press Enter to jump to next match, Shift+Enter for previous
- [ ] Press Escape - search bar closes, highlights clear, terminal refocuses
- [ ] Switch tasks and back - search addon still works on the reparented terminal