### PR TITLE
Persist last open session per task across navigation and restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - Session input textarea now shrinks back to default height after sending a message
+- Persist last open session per task across navigation and restarts via localStorage
+
 - Gemini CLI agent: `gemini --output-format stream-json --yolo`, plan mode, model selection, resume, attachments; stream parser handles `message`, `tool_use`, `tool_result`, and `result` event types
 - New session menu agent order matches new task dropdown (default agent first, then alphabetical); accepts `defaultAgent` prop from TaskPanel
 

--- a/src/components/TaskPanel.tsx
+++ b/src/components/TaskPanel.tsx
@@ -1,5 +1,5 @@
 import { Component, Show, For, createEffect, on, createSignal, onCleanup } from 'solid-js'
-import { selectedTaskId, selectedSessionId, setSelectedSessionId, setSelectedProjectId, addToast, showTerminal, setShowTerminal, setShowSettings, toggleTerminal, terminalHeight, setTerminalHeightAndPersist, isSessionUnread, clearSessionUnread, rightPanelWidth, setRightPanelWidth, consumePendingSessionNav } from '../store/ui'
+import { selectedTaskId, selectedSessionId, setSelectedSessionId, setSelectedProjectId, addToast, showTerminal, setShowTerminal, setShowSettings, toggleTerminal, terminalHeight, setTerminalHeightAndPersist, isSessionUnread, clearSessionUnread, rightPanelWidth, setRightPanelWidth, consumePendingSessionNav, getLastSessionForTask } from '../store/ui'
 import { refitActiveTerminal, setActiveTerminalForTask, startCommandTerminalId, isStartCommandRunning, spawnStartCommand, stopStartCommand } from '../store/terminals'
 import { projects, addProject, projectById } from '../store/projects'
 import { open as openDialog } from '@tauri-apps/plugin-dialog'
@@ -148,10 +148,15 @@ export const TaskPanel: Component = () => {
       const taskSessions = sessionsForTask(taskId)
       if (pending && taskSessions.some(s => s.id === pending)) {
         setSelectedSessionId(pending)
-      } else if (taskSessions.length > 0) {
-        setSelectedSessionId(taskSessions[0].id)
       } else {
-        setSelectedSessionId(null)
+        const last = getLastSessionForTask(taskId)
+        if (last && taskSessions.some(s => s.id === last)) {
+          setSelectedSessionId(last)
+        } else if (taskSessions.length > 0) {
+          setSelectedSessionId(taskSessions[0].id)
+        } else {
+          setSelectedSessionId(null)
+        }
       }
       // Start LSP eagerly so project-wide diagnostics populate the problems
       // panel without waiting for the user to open a file in the editor.

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -12,7 +12,33 @@ export function setSelectedTaskId(id: string | null) {
   else localStorage.removeItem('verun:selectedTaskId')
 }
 
-export const [selectedSessionId, setSelectedSessionId] = createSignal<string | null>(null)
+const LAST_SESSION_KEY = 'verun:lastSessionPerTask'
+
+function loadLastSessionMap(): Record<string, string> {
+  try {
+    const raw = typeof localStorage !== 'undefined' ? localStorage.getItem(LAST_SESSION_KEY) : null
+    return raw ? JSON.parse(raw) : {}
+  } catch { return {} }
+}
+
+export function getLastSessionForTask(taskId: string): string | null {
+  return loadLastSessionMap()[taskId] ?? null
+}
+
+export function setLastSessionForTask(taskId: string, sessionId: string | null) {
+  const map = loadLastSessionMap()
+  if (sessionId) map[taskId] = sessionId
+  else delete map[taskId]
+  localStorage.setItem(LAST_SESSION_KEY, JSON.stringify(map))
+}
+
+const [_selectedSessionId, _setSelectedSessionId] = createSignal<string | null>(null)
+export const selectedSessionId = _selectedSessionId
+export function setSelectedSessionId(id: string | null) {
+  _setSelectedSessionId(id)
+  const taskId = selectedTaskId()
+  if (taskId) setLastSessionForTask(taskId, id)
+}
 
 // When set, the next task-selection effect should navigate to this session
 // instead of defaulting to the first one. Consumed (cleared) after use.

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -12,24 +12,13 @@ export function setSelectedTaskId(id: string | null) {
   else localStorage.removeItem('verun:selectedTaskId')
 }
 
-const LAST_SESSION_KEY = 'verun:lastSessionPerTask'
-
-function loadLastSessionMap(): Record<string, string> {
-  try {
-    const raw = typeof localStorage !== 'undefined' ? localStorage.getItem(LAST_SESSION_KEY) : null
-    return raw ? JSON.parse(raw) : {}
-  } catch { return {} }
-}
-
 export function getLastSessionForTask(taskId: string): string | null {
-  return loadLastSessionMap()[taskId] ?? null
+  return typeof localStorage !== 'undefined' ? localStorage.getItem(`verun:lastSession:${taskId}`) : null
 }
 
 export function setLastSessionForTask(taskId: string, sessionId: string | null) {
-  const map = loadLastSessionMap()
-  if (sessionId) map[taskId] = sessionId
-  else delete map[taskId]
-  localStorage.setItem(LAST_SESSION_KEY, JSON.stringify(map))
+  if (sessionId) localStorage.setItem(`verun:lastSession:${taskId}`, sessionId)
+  else localStorage.removeItem(`verun:lastSession:${taskId}`)
 }
 
 const [_selectedSessionId, _setSelectedSessionId] = createSignal<string | null>(null)


### PR DESCRIPTION
Closes #96

## What changed

When switching tasks or restarting the app, Verun now restores the last selected session tab instead of always defaulting to the first one.

## Implementation

- `setSelectedSessionId` now writes `verun:lastSession:<taskId>` to localStorage on every call (zero changes needed at call sites)
- On task switch, the effect in `TaskPanel` checks the persisted key before falling back to `sessions[0]`
- Uses one key per task (not a single JSON map) to avoid parse overhead and write races between windows