### PR TITLE
fix: notification click navigation (#87)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix clicking a notification not selecting the source task - visibility change was clearing the nav map before the click handler could consume it
 - Fix single-line text selection invisible in code editor - active line highlight now suppresses when text is selected so drawSelection's selection layer is visible
 - Rewrote bash policy engine to use AST-based shell parsing (yash-syntax) instead of substring matching - handles compound commands, subshells, combined flags, and wrapper programs (env, sudo, bash -c)
 - Normal mode now blocks destructive git ops: branch delete, worktree remove/prune, stash drop/clear, tag delete, remote remove, reflog expire, gc --prune, filter-branch, update-ref -d, push --force-with-lease

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -87,7 +87,6 @@ export function consumePendingNav(id: number): { taskId: string; sessionId: stri
 }
 
 export function clearDeliveredNotifications() {
-  pendingNavMap.clear()
   removeAllActive().catch(() => {})
 }
 


### PR DESCRIPTION
## Summary

- Fixes clicking a notification not navigating to the source task

## Root cause

When a notification is clicked, the OS brings the app to the foreground — firing `visibilitychange` before `onNotificationClicked`. The `visibilitychange` handler was calling `clearDeliveredNotifications()` which wiped `pendingNavMap`, so by the time the click handler ran, the nav data was gone.

## Fix

Stop clearing `pendingNavMap` in `clearDeliveredNotifications`. Map entries self-clean when consumed by `consumePendingNav` on click. The map stays small (throttled to 1 notification/sec) so there's no memory concern.

Closes #87