### PR TITLE
fix: show archive after PR merged with deleted remote branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Chat search position no longer jumps to last match when new agent messages arrive
 - File browser now shows .env and other gitignored files
 - Quick open now boosts project-scoped recent files, including ignored files like `.env` when recently opened, without indexing build output or `node_modules`
-- Fix: show Archive button (not Push) after merging a PR with deleted remote branch
+- Store `last_pushed_sha` on tasks (migration 18) so unpushed commit count no longer depends on the remote tracking branch existing - fixes Archive button showing as Push after merging a PR with deleted remote branch
 
 ## 0.7.1 — 2026-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Chat search position no longer jumps to last match when new agent messages arrive
 - File browser now shows .env and other gitignored files
 - Quick open now boosts project-scoped recent files, including ignored files like `.env` when recently opened, without indexing build output or `node_modules`
+- Fix: show Archive button (not Push) after merging a PR with deleted remote branch
 
 ## 0.7.1 — 2026-04-17
 

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -202,6 +202,12 @@ pub fn migrations() -> Vec<Migration> {
         description: "rename claude_session_id to resume_session_id",
         sql: "ALTER TABLE sessions RENAME COLUMN claude_session_id TO resume_session_id;",
         kind: MigrationKind::Up,
+    },
+    Migration {
+        version: 18,
+        description: "add last_pushed_sha to tasks",
+        sql: "ALTER TABLE tasks ADD COLUMN last_pushed_sha TEXT;",
+        kind: MigrationKind::Up,
     }]
 }
 
@@ -246,6 +252,8 @@ pub struct Task {
     pub parent_task_id: Option<String>,
     #[sqlx(default)]
     pub agent_type: String,
+    #[sqlx(default)]
+    pub last_pushed_sha: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
@@ -363,6 +371,10 @@ pub enum DbWrite {
     },
     RestoreTask {
         id: String,
+    },
+    SetLastPushedSha {
+        id: String,
+        sha: String,
     },
 
     // Sessions
@@ -660,6 +672,10 @@ async fn process_write(pool: &SqlitePool, write: DbWrite) -> Result<(), sqlx::Er
                 .bind(&id)
                 .execute(pool)
                 .await?;
+        }
+        DbWrite::SetLastPushedSha { id, sha } => {
+            sqlx::query("UPDATE tasks SET last_pushed_sha = ? WHERE id = ?")
+                .bind(&sha).bind(&id).execute(pool).await?;
         }
 
         // -- Sessions --
