### PR TITLE
fix: primary git action icon not updating on task switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix clicking a notification not selecting the source task - visibility change was clearing the nav map before the click handler could consume it
 - Fix step edit highlight persisting when switching tasks - clear editing state on session change
 - Fix clicking arrow button while editing a step adding a duplicate instead of saving the edit - edit controls now render regardless of session running state
+- Fix primary git action icon not updating when switching tasks - use Dynamic component for reactive icon rendering
 - Fix single-line text selection invisible in code editor - active line highlight now suppresses when text is selected so drawSelection's selection layer is visible
 - Rewrote bash policy engine to use AST-based shell parsing (yash-syntax) instead of substring matching - handles compound commands, subshells, combined flags, and wrapper programs (env, sudo, bash -c)
 - Normal mode now blocks destructive git ops: branch delete, worktree remove/prune, stash drop/clear, tag delete, remote remove, reflog expire, gc --prune, filter-branch, update-ref -d, push --force-with-lease

--- a/src/components/GitActions.tsx
+++ b/src/components/GitActions.tsx
@@ -1,4 +1,5 @@
 import { Component, createSignal, createEffect, on, Show, For, onCleanup } from 'solid-js'
+import { Dynamic } from 'solid-js/web'
 import { ArrowUpFromLine, Download, GitPullRequest, GitMerge, Swords, Wrench, Search, ExternalLink, CircleCheck, CircleX, Clock, Circle, ChevronDown, Loader2, Eye, Archive } from 'lucide-solid'
 import { openUrl } from '@tauri-apps/plugin-opener'
 import * as ipc from '../lib/ipc'
@@ -251,8 +252,7 @@ export const GitActions: Component<Props> = (props) => {
   const hasAnything = () => hasOpenPr() || prMerged() || (!prDone() && (commitCount() > 0 || isBehind())) || fileCount() > 0
 
   const PrimaryIcon = () => {
-    const Icon = primaryAction().icon
-    return <Icon size={12} />
+    return <Dynamic component={primaryAction().icon} size={12} />
   }
 
   return (


### PR DESCRIPTION
## Summary

- `PrimaryIcon` captured `primaryAction().icon` once in the component body via `const Icon = ...`, which never re-evaluated in Solid.js since components run once
- Replaced with `<Dynamic component={primaryAction().icon} size={12} />` so the icon tracks reactive git state changes when switching tasks

Closes #78