### PR TITLE
fix: setup script opens terminal in wrong task after navigating away

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix setup script opening a terminal in the wrong task when the user navigates away before the hook starts - terminal panel now only auto-shows if the task is still selected
 - Fix clicking a notification not selecting the source task - visibility change was clearing the nav map before the click handler could consume it
 - Fix single-line text selection invisible in code editor - active line highlight now suppresses when text is selected so drawSelection's selection layer is visible
 - Rewrote bash policy engine to use AST-based shell parsing (yash-syntax) instead of substring matching - handles compound commands, subshells, combined flags, and wrapper programs (env, sudo, bash -c)

--- a/src/store/setup.ts
+++ b/src/store/setup.ts
@@ -3,7 +3,7 @@ import { listen } from '@tauri-apps/api/event'
 import type { Attachment } from '../types'
 import * as ipc from '../lib/ipc'
 import { registerHookTerminal } from './terminals'
-import { setShowTerminal } from './ui'
+import { selectedTaskId, setShowTerminal } from './ui'
 import { isTaskOwnedByThisWindow } from '../lib/windowContext'
 
 interface SetupState {
@@ -56,7 +56,7 @@ export async function initSetupListeners() {
       if (terminalId) {
         const ht = (hookType === 'destroy' ? 'destroy' : 'setup') as 'setup' | 'destroy'
         registerHookTerminal(taskId, terminalId, ht)
-        setShowTerminal(true)
+        if (selectedTaskId() === taskId) setShowTerminal(true)
       }
     } else if (status === 'completed') {
       setSetupTasks(produce(store => { delete store[taskId] }))


### PR DESCRIPTION
## Summary
- Guard `setShowTerminal(true)` in the setup-hook listener to only fire when `selectedTaskId()` matches the hook's task
- Previously, navigating away from a newly created task before the setup hook started would open the terminal panel on the wrong (currently viewed) task

Closes #84

## Test plan
- [ ] Create a new task with a setup script, immediately switch to another task
- [ ] Verify the terminal panel does NOT auto-open on the navigated-to task
- [ ] Switch back to the original task and verify the setup terminal is registered there