### PR TITLE
fix: preserve chat search position when new messages arrive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Chat search position no longer jumps to last match when new agent messages arrive
+
 ## 0.7.1 — 2026-04-17
 
 - Claude Opus 4.7 model option with minimum CLI version gate (v2.1.111+); shows update dialog on older versions

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -749,6 +749,26 @@ export const ChatView: Component<Props> = (props) => {
     matches().forEach(m => { if (m !== el) m.classList.remove('chat-search-current') })
   }
 
+  const refreshHighlights = () => {
+    if (contentRef) clearHighlights(contentRef)
+    const query = searchQuery()
+    if (!query) {
+      setMatches([])
+      setCurrentMatchIdx(-1)
+      return
+    }
+    const found = highlightMatches(contentRef, query)
+    setMatches(found)
+    if (found.length === 0) {
+      setCurrentMatchIdx(-1)
+      return
+    }
+    const prev = currentMatchIdx()
+    const idx = prev >= 0 && prev < found.length ? prev : found.length - 1
+    setCurrentMatchIdx(idx)
+    found[idx].classList.add('chat-search-current')
+  }
+
   const goToMatch = (delta: number) => {
     const m = matches()
     if (m.length === 0) return
@@ -833,9 +853,9 @@ export const ChatView: Component<Props> = (props) => {
         const newBlocks = rebuildBlocks(props.output)
         setBlocks(reconcile(newBlocks, { merge: !sessionChanged }))
         lastItemCount = len
-        // Re-apply search highlights after block rebuild
+        // Re-apply search highlights after block rebuild (preserve position)
         if (showSearch() && searchQuery()) {
-          requestAnimationFrame(() => runSearch(searchQuery()))
+          requestAnimationFrame(() => refreshHighlights())
         }
         if (sessionChanged) {
           scheduleAutoScroll()


### PR DESCRIPTION
## Summary
- When chat search (Cmd+F) was active, incoming agent messages triggered `runSearch` which always reset `currentMatchIdx` to the last match, scrolling the user away from their current position
- Added `refreshHighlights()` that re-applies search marks after block rebuild but preserves the current match index
- Used during block rebuild instead of `runSearch` so only the initial search and arrow-key navigation move the position

Closes #120

## Test plan
- [ ] Open a session with a running agent, use Cmd+F to search for a term
- [ ] Navigate to a specific match using Enter/Shift+Enter
- [ ] Confirm position stays stable as new messages stream in
- [ ] Verify initial search still jumps to last match
- [ ] Verify arrow navigation still works normally