### PR TITLE
Show provider errors inline in chat with retry options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 - Gemini CLI agent: `gemini --output-format stream-json --yolo`, plan mode, model selection, resume, attachments; stream parser handles `message`, `tool_use`, `tool_result`, and `result` event types
 - New session menu agent order matches new task dropdown (default agent first, then alphabetical); accepts `defaultAgent` prop from TaskPanel
+- Provider error messages shown inline in chat with Retry / Retry in new session buttons; retries preserve model, plan/thinking/fast modes
+- Worktree path shown after task name in header - click to copy to clipboard with info toast
 
 - Model search bar in ModelSelector and NewSessionMenu submenus for agents with >10 models - filters by label/id, auto-focuses, clears on close
 
@@ -22,6 +24,7 @@
 - Fix step edit highlight persisting when switching tasks - clear editing state on session change
 - Fix clicking arrow button while editing a step adding a duplicate instead of saving the edit - edit controls now render regardless of session running state
 - Fix primary git action icon not updating when switching tasks - use Dynamic component for reactive icon rendering
+- Show provider errors inline in chat with the actual error message and Retry / Retry in new session buttons - error message is extracted from the Claude CLI result event and propagated through SessionStatusEvent
 - Fix single-line text selection invisible in code editor - active line highlight now suppresses when text is selected so drawSelection's selection layer is visible
 - Rewrote bash policy engine to use AST-based shell parsing (yash-syntax) instead of substring matching - handles compound commands, subshells, combined flags, and wrapper programs (env, sudo, bash -c)
 - Normal mode now blocks destructive git ops: branch delete, worktree remove/prune, stash drop/clear, tag delete, remote remove, reflog expire, gc --prune, filter-branch, update-ref -d, push --force-with-lease

--- a/src-tauri/src/stream.rs
+++ b/src-tauri/src/stream.rs
@@ -60,6 +60,7 @@ pub enum OutputItem {
         output_tokens: Option<u64>,
         cache_read_tokens: Option<u64>,
         cache_write_tokens: Option<u64>,
+        error: Option<String>,
     },
 
     /// Per-turn snapshot marker — frontend attaches the message uuid to the
