### PR TITLE
fix: step edit state persists or resets correctly when switching tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix clicking a notification not selecting the source task - visibility change was clearing the nav map before the click handler could consume it
+- Fix step edit highlight persisting when switching tasks - clear editing state on session change
 - Fix single-line text selection invisible in code editor - active line highlight now suppresses when text is selected so drawSelection's selection layer is visible
 - Rewrote bash policy engine to use AST-based shell parsing (yash-syntax) instead of substring matching - handles compound commands, subshells, combined flags, and wrapper programs (env, sudo, bash -c)
 - Normal mode now blocks destructive git ops: branch delete, worktree remove/prune, stash drop/clear, tag delete, remote remove, reflog expire, gc --prune, filter-branch, update-ref -d, push --force-with-lease

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -426,6 +426,12 @@ export const MessageInput: Component<Props> = (props) => {
   // Restore persisted draft when the visible session changes
   createEffect(on(() => props.sessionId, (sid) => {
     if (!sid) return
+    if (editingStepId() !== null || editingMessageIdx() !== null) {
+      setEditingMessageIdx(null)
+      setEditingStepId(null)
+      setSavedDraft('')
+      setSavedDraftAttachments([])
+    }
     if (!sessionMessages()[sid]) {
       const savedMsg = localStorage.getItem(`verun:draft-msg:${sid}`)
       if (savedMsg) setSessionMessages(prev => ({ ...prev, [sid]: savedMsg }))

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -377,6 +377,10 @@ export const MessageInput: Component<Props> = (props) => {
   const [savedDraft, setSavedDraft] = createSignal<string>('')
   const [savedDraftAttachments, setSavedDraftAttachments] = createSignal<Attachment[]>([])
 
+  // Per-session edit state so switching tasks preserves in-progress edits
+  type SessionEditState = { messageIdx: number | null; stepId: string | null; draft: string; draftAttachments: Attachment[] }
+  const sessionEditStates = new Map<string, SessionEditState>()
+
   // React to edit requests from StepList (clicking Edit on a step)
   createEffect(on(editStepRequest, (req) => {
     if (!req) return
@@ -424,14 +428,33 @@ export const MessageInput: Component<Props> = (props) => {
   }))
 
   // Restore persisted draft when the visible session changes
+  let prevSessionId: string | undefined
   createEffect(on(() => props.sessionId, (sid) => {
     if (!sid) return
-    if (editingStepId() !== null || editingMessageIdx() !== null) {
+    // Save edit state for the session we're leaving
+    if (prevSessionId && (editingStepId() !== null || editingMessageIdx() !== null)) {
+      sessionEditStates.set(prevSessionId, {
+        messageIdx: editingMessageIdx(),
+        stepId: editingStepId(),
+        draft: savedDraft(),
+        draftAttachments: savedDraftAttachments(),
+      })
+    }
+    // Restore edit state for the session we're entering, or clear
+    const saved = sessionEditStates.get(sid)
+    if (saved) {
+      sessionEditStates.delete(sid)
+      setEditingMessageIdx(saved.messageIdx)
+      setEditingStepId(saved.stepId)
+      setSavedDraft(saved.draft)
+      setSavedDraftAttachments(saved.draftAttachments)
+    } else {
       setEditingMessageIdx(null)
       setEditingStepId(null)
       setSavedDraft('')
       setSavedDraftAttachments([])
     }
+    prevSessionId = sid
     if (!sessionMessages()[sid]) {
       const savedMsg = localStorage.getItem(`verun:draft-msg:${sid}`)
       if (savedMsg) setSessionMessages(prev => ({ ...prev, [sid]: savedMsg }))


### PR DESCRIPTION
## Summary

- When switching away from a task mid-edit, the edit state (step ID, draft, saved attachments) is now saved per-session in a `Map`
- Switching back to that task restores the amber highlight and edit context exactly where it was left
- Switching to a task with no in-progress edit shows a clean composer

Closes #86