### PR TITLE
feat: add Claude Opus 4.7 with minimum CLI version gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Claude Opus 4.7 model option with minimum CLI version gate (v2.1.111+); shows update dialog on older versions
+- Agent detection now exposes CLI version to frontend via `cliVersion` field
+
 ## 0.7.0 - 2026-04-15
 
 ### Changes

--- a/src-tauri/src/agent/claude.rs
+++ b/src-tauri/src/agent/claude.rs
@@ -18,6 +18,10 @@ impl Agent for Claude {
         "npm i -g @anthropic-ai/claude-code"
     }
 
+    fn update_hint(&self) -> &'static str {
+        "claude update"
+    }
+
     fn docs_url(&self) -> &'static str {
         "https://docs.anthropic.com/en/docs/claude-code/quickstart"
     }
@@ -25,6 +29,8 @@ impl Agent for Claude {
     fn available_models(&self) -> Vec<crate::agent::ModelOption> {
         use crate::agent::ModelOption;
         vec![
+            ModelOption::new("claude-opus-4-7", "Claude Opus 4.7", "Latest and most capable")
+                .with_min_version("2.1.111"),
             ModelOption::new("claude-opus-4-6", "Claude Opus 4.6", "Most capable for complex tasks"),
             ModelOption::new("claude-sonnet-4-6", "Claude Sonnet 4.6", "Best for everyday tasks"),
             ModelOption::new("claude-haiku-4-5", "Claude Haiku 4.5", "Fastest for quick answers"),

--- a/src-tauri/src/agent/mod.rs
+++ b/src-tauri/src/agent/mod.rs
@@ -75,15 +75,23 @@ impl std::fmt::Display for AgentKind {
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ModelOption {
     pub id: String,
     pub label: String,
     pub description: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min_version: Option<String>,
 }
 
 impl ModelOption {
     pub fn new(id: &str, label: &str, description: &str) -> Self {
-        Self { id: id.into(), label: label.into(), description: description.into() }
+        Self { id: id.into(), label: label.into(), description: description.into(), min_version: None }
+    }
+
+    pub fn with_min_version(mut self, version: &str) -> Self {
+        self.min_version = Some(version.into());
+        self
     }
 }
 
@@ -136,6 +144,10 @@ pub trait Agent: Send + Sync {
 
     /// Human-readable install instructions.
     fn install_hint(&self) -> &'static str;
+
+    /// Command to update the CLI to the latest version.
+    /// Defaults to `install_hint` if not overridden.
+    fn update_hint(&self) -> &'static str { self.install_hint() }
 
     /// Static fallback model list (first = default). Used when dynamic listing
     /// is unavailable or fails.

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -1593,10 +1593,9 @@ pub fn detect_all_agents() -> Vec<AgentInfo> {
         .iter()
         .map(|&kind| {
             let agent = kind.implementation();
-            let installed = check_agent_impl(&*agent).is_ok();
+            let cli_version = check_agent_impl(&*agent).ok();
+            let installed = cli_version.is_some();
 
-            // For installed agents, try to fetch the live model list.
-            // Fall back to the static list if the command fails or returns nothing.
             let models = if installed {
                 agent.model_list_args()
                     .and_then(|args| {
@@ -1616,9 +1615,11 @@ pub fn detect_all_agents() -> Vec<AgentInfo> {
                 id: kind.as_str().to_string(),
                 name: agent.display_name().to_string(),
                 install_hint: agent.install_hint().to_string(),
+                update_hint: agent.update_hint().to_string(),
                 docs_url: agent.docs_url().to_string(),
                 models,
                 installed,
+                cli_version,
                 supports_streaming: agent.supports_streaming(),
                 supports_resume: agent.supports_resume(),
                 supports_plan_mode: agent.supports_plan_mode(),
@@ -1656,9 +1657,11 @@ pub struct AgentInfo {
     pub id: String,
     pub name: String,
     pub install_hint: String,
+    pub update_hint: String,
     pub docs_url: String,
     pub models: Vec<crate::agent::ModelOption>,
     pub installed: bool,
+    pub cli_version: Option<String>,
     pub supports_streaming: bool,
     pub supports_resume: bool,
     pub supports_plan_mode: bool,

--- a/src/components/ModelRow.tsx
+++ b/src/components/ModelRow.tsx
@@ -1,0 +1,39 @@
+import { Component, Show } from 'solid-js'
+import { clsx } from 'clsx'
+import type { ModelOption } from '../types'
+
+interface Props {
+  model: ModelOption
+  selected?: boolean
+  locked: boolean
+  onClick: () => void
+}
+
+export const ModelRow: Component<Props> = (props) => {
+  return (
+    <button
+      class={clsx(
+        'w-full text-left px-3 py-1.5 text-xs transition-colors',
+        props.locked
+          ? 'opacity-50'
+          : props.selected
+            ? 'text-accent bg-accent-muted'
+            : 'text-text-secondary hover:text-text-primary hover:bg-surface-3'
+      )}
+      onClick={props.onClick}
+    >
+      <div class="flex items-center gap-1.5">
+        <span class="font-medium">{props.model.label}</span>
+        <Show when={props.locked}>
+          <span class="text-[9px] px-1 py-px rounded bg-warning/15 text-warning leading-tight shrink-0">Update required</span>
+        </Show>
+      </div>
+      <Show when={props.locked && props.model.minVersion}>
+        <span class="block text-[10px] text-text-dim mt-0.5">Requires v{props.model.minVersion}+</span>
+      </Show>
+      <Show when={!props.locked && props.model.description}>
+        <span class="block text-[10px] text-text-dim mt-0.5">{props.model.description}</span>
+      </Show>
+    </button>
+  )
+}

--- a/src/components/ModelSelector.tsx
+++ b/src/components/ModelSelector.tsx
@@ -1,12 +1,14 @@
 import { Component, For, Show, createSignal, createEffect, createMemo } from 'solid-js'
 import { AGENT_DISPLAY_NAMES } from '../types'
-import type { ModelId, AgentType } from '../types'
+import type { ModelId, AgentType, ModelOption } from '../types'
 import { agents } from '../store/agents'
 import { ChevronDown, Search } from 'lucide-solid'
 import { clsx } from 'clsx'
 import { Popover } from './Popover'
-import { agentIcon } from '../lib/agents'
+import { agentIcon, meetsVersionReq } from '../lib/agents'
 import SvgIcon from './SvgIcon'
+import { ModelRow } from './ModelRow'
+import { UpdateRequiredDialog } from './UpdateRequiredDialog'
 
 const MODEL_SEARCH_THRESHOLD = 10
 
@@ -20,8 +22,10 @@ interface Props {
 export const ModelSelector: Component<Props> = (props) => {
   const [open, setOpen] = createSignal(false)
   const [query, setQuery] = createSignal('')
+  const [updateModel, setUpdateModel] = createSignal<ModelOption | null>(null)
 
   const agentInfo = () => agents.find(a => a.id === props.agentType)
+  const cliVersion = () => agentInfo()?.cliVersion
   const agentModels = () => agentInfo()?.models ?? []
   const agentSvg = () => agentIcon(props.agentType)
   const showSearch = () => agentModels().length > MODEL_SEARCH_THRESHOLD
@@ -34,7 +38,6 @@ export const ModelSelector: Component<Props> = (props) => {
     )
   })
 
-  // Resolved model: stored value if valid for this agent, else first in list
   const resolvedModel = createMemo(() => {
     const models = agentModels()
     if (models.length === 0) return props.model ?? undefined
@@ -42,7 +45,6 @@ export const ModelSelector: Component<Props> = (props) => {
     return match ? props.model! : models[0].id
   })
 
-  // Auto-correct stored model when agent changes and stored model isn't in list
   createEffect(() => {
     const resolved = resolvedModel()
     if (resolved && resolved !== props.model) {
@@ -50,7 +52,6 @@ export const ModelSelector: Component<Props> = (props) => {
     }
   })
 
-  // Clear search when popover closes
   createEffect(() => {
     if (!open()) setQuery('')
   })
@@ -58,6 +59,16 @@ export const ModelSelector: Component<Props> = (props) => {
   const currentOpt = () => {
     const models = agentModels()
     return models.find(m => m.id === resolvedModel()) ?? models[0]
+  }
+
+  const handleModelSelect = (opt: ModelOption) => {
+    if (opt.minVersion && !meetsVersionReq(cliVersion(), opt.minVersion)) {
+      setUpdateModel(opt)
+      setOpen(false)
+      return
+    }
+    props.onChange(opt.id)
+    setOpen(false)
   }
 
   return (
@@ -97,34 +108,28 @@ export const ModelSelector: Component<Props> = (props) => {
         </Show>
         <div class="max-h-52 overflow-y-auto">
         <For each={filteredModels()}>
-          {(opt) => {
-            const selected = () => resolvedModel() === opt.id
-            return (
-              <button
-                class={clsx(
-                  'w-full text-left px-3 py-1.5 text-xs transition-colors',
-                  selected()
-                    ? 'text-accent bg-accent-muted'
-                    : 'text-text-secondary hover:text-text-primary hover:bg-surface-3'
-                )}
-                onClick={() => {
-                  props.onChange(opt.id)
-                  setOpen(false)
-                }}
-              >
-                <span class="font-medium">{opt.label}</span>
-                <Show when={opt.description}>
-                  <span class="block text-[10px] text-text-dim mt-0.5">{opt.description}</span>
-                </Show>
-              </button>
-            )
-          }}
+          {(opt) => (
+            <ModelRow
+              model={opt}
+              selected={resolvedModel() === opt.id}
+              locked={!meetsVersionReq(cliVersion(), opt.minVersion)}
+              onClick={() => handleModelSelect(opt)}
+            />
+          )}
         </For>
         <Show when={query() && filteredModels().length === 0}>
           <div class="px-3 py-2 text-[11px] text-text-dim">No matches</div>
         </Show>
         </div>
       </Popover>
+
+      <UpdateRequiredDialog
+        open={!!updateModel()}
+        modelName={updateModel()?.label ?? ''}
+        minVersion={updateModel()?.minVersion ?? ''}
+        updateHint={agentInfo()?.updateHint ?? agentInfo()?.installHint ?? ''}
+        onClose={() => setUpdateModel(null)}
+      />
     </div>
   )
 }

--- a/src/components/NewSessionMenu.tsx
+++ b/src/components/NewSessionMenu.tsx
@@ -1,12 +1,14 @@
 import { Component, For, Show, createSignal, createEffect, createMemo, onCleanup } from 'solid-js'
 import { Portal } from 'solid-js/web'
-import type { AgentType } from '../types'
+import type { AgentType, ModelOption } from '../types'
 import { agents } from '../store/agents'
 import { clsx } from 'clsx'
 import { Plus, ChevronRight, Loader2, Search } from 'lucide-solid'
 import { registerDismissable } from '../lib/dismissable'
-import { agentIcon } from '../lib/agents'
+import { agentIcon, meetsVersionReq } from '../lib/agents'
 import SvgIcon from './SvgIcon'
+import { ModelRow } from './ModelRow'
+import { UpdateRequiredDialog } from './UpdateRequiredDialog'
 
 const MODEL_SEARCH_THRESHOLD = 10
 
@@ -74,6 +76,7 @@ export const NewSessionMenu: Component<Props> = (props) => {
   }
 
   const [modelQuery, setModelQuery] = createSignal('')
+  const [updateModel, setUpdateModel] = createSignal<ModelOption | null>(null)
 
   const hoveredAgentInfo = () => {
     const id = hoveredAgent()
@@ -92,6 +95,16 @@ export const NewSessionMenu: Component<Props> = (props) => {
     )
   })
 
+  const handleModelClick = (model: ModelOption) => {
+    const info = hoveredAgentInfo()!
+    if (model.minVersion && !meetsVersionReq(info.cliVersion, model.minVersion)) {
+      closeMenu()
+      setUpdateModel(model)
+      return
+    }
+    handleSelect(info.id as AgentType, model.id)
+  }
+
   return (
     <>
       <button
@@ -108,7 +121,6 @@ export const NewSessionMenu: Component<Props> = (props) => {
 
       <Show when={open()}>
         <Portal>
-          {/* backdrop */}
           <div
             class="fixed inset-0 z-[100]"
             onMouseDown={(e) => e.preventDefault()}
@@ -116,7 +128,6 @@ export const NewSessionMenu: Component<Props> = (props) => {
             onContextMenu={(e) => { e.preventDefault(); closeMenu() }}
           />
 
-          {/* main menu */}
           <div
             class="fixed z-[101] bg-surface-2 ring-1 ring-white/8 rounded-md shadow-xl py-1 w-44"
             style={{
@@ -166,7 +177,6 @@ export const NewSessionMenu: Component<Props> = (props) => {
             </Show>
           </div>
 
-          {/* model submenu */}
           <Show when={hoveredAgentInfo() && hoveredAgentInfo()!.models.length > 0}>
             <div
               class="fixed z-[102] bg-surface-2 ring-1 ring-white/8 rounded-md shadow-xl py-1 w-44 max-h-80 flex flex-col"
@@ -175,9 +185,7 @@ export const NewSessionMenu: Component<Props> = (props) => {
                 top: `${submenuRect()?.top ?? 0}px`,
               }}
               onMouseDown={(e) => e.preventDefault()}
-              onMouseEnter={() => {
-                // keep hovered state while mouse is in submenu
-              }}
+              onMouseEnter={() => {}}
             >
               <Show when={showModelSearch()}>
                 <div class="px-2 py-1 shrink-0">
@@ -197,12 +205,11 @@ export const NewSessionMenu: Component<Props> = (props) => {
               <div class="overflow-y-auto">
                 <For each={filteredHoveredModels()}>
                   {(model) => (
-                    <button
-                      class="w-full text-left px-3 py-2 text-xs text-text-secondary hover:text-text-primary hover:bg-surface-3 transition-colors truncate"
-                      onClick={() => handleSelect(hoveredAgentInfo()!.id as AgentType, model.id)}
-                    >
-                      {model.label}
-                    </button>
+                    <ModelRow
+                      model={model}
+                      locked={!meetsVersionReq(hoveredAgentInfo()?.cliVersion, model.minVersion)}
+                      onClick={() => handleModelClick(model)}
+                    />
                   )}
                 </For>
                 <Show when={modelQuery() && filteredHoveredModels().length === 0}>
@@ -213,6 +220,14 @@ export const NewSessionMenu: Component<Props> = (props) => {
           </Show>
         </Portal>
       </Show>
+
+      <UpdateRequiredDialog
+        open={!!updateModel()}
+        modelName={updateModel()?.label ?? ''}
+        minVersion={updateModel()?.minVersion ?? ''}
+        updateHint={hoveredAgentInfo()?.updateHint ?? hoveredAgentInfo()?.installHint ?? ''}
+        onClose={() => setUpdateModel(null)}
+      />
     </>
   )
 }

--- a/src/components/UpdateRequiredDialog.tsx
+++ b/src/components/UpdateRequiredDialog.tsx
@@ -1,0 +1,38 @@
+import { Component } from 'solid-js'
+import { Dialog } from './Dialog'
+
+interface Props {
+  open: boolean
+  modelName: string
+  minVersion: string
+  updateHint: string
+  onClose: () => void
+}
+
+export const UpdateRequiredDialog: Component<Props> = (props) => {
+  const copyCommand = () => navigator.clipboard.writeText(props.updateHint)
+
+  return (
+    <Dialog open={props.open} onClose={props.onClose}>
+      <h2 class="text-base font-semibold text-text-primary mb-2">Update Required</h2>
+      <p class="text-sm text-text-muted mb-3">
+        {props.modelName} requires v{props.minVersion} or later.
+      </p>
+      <button
+        class="w-full text-left px-3 py-2 mb-4 rounded-md bg-surface-1 ring-1 ring-white/6 font-mono text-xs text-text-secondary hover:text-text-primary hover:ring-white/12 transition-colors select-all"
+        onClick={copyCommand}
+        title="Click to copy"
+      >
+        {props.updateHint}
+      </button>
+      <div class="flex justify-end">
+        <button
+          class="btn-primary px-3 py-1.5 text-xs rounded-md"
+          onClick={props.onClose}
+        >
+          OK
+        </button>
+      </div>
+    </Dialog>
+  )
+}

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -18,4 +18,21 @@ export function agentIcon(agentType: string): string {
   return AGENT_ICONS[agentType] || GENERIC_ICON
 }
 
+export function compareVersions(a: string, b: string): number {
+  const pa = a.split('.').map(Number)
+  const pb = b.split('.').map(Number)
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const na = pa[i] ?? 0
+    const nb = pb[i] ?? 0
+    if (na !== nb) return na - nb
+  }
+  return 0
+}
+
+export function meetsVersionReq(cliVersion: string | undefined, minVersion: string | undefined): boolean {
+  if (!minVersion) return true
+  if (!cliVersion) return false
+  return compareVersions(cliVersion, minVersion) >= 0
+}
+
 export { claudeIcon, codexIcon, cursorIcon, geminiIcon, opencodeIcon }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -93,6 +93,7 @@ export interface ModelOption {
   id: string
   label: string
   description: string
+  minVersion?: string
 }
 
 export interface AgentSkill {
@@ -104,9 +105,11 @@ export interface AgentInfo {
   id: AgentType
   name: string
   installHint: string
+  updateHint: string
   docsUrl: string
   models: ModelOption[]
   installed: boolean
+  cliVersion?: string
   supportsStreaming: boolean
   supportsResume: boolean
   supportsPlanMode: boolean


### PR DESCRIPTION
## Summary
- Adds Claude Opus 4.7 to model lists, gated behind CLI version 2.1.111+
- Models with unmet version requirements show dimmed with an "Update required" badge and version subtitle
- Clicking a locked model opens a dialog with the copiable update command (`claude update`)
- `ModelOption` gains `minVersion`, `Agent` trait gains `update_hint()`, `AgentInfo` exposes `cliVersion` and `updateHint`
- Shared `ModelRow` and `UpdateRequiredDialog` components used by both `ModelSelector` and `NewSessionMenu`

## Test plan
- [ ] Verify Opus 4.7 appears in model selector and new session menu
- [ ] On CLI >= 2.1.111: selecting Opus 4.7 works normally
- [ ] On CLI < 2.1.111: row is dimmed with badge, clicking shows update dialog with `claude update`
- [ ] Command in dialog is copiable (click to copy)
- [ ] Other models unaffected