@@ -78,6 +79,7 @@ pub enum OutputItem {
 pub struct SessionStatusEvent {
     pub session_id: String,
     pub status: String,
+    pub error: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -209,7 +211,14 @@ fn parse_sdk_event(line: &str) -> Vec<OutputItem> {
             let cache_write_tokens = usage.and_then(|u|
                 u.get("cache_creation_input_tokens").or_else(|| u.get("cacheWriteTokens"))
             ).and_then(|t| t.as_u64());
-            vec![OutputItem::TurnEnd { status: status.to_string(), cost, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens }]
+            let error = if status == "error" {
+                v.get("error")
+                    .and_then(|e| e.as_str())
+                    .map(|s| s.to_string())
+            } else {
+                None
+            };
+            vec![OutputItem::TurnEnd { status: status.to_string(), cost, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, error }]
         }
 
         // -- Telemetry events we can surface --
@@ -323,7 +332,7 @@ fn parse_sdk_event(line: &str) -> Vec<OutputItem> {
             let input_tokens = usage.and_then(|u| u.get("input_tokens")).and_then(|t| t.as_u64());
             let output_tokens = usage.and_then(|u| u.get("output_tokens")).and_then(|t| t.as_u64());
             let cache_read_tokens = usage.and_then(|u| u.get("cached_input_tokens")).and_then(|t| t.as_u64());
-            vec![OutputItem::TurnEnd { status: "completed".to_string(), cost: None, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens: None }]
+            vec![OutputItem::TurnEnd { status: "completed".to_string(), cost: None, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens: None, error: None }]
         }
 
         // Ignored Codex lifecycle events
@@ -392,7 +401,7 @@ fn parse_sdk_event(line: &str) -> Vec<OutputItem> {
                 let cache_read_tokens = cache.and_then(|c| c.get("read")).and_then(|t| t.as_u64());
                 let cache_write_tokens = cache.and_then(|c| c.get("write")).and_then(|t| t.as_u64());
                 let cost = part.and_then(|p| p.get("cost")).and_then(|c| c.as_f64()).filter(|c| *c > 0.0);
-                vec![OutputItem::TurnEnd { status: "completed".to_string(), cost, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens }]
+                vec![OutputItem::TurnEnd { status: "completed".to_string(), cost, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, error: None }]
             } else {
                 vec![]
             }
@@ -633,6 +642,7 @@ fn extract_cursor_tool_result(tc: &serde_json::Map<String, serde_json::Value>) -
 
 pub struct StreamResult {
     pub total_cost: f64,
+    pub error: Option<String>,
 }
 
 /// After a turn ends, snapshot the worktree and persist a `turn_snapshots`
@@ -785,6 +795,7 @@ pub async fn stream_and_capture(
     let mut last_flush = Instant::now();
     let mut total_persisted: usize = 0;
     let mut total_cost: f64 = 0.0;
+    let mut last_error: Option<String> = None;
     // Captured from `system.init` events for the per-turn snapshot hook.
     let mut resume_id_for_snapshot: Option<String> = None;
 
@@ -861,10 +872,13 @@ pub async fn stream_and_capture(
                                     emit_item(&app, &session_id, item.clone());
                                     has_immediate = true;
                                 }
-                                OutputItem::TurnEnd { cost, .. } => {
+                                OutputItem::TurnEnd { cost, error: ref err, .. } => {
                                     is_turn_end = true;
                                     if let Some(c) = cost {
                                         total_cost += *c;
+                                    }
+                                    if err.is_some() {
+                                        last_error.clone_from(err);
                                     }
                                     buffer.push(item.clone());
                                 }
@@ -931,7 +945,7 @@ pub async fn stream_and_capture(
     }
 
     flush_buffer(&app, &session_id, &mut buffer);
-    StreamResult { total_cost }
+    StreamResult { total_cost, error: last_error }
 }
 
 /// Check if a line is a `control_request` for tool approval.
@@ -1247,11 +1261,12 @@ mod tests {
         let items = parse_sdk_event(line);
         assert_eq!(items.len(), 1);
         match &items[0] {
-            OutputItem::TurnEnd { status, cost, input_tokens, output_tokens, .. } => {
+            OutputItem::TurnEnd { status, cost, input_tokens, output_tokens, error, .. } => {
                 assert_eq!(status, "completed");
                 assert_eq!(*cost, Some(0.042));
                 assert_eq!(*input_tokens, Some(100));
                 assert_eq!(*output_tokens, Some(50));
+                assert!(error.is_none());
             }
             _ => panic!("Expected TurnEnd item"),
         }
@@ -1267,6 +1282,20 @@ mod tests {
                 assert_eq!(*cost, None);
                 assert_eq!(*input_tokens, None);
                 assert_eq!(*output_tokens, None);
+            }
+            _ => panic!("Expected TurnEnd item"),
+        }
+    }
+
+    #[test]
+    fn parse_result_error_with_message() {
+        let line = r#"{"type":"result","subtype":"error","error":"API Error: 529 overloaded","session_id":"abc"}"#;
+        let items = parse_sdk_event(line);
+        assert_eq!(items.len(), 1);
+        match &items[0] {
+            OutputItem::TurnEnd { status, error, .. } => {
+                assert_eq!(status, "error");
+                assert_eq!(error.as_deref(), Some("API Error: 529 overloaded"));
             }
             _ => panic!("Expected TurnEnd item"),
         }
@@ -1305,6 +1334,7 @@ mod tests {
         let event = SessionStatusEvent {
             session_id: "s-001".into(),
             status: "done".into(),
+            error: None,
         };
         let json = serde_json::to_value(&event).unwrap();
         assert_eq!(json["sessionId"], "s-001");

--- a/src-tauri/src/task.rs
+++ b/src-tauri/src/task.rs
@@ -792,6 +792,7 @@ pub async fn send_message(
         stream::SessionStatusEvent {
             session_id: session_id.clone(),
             status: "running".to_string(),
+            error: None,
         },
     );
 
@@ -899,11 +900,17 @@ pub async fn send_message(
                 .await;
         }
 
+        let error_msg = if final_status == "error" {
+            stream_result.error.or_else(|| Some("Session exited unexpectedly".to_string()))
+        } else {
+            None
+        };
         let _ = monitor_app.emit(
             "session-status",
             stream::SessionStatusEvent {
                 session_id: monitor_sid,
                 status: final_status.to_string(),
+                error: error_msg,
             },
         );
 
@@ -942,6 +949,7 @@ pub async fn abort_message(
             stream::SessionStatusEvent {
                 session_id: session_id.to_string(),
                 status: "idle".to_string(),
+                error: None,
             },
         );
     }

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -3,7 +3,7 @@ import { createStore, produce, reconcile } from 'solid-js/store'
 import { clsx } from 'clsx'
 import { renderMarkdown, handleMarkdownLinkClick, getWorktreePath } from '../lib/markdown'
 import type { OutputItem, SessionStatus } from '../types'
-import { ChevronDown, ChevronRight, AlertTriangle, Copy, Check, ArrowUp, ArrowDown, X, GitBranch } from 'lucide-solid'
+import { ChevronDown, ChevronRight, AlertTriangle, Copy, Check, ArrowUp, ArrowDown, X, GitBranch, RotateCw, Plus } from 'lucide-solid'
 import { FileMentionBadge } from './FileMentionBadge'
 import { ImageViewer } from './ImageViewer'
 import { BlobImage } from './BlobImage'
@@ -11,7 +11,7 @@ import { parseMentions } from '../lib/mentions'
 import { Popover } from './Popover'
 import * as ipc from '../lib/ipc'
 import { addToast, setSelectedTaskId, setSelectedSessionId } from '../store/ui'
-import { setSessions, loadOutputLines } from '../store/sessions'
+import { setSessions, loadOutputLines, sendMessage, createSession, taskPlanMode, taskThinkingMode, taskFastMode } from '../store/sessions'
 import { setTasks } from '../store/tasks'
 
 function formatDuration(ms: number): string {
@@ -53,8 +53,11 @@ function renderMarkdownForTask(text: string, taskId?: string): string {
 interface Props {
   output: OutputItem[]
   sessionStatus?: SessionStatus
+  sessionError?: string
   sessionId?: string | null
   taskId?: string
+  agentType?: string
+  model?: string | null
 }
 
 // ---------------------------------------------------------------------------
@@ -594,6 +597,94 @@ function clearHighlights(container: HTMLElement) {
 const savedScrollPositions = new Map<string, { scrollTop: number; autoScroll: boolean }>()
 
 // ---------------------------------------------------------------------------
+// Error banner with retry actions
+// ---------------------------------------------------------------------------
+
+function getLastUserMessage(output: OutputItem[]): string | undefined {
+  for (let i = output.length - 1; i >= 0; i--) {
+    if (output[i].kind === 'userMessage') return (output[i] as { kind: 'userMessage'; text: string }).text
+  }
+  return undefined
+}
+
+const ErrorBanner: Component<{
+  error?: string
+  output: OutputItem[]
+  sessionId?: string | null
+  taskId?: string
+  agentType?: string
+  model?: string | null
+}> = (props) => {
+  const [retrying, setRetrying] = createSignal(false)
+  const lastMessage = () => getLastUserMessage(props.output)
+
+  const modeArgs = (): [string | undefined, boolean | undefined, boolean | undefined, boolean | undefined] => {
+    const tid = props.taskId
+    return [
+      props.model ?? undefined,
+      tid ? taskPlanMode[tid] ?? undefined : undefined,
+      tid ? taskThinkingMode[tid] ?? undefined : undefined,
+      tid ? taskFastMode[tid] ?? undefined : undefined,
+    ]
+  }
+
+  const retry = async () => {
+    const msg = lastMessage()
+    if (!msg || !props.sessionId) return
+    setRetrying(true)
+    try {
+      const [model, plan, thinking, fast] = modeArgs()
+      await sendMessage(props.sessionId, msg, undefined, model, plan, thinking, fast)
+    } catch { /* status will update via event */ }
+    setRetrying(false)
+  }
+
+  const retryNewSession = async () => {
+    const msg = lastMessage()
+    if (!msg || !props.taskId) return
+    setRetrying(true)
+    try {
+      const session = await createSession(props.taskId, props.agentType ?? 'claude', props.model ?? undefined)
+      setSelectedSessionId(session.id)
+      const [model, plan, thinking, fast] = modeArgs()
+      await sendMessage(session.id, msg, undefined, model, plan, thinking, fast)
+    } catch { /* status will update via event */ }
+    setRetrying(false)
+  }
+
+  return (
+    <div class="mx-5 flex flex-col gap-2 px-3 py-2.5 rounded-lg bg-status-error/8 ring-1 ring-status-error/15">
+      <div class="flex items-start gap-2">
+        <AlertTriangle size={14} class="text-status-error shrink-0 mt-0.5" />
+        <span class="text-xs text-status-error">
+          {props.error || 'Session encountered an error'}
+        </span>
+      </div>
+      <Show when={lastMessage()}>
+        <div class="flex items-center gap-2 ml-5.5">
+          <button
+            class="flex items-center gap-1.5 px-2.5 py-1 rounded-md text-[11px] font-medium bg-status-error/12 text-status-error hover:bg-status-error/20 transition-colors disabled:opacity-50"
+            onClick={retry}
+            disabled={retrying()}
+          >
+            <RotateCw size={11} />
+            Retry
+          </button>
+          <button
+            class="flex items-center gap-1.5 px-2.5 py-1 rounded-md text-[11px] font-medium bg-surface-2 text-text-secondary hover:bg-surface-3 transition-colors disabled:opacity-50"
+            onClick={retryNewSession}
+            disabled={retrying()}
+          >
+            <Plus size={11} />
+            Retry in new session
+          </button>
+        </div>
+      </Show>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
 // Main ChatView
 // ---------------------------------------------------------------------------
 
@@ -851,13 +942,6 @@ export const ChatView: Component<Props> = (props) => {
         onClick={handleLinkClick}
       >
       <div ref={contentRef} class="flex flex-col gap-2 pt-4 pb-6">
-        <Show when={props.sessionStatus === 'error'}>
-          <div class="mx-5 flex items-center gap-2 px-3 py-2 rounded-lg bg-status-error/8 border border-status-error/15">
-            <AlertTriangle size={14} class="text-status-error shrink-0" />
-            <span class="text-xs text-status-error">Session encountered an error. Create a new session to continue.</span>
-          </div>
-        </Show>
-
         <For each={blocks}>
           {(block) => (
             <Switch>
@@ -966,6 +1050,17 @@ export const ChatView: Component<Props> = (props) => {
             </Switch>
           )}
         </For>
+
+        <Show when={props.sessionStatus === 'error'}>
+          <ErrorBanner
+            error={props.sessionError}
+            output={props.output}
+            sessionId={props.sessionId}
+            taskId={props.taskId}
+            agentType={props.agentType}
+            model={props.model}
+          />
+        </Show>
 
         <Show when={props.sessionStatus === 'running'}>
           <div class="px-5 py-2">

--- a/src/components/TaskPanel.tsx
+++ b/src/components/TaskPanel.tsx
@@ -301,9 +301,21 @@ export const TaskPanel: Component = () => {
               <div class="flex flex-col flex-1 min-w-0 overflow-hidden bg-surface-1">
                 {/* Header — drag region for titlebar */}
                 <div class="px-4 pt-8 pb-2 flex items-center justify-between bg-surface-1 drag-region" data-tauri-drag-region>
-                  <h2 class="text-[13px] font-medium text-text-primary truncate min-w-0 no-drag">
-                    {t().name || 'New task'}
-                  </h2>
+                  <div class="flex items-center gap-2 min-w-0 no-drag">
+                    <h2 class="text-[13px] font-medium text-text-primary truncate shrink-0">
+                      {t().name || 'New task'}
+                    </h2>
+                    <button
+                      class="text-[11px] text-text-tertiary hover:text-text-secondary truncate min-w-0 transition-colors"
+                      title="Click to copy path"
+                      onClick={() => {
+                        navigator.clipboard.writeText(t().worktreePath)
+                        addToast('Path copied to clipboard', 'info')
+                      }}
+                    >
+                      {t().worktreePath.split('/').slice(-2).join('/')}
+                    </button>
+                  </div>
                   <Show when={!creating() && !error()}>
                     <div class="flex items-center gap-2 no-drag shrink-0">
                       <OpenInButton path={t().worktreePath} />
@@ -607,8 +619,11 @@ export const TaskPanel: Component = () => {
                             <ChatView
                               output={currentOutput()}
                               sessionStatus={currentSession()?.status}
+                              sessionError={currentSession()?.error}
                               sessionId={selectedSessionId()}
                               taskId={t().id}
+                              agentType={currentSession()?.agentType}
+                              model={currentSession()?.model}
                             />
                           </div>
                           <Show

--- a/src/store/sessions.ts
+++ b/src/store/sessions.ts
@@ -167,13 +167,15 @@ export async function closeSession(sessionId: string) {
 }
 
 export async function loadOutputLines(sessionId: string) {
-  setOutputItems(sessionId, [])
   const lines = await ipc.getOutputLines(sessionId)
   const items: OutputItem[] = []
   for (const l of lines) {
     const parsed = parseNdjsonLine(l.line, l.emittedAt)
     if (parsed) items.push(...parsed)
   }
+  // Don't overwrite live items (from sendMessage/streaming) when DB returned nothing
+  const current = outputItems[sessionId]
+  if (current && current.length > 0 && items.length === 0) return
   setOutputItems(sessionId, items)
   // Accumulate costs + tokens from replayed output
   let replayCost = 0
@@ -326,10 +328,11 @@ export async function initSessionListeners() {
   })
 
   await listen<SessionStatusEvent>('session-status', (event) => {
-    const { sessionId, status } = event.payload
+    const { sessionId, status, error } = event.payload
     const prevSession = sessions.find(s => s.id === sessionId)
     const wasRunning = prevSession?.status === 'running'
     setSessions(s => s.id === sessionId, 'status', status)
+    setSessions(s => s.id === sessionId, 'error', status === 'error' ? error : undefined)
     // Clear pending approvals when session stops running
     if (status !== 'running') {
       setPendingApprovals(produce(store => { delete store[sessionId] }))

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -45,6 +45,7 @@ export interface Session {
   name: string | null
   resumeSessionId: string | null
   status: SessionStatus
+  error?: string
   startedAt: number
   endedAt: number | null
   totalCost: number
@@ -130,7 +131,7 @@ export type OutputItem =
   | { kind: 'toolStart'; tool: string; input: string }
   | { kind: 'toolResult'; text: string; isError: boolean }
   | { kind: 'system'; text: string }
-  | { kind: 'turnEnd'; status: string; timestamp?: number; cost?: number; inputTokens?: number; outputTokens?: number; cacheReadTokens?: number; cacheWriteTokens?: number }
+  | { kind: 'turnEnd'; status: string; timestamp?: number; cost?: number; inputTokens?: number; outputTokens?: number; cacheReadTokens?: number; cacheWriteTokens?: number; error?: string }
   | { kind: 'turnSnapshot'; messageUuid: string }
   | { kind: 'userMessage'; text: string; images?: Array<{ mimeType: string; data: Uint8Array }>; timestamp?: number }
   | { kind: 'raw'; text: string }
@@ -143,6 +144,7 @@ export interface SessionOutputEvent {
 export interface SessionStatusEvent {
   sessionId: string
   status: SessionStatus
+  error?: string
 }
 
 export interface RateLimitInfo {


### PR DESCRIPTION
Closes #82

## Summary

- Provider error messages (e.g. API overload, rate limit) now surface inline in the chat view with the actual error text instead of a generic banner
- Two retry buttons appear below the error: **Retry** (resend last message to the same session) and **Retry in new session** — both preserve the selected model and plan/thinking/fast modes
- Worktree path shown after the task name in the header; click it to copy the full path to clipboard with an info toast
- Fix: `loadOutputLines` was wiping the optimistic user message when switching to a newly-created session — now skips overwriting the store when it has live items but the DB returned nothing (race between `sendMessage` push and the async DB fetch)

## Changes

- `stream.rs` — extract `error` field from Claude CLI `result` events, propagate through `TurnEnd` and `StreamResult`
- `task.rs` — emit error message on `SessionStatusEvent` when status is `error`
- `types/index.ts` — add `error?: string` to `Session`, `OutputItem` turnEnd, `SessionStatusEvent`
- `store/sessions.ts` — store error on session; fix `loadOutputLines` race
- `ChatView.tsx` — inline `ErrorBanner` component with Retry / Retry in new session
- `TaskPanel.tsx` — pass error/agent/model props to ChatView; clickable worktree path in header

## Test plan

- [ ] Trigger a provider error (e.g. bad API key) — error text appears inline below the last message
- [ ] Click Retry — message is resent to the same session, model and modes preserved
- [ ] Click Retry in new session — new session created, message sent, user message visible immediately
- [ ] Click the worktree path in the header — path copied, info toast appears