@@ -1093,7 +1109,7 @@ mod tests {
     #[test]
     fn has_twelve_migrations() {
         let m = migrations();
-        assert_eq!(m.len(), 17);
+        assert_eq!(m.len(), 18);
         assert_eq!(m[0].version, 1);
         assert_eq!(m[1].version, 2);
         assert_eq!(m[2].version, 3);
@@ -1157,6 +1173,7 @@ mod tests {
             last_commit_message: None,
             parent_task_id: None,
             agent_type: "claude".into(),
+            last_pushed_sha: None,
         }
     }
 

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -884,8 +884,9 @@ pub async fn get_branch_status(
         .await?
         .ok_or_else(|| format!("Task {task_id} not found"))?;
 
+    let last_pushed = t.last_pushed_sha.clone();
     flatten_join(
-        tokio::task::spawn_blocking(move || worktree::get_branch_status(&t.worktree_path)).await,
+        tokio::task::spawn_blocking(move || worktree::get_branch_status(&t.worktree_path, last_pushed.as_deref())).await,
     )
 }
 
@@ -1087,14 +1088,25 @@ pub async fn git_commit(
 pub async fn git_push(
     app: AppHandle,
     pool: State<'_, SqlitePool>,
+    db_tx: State<'_, db::DbWriteTx>,
     task_id: String,
 ) -> Result<(), String> {
     let t = db::get_task(pool.inner(), &task_id)
         .await?
         .ok_or_else(|| format!("Task {task_id} not found"))?;
 
+    let wt = t.worktree_path.clone();
+    let tid = t.id.clone();
+    let tx = db_tx.inner().clone();
     flatten_join(
-        tokio::task::spawn_blocking(move || git_ops::push_branch(&t.worktree_path)).await,
+        tokio::task::spawn_blocking(move || {
+            git_ops::push_branch(&wt)?;
+            if let Ok(sha) = worktree::get_head_sha(&wt) {
+                let _ = tx.try_send(db::DbWrite::SetLastPushedSha { id: tid, sha });
+            }
+            Ok(())
+        })
+        .await,
     )?;
     emit_git_status_changed(&app, &task_id);
     Ok(())
@@ -1340,6 +1352,7 @@ pub async fn mark_pr_ready(
 pub async fn merge_pull_request(
     app: AppHandle,
     pool: State<'_, SqlitePool>,
+    db_tx: State<'_, db::DbWriteTx>,
     task_id: String,
     force: Option<bool>,
     delete_branch: Option<bool>,
@@ -1350,9 +1363,15 @@ pub async fn merge_pull_request(
 
     let force = force.unwrap_or(false);
     let delete_branch = delete_branch.unwrap_or(false);
+    let wt = t.worktree_path.clone();
+    let tid = t.id.clone();
+    let tx = db_tx.inner().clone();
     flatten_join(
         tokio::task::spawn_blocking(move || {
-            github::merge_pr(&t.worktree_path, force, delete_branch)
+            if let Ok(sha) = worktree::get_head_sha(&wt) {
+                let _ = tx.try_send(db::DbWrite::SetLastPushedSha { id: tid, sha });
+            }
+            github::merge_pr(&wt, force, delete_branch)
         })
         .await,
     )?;

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -878,6 +878,7 @@ pub async fn merge_branch(
 #[tauri::command]
 pub async fn get_branch_status(
     pool: State<'_, SqlitePool>,
+    db_tx: State<'_, db::DbWriteTx>,
     task_id: String,
 ) -> Result<(u32, u32, u32), String> {
     let t = db::get_task(pool.inner(), &task_id)
@@ -885,9 +886,15 @@ pub async fn get_branch_status(
         .ok_or_else(|| format!("Task {task_id} not found"))?;
 
     let last_pushed = t.last_pushed_sha.clone();
-    flatten_join(
+    let status = flatten_join(
         tokio::task::spawn_blocking(move || worktree::get_branch_status(&t.worktree_path, last_pushed.as_deref())).await,
-    )
+    )?;
+
+    if let Some(sha) = status.tracking_sha {
+        let _ = db_tx.try_send(db::DbWrite::SetLastPushedSha { id: task_id, sha });
+    }
+
+    Ok((status.ahead, status.behind, status.unpushed))
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src-tauri/src/task.rs
+++ b/src-tauri/src/task.rs
@@ -401,6 +401,7 @@ pub async fn create_task(
         last_commit_message: None,
         parent_task_id: None,
         agent_type: agent_type.clone(),
+        last_pushed_sha: None,
     };
 
     db_tx
@@ -1485,6 +1486,7 @@ pub async fn fork_session_to_new_task(
         last_commit_message: None,
         parent_task_id: Some(parent_task.id.clone()),
         agent_type: parent_session.agent_type.clone(),
+        last_pushed_sha: None,
     };
 
     let parent_agent = AgentKind::parse(&parent_session.agent_type).implementation();

--- a/src-tauri/src/worktree.rs
+++ b/src-tauri/src/worktree.rs
@@ -311,26 +311,34 @@ pub fn merge_branch(
 /// - ahead_of_base = commits on this branch not in origin/main — for PR indicators
 /// - behind_base = commits on origin/main not in this branch — needs rebase
 /// - unpushed = commits on this branch not pushed to origin/<branch> — for push button
-pub fn get_branch_status(worktree_path: &str) -> Result<(u32, u32, u32), String> {
+pub fn get_branch_status(worktree_path: &str, last_pushed_sha: Option<&str>) -> Result<(u32, u32, u32), String> {
     let current = get_current_branch(worktree_path)?;
     let base_ref = find_compare_ref(worktree_path, &current)?;
     let (behind, ahead) = rev_list_left_right(worktree_path, &base_ref, &current);
 
-    // Check unpushed commits against origin/<branch>
     let tracking = format!("origin/{current}");
     let unpushed = if ref_exists(worktree_path, &tracking) {
         let (_, u) = rev_list_left_right(worktree_path, &tracking, &current);
         u
-    } else if branch_has_remote_config(worktree_path, &current) {
-        // Remote branch was deleted (e.g., after PR merge with delete branch).
-        // Use patch-equivalence to find commits not yet on the base branch.
-        count_cherry_commits(worktree_path, &base_ref)
+    } else if let Some(sha) = last_pushed_sha {
+        let (_, u) = rev_list_left_right(worktree_path, sha, &current);
+        u
     } else {
-        // No remote tracking branch yet — everything is unpushed
         ahead
     };
 
     Ok((ahead, behind, unpushed))
+}
+
+pub fn get_head_sha(worktree_path: &str) -> Result<String, String> {
+    let output = git(worktree_path)
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .map_err(|e| format!("Failed to get HEAD: {e}"))?;
+    if !output.status.success() {
+        return Err("Failed to get HEAD SHA".to_string());
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
 fn get_current_branch(worktree_path: &str) -> Result<String, String> {
@@ -344,30 +352,6 @@ fn get_current_branch(worktree_path: &str) -> Result<String, String> {
     }
 
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
-}
-
-fn branch_has_remote_config(worktree_path: &str, branch: &str) -> bool {
-    git(worktree_path)
-        .args(["config", &format!("branch.{branch}.remote")])
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
-}
-
-fn count_cherry_commits(worktree_path: &str, base_ref: &str) -> u32 {
-    let output = git(worktree_path)
-        .args(["cherry", base_ref])
-        .output();
-
-    match output {
-        Ok(o) if o.status.success() => {
-            String::from_utf8_lossy(&o.stdout)
-                .lines()
-                .filter(|line| line.starts_with('+'))
-                .count() as u32
-        }
-        _ => 0,
-    }
 }
 
 fn ref_exists(worktree_path: &str, refname: &str) -> bool {
@@ -603,7 +587,7 @@ mod tests {
         let (_dir, repo_path) = init_test_repo();
         let wt_path = create_worktree(&repo_path, "status-test", "main").unwrap();
 
-        let (ahead, behind, _unpushed) = get_branch_status(&wt_path).unwrap();
+        let (ahead, behind, _unpushed) = get_branch_status(&wt_path, None).unwrap();
         assert_eq!(ahead, 0);
         assert_eq!(behind, 0);
     }
@@ -620,7 +604,7 @@ mod tests {
             .output()
             .unwrap();
 
-        let (ahead, behind, _unpushed) = get_branch_status(&wt_path).unwrap();
+        let (ahead, behind, _unpushed) = get_branch_status(&wt_path, None).unwrap();
         assert_eq!(ahead, 1);
         assert_eq!(behind, 0);
     }
@@ -639,7 +623,7 @@ mod tests {
             .output()
             .unwrap();
 
-        let (ahead, behind, _unpushed) = get_branch_status(&wt_path).unwrap();
+        let (ahead, behind, _unpushed) = get_branch_status(&wt_path, None).unwrap();
         assert_eq!(behind, 1, "should be 1 behind main");
         assert_eq!(ahead, 0);
     }
@@ -734,7 +718,7 @@ mod tests {
         // Fetch in original clone so it sees the new origin/main
         git(&clone_path).args(["fetch"]).output().unwrap();
 
-        let (ahead, behind, _unpushed) = get_branch_status(&clone_path).unwrap();
+        let (ahead, behind, _unpushed) = get_branch_status(&clone_path, None).unwrap();
         assert_eq!(ahead, 1, "should be 1 ahead of origin/main");
         assert_eq!(behind, 1, "should be 1 behind origin/main");
     }
@@ -755,7 +739,7 @@ mod tests {
             .output()
             .unwrap();
 
-        let (ahead, behind, _unpushed) = get_branch_status(&clone_path).unwrap();
+        let (ahead, behind, _unpushed) = get_branch_status(&clone_path, None).unwrap();
         assert_eq!(ahead, 1, "should be 1 ahead of origin/main");
         assert_eq!(behind, 0, "should not be behind when main hasn't changed");
     }

--- a/src-tauri/src/worktree.rs
+++ b/src-tauri/src/worktree.rs
@@ -311,23 +311,41 @@ pub fn merge_branch(
 /// - ahead_of_base = commits on this branch not in origin/main — for PR indicators
 /// - behind_base = commits on origin/main not in this branch — needs rebase
 /// - unpushed = commits on this branch not pushed to origin/<branch> — for push button
-pub fn get_branch_status(worktree_path: &str, last_pushed_sha: Option<&str>) -> Result<(u32, u32, u32), String> {
+pub struct BranchStatus {
+    pub ahead: u32,
+    pub behind: u32,
+    pub unpushed: u32,
+    /// SHA of origin/<branch> when it exists, so callers can cache it.
+    pub tracking_sha: Option<String>,
+}
+
+pub fn get_branch_status(worktree_path: &str, last_pushed_sha: Option<&str>) -> Result<BranchStatus, String> {
     let current = get_current_branch(worktree_path)?;
     let base_ref = find_compare_ref(worktree_path, &current)?;
     let (behind, ahead) = rev_list_left_right(worktree_path, &base_ref, &current);
 
     let tracking = format!("origin/{current}");
-    let unpushed = if ref_exists(worktree_path, &tracking) {
+    let (unpushed, tracking_sha) = if ref_exists(worktree_path, &tracking) {
         let (_, u) = rev_list_left_right(worktree_path, &tracking, &current);
-        u
+        let sha = resolve_ref(worktree_path, &tracking);
+        (u, sha)
     } else if let Some(sha) = last_pushed_sha {
         let (_, u) = rev_list_left_right(worktree_path, sha, &current);
-        u
+        (u, None)
     } else {
-        ahead
+        (ahead, None)
     };
 
-    Ok((ahead, behind, unpushed))
+    Ok(BranchStatus { ahead, behind, unpushed, tracking_sha })
+}
+
+fn resolve_ref(worktree_path: &str, refname: &str) -> Option<String> {
+    git(worktree_path)
+        .args(["rev-parse", refname])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
 }
 
 pub fn get_head_sha(worktree_path: &str) -> Result<String, String> {
@@ -587,7 +605,8 @@ mod tests {
         let (_dir, repo_path) = init_test_repo();
         let wt_path = create_worktree(&repo_path, "status-test", "main").unwrap();
 
-        let (ahead, behind, _unpushed) = get_branch_status(&wt_path, None).unwrap();
+        let s = get_branch_status(&wt_path, None).unwrap();
+        let (ahead, behind) = (s.ahead, s.behind);
         assert_eq!(ahead, 0);
         assert_eq!(behind, 0);
     }
@@ -604,7 +623,8 @@ mod tests {
             .output()
             .unwrap();
 
-        let (ahead, behind, _unpushed) = get_branch_status(&wt_path, None).unwrap();
+        let s = get_branch_status(&wt_path, None).unwrap();
+        let (ahead, behind) = (s.ahead, s.behind);
         assert_eq!(ahead, 1);
         assert_eq!(behind, 0);
     }
@@ -623,7 +643,8 @@ mod tests {
             .output()
             .unwrap();
 
-        let (ahead, behind, _unpushed) = get_branch_status(&wt_path, None).unwrap();
+        let s = get_branch_status(&wt_path, None).unwrap();
+        let (ahead, behind) = (s.ahead, s.behind);
         assert_eq!(behind, 1, "should be 1 behind main");
         assert_eq!(ahead, 0);
     }
@@ -718,7 +739,8 @@ mod tests {
         // Fetch in original clone so it sees the new origin/main
         git(&clone_path).args(["fetch"]).output().unwrap();
 
-        let (ahead, behind, _unpushed) = get_branch_status(&clone_path, None).unwrap();
+        let s = get_branch_status(&clone_path, None).unwrap();
+        let (ahead, behind) = (s.ahead, s.behind);
         assert_eq!(ahead, 1, "should be 1 ahead of origin/main");
         assert_eq!(behind, 1, "should be 1 behind origin/main");
     }
@@ -739,7 +761,8 @@ mod tests {
             .output()
             .unwrap();
 
-        let (ahead, behind, _unpushed) = get_branch_status(&clone_path, None).unwrap();
+        let s = get_branch_status(&clone_path, None).unwrap();
+        let (ahead, behind) = (s.ahead, s.behind);
         assert_eq!(ahead, 1, "should be 1 ahead of origin/main");
         assert_eq!(behind, 0, "should not be behind when main hasn't changed");
     }

--- a/src-tauri/src/worktree.rs
+++ b/src-tauri/src/worktree.rs
@@ -321,6 +321,10 @@ pub fn get_branch_status(worktree_path: &str) -> Result<(u32, u32, u32), String>
     let unpushed = if ref_exists(worktree_path, &tracking) {
         let (_, u) = rev_list_left_right(worktree_path, &tracking, &current);
         u
+    } else if branch_has_remote_config(worktree_path, &current) {
+        // Remote branch was deleted (e.g., after PR merge with delete branch).
+        // Use patch-equivalence to find commits not yet on the base branch.
+        count_cherry_commits(worktree_path, &base_ref)
     } else {
         // No remote tracking branch yet — everything is unpushed
         ahead
@@ -340,6 +344,30 @@ fn get_current_branch(worktree_path: &str) -> Result<String, String> {
     }
 
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn branch_has_remote_config(worktree_path: &str, branch: &str) -> bool {
+    git(worktree_path)
+        .args(["config", &format!("branch.{branch}.remote")])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn count_cherry_commits(worktree_path: &str, base_ref: &str) -> u32 {
+    let output = git(worktree_path)
+        .args(["cherry", base_ref])
+        .output();
+
+    match output {
+        Ok(o) if o.status.success() => {
+            String::from_utf8_lossy(&o.stdout)
+                .lines()
+                .filter(|line| line.starts_with('+'))
+                .count() as u32
+        }
+        _ => 0,
+    }
 }
 
 fn ref_exists(worktree_path: &str, refname: &str) -> bool {

--- a/src/components/GitActions.tsx
+++ b/src/components/GitActions.tsx
@@ -188,7 +188,7 @@ export const GitActions: Component<Props> = (props) => {
   // Smart default action based on state
   // Flow: Pull (if behind) → Push (updates existing PR) → Create PR → Ready for Review (if draft) → Resolve conflicts → Merge
   const primaryAction = (): GitAction => {
-    if (prMerged() && fileCount() === 0) return archiveAction()
+    if (prMerged() && localClean()) return archiveAction()
     if (prMerged()) return pushAction()
     if (failedChecks().length > 0) return { icon: Wrench, label: 'Fix CI', message: `fix the failing CI checks: ${failedChecks().map(c => c.name).join(', ')}` }
     if (isBehind() && !prDone()) return pullAction()

--- a/src/components/GitActions.tsx
+++ b/src/components/GitActions.tsx
@@ -188,7 +188,7 @@ export const GitActions: Component<Props> = (props) => {
   // Smart default action based on state
   // Flow: Pull (if behind) → Push (updates existing PR) → Create PR → Ready for Review (if draft) → Resolve conflicts → Merge
   const primaryAction = (): GitAction => {
-    if (prMerged() && localClean()) return archiveAction()
+    if (prMerged() && fileCount() === 0) return archiveAction()
     if (prMerged()) return pushAction()
     if (failedChecks().length > 0) return { icon: Wrench, label: 'Fix CI', message: `fix the failing CI checks: ${failedChecks().map(c => c.name).join(', ')}` }
     if (isBehind() && !prDone()) return pullAction()


### PR DESCRIPTION
## Summary

- When a PR is merged with "delete remote branch", `origin/<branch>` disappears. The old `get_branch_status` fallback set `unpushed = ahead`, making `localClean()` false and showing Push instead of Archive.
- Fix is in the Rust backend: distinguish "never pushed" (via `git config branch.<name>.remote`) from "remote deleted". For deleted remote branches, use `git cherry` to do patch-equivalence comparison against the base branch - correctly reports 0 for merged commits while detecting genuinely new commits made after the merge.
- Frontend logic (`prMerged() && localClean()`) is unchanged and now works correctly for both cases.

Closes #130

## Test plan

- [ ] Merge a PR with "delete remote branch" checked - verify Archive button shows
- [ ] Merge a PR without deleting remote branch - verify Archive button shows
- [ ] After merging, make a new commit on the same worktree - verify Push shows (not Archive)
- [ ] Fresh task with no remote branch yet - verify Push shows with correct unpushed count