### PR TITLE
fix: reset input height after sending a message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Session input textarea now shrinks back to default height after sending a message
 - Gemini CLI agent: `gemini --output-format stream-json --yolo`, plan mode, model selection, resume, attachments; stream parser handles `message`, `tool_use`, `tool_result`, and `result` event types
 - New session menu agent order matches new task dropdown (default agent first, then alphabetical); accepts `defaultAgent` prop from TaskPanel
 

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -377,6 +377,7 @@ export const MessageInput: Component<Props> = (props) => {
         setInputContent(v)
         setCursorToEnd()
       }
+      autoResizeInput()
     }
   }
   const attachments = () => sessionAttachments()[props.sessionId ?? ''] ?? []


### PR DESCRIPTION
## Summary
- `setMessage('')` cleared the contenteditable text but never called `autoResizeInput()`, leaving the textarea at its expanded height
- Added `autoResizeInput()` call inside `setMessage` after DOM sync so height resets on any programmatic change

Closes #102

## Test plan
- [ ] Type a multi-line message, send it, verify the input shrinks back to default height
- [ ] Verify auto-grow still works when typing long messages
- [ ] Verify switching tasks still resets input height