### PR TITLE
fix: show .env files in file browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Chat search position no longer jumps to last match when new agent messages arrive
+- File browser now shows .env and other gitignored files
 
 ## 0.7.1 — 2026-04-17
 

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -1823,7 +1823,14 @@ pub async fn list_directory(
             }
 
             let mut entries = Vec::new();
-            for result in WalkBuilder::new(&base).max_depth(Some(1)).hidden(false).build() {
+            for result in WalkBuilder::new(&base)
+                .max_depth(Some(1))
+                .hidden(false)
+                .git_ignore(false)
+                .git_global(false)
+                .git_exclude(false)
+                .build()
+            {
                 let entry = result.map_err(|e| format!("Walk error: {e}"))?;
                 // Skip the root directory itself
                 if entry.path() == base {


### PR DESCRIPTION
## Summary
- Disabled gitignore filtering in `list_directory` so `.env`, `.env.local`, and other gitignored files appear in the file browser
- The `ignore::WalkBuilder` was respecting `.gitignore` by default - added `.git_ignore(false)`, `.git_global(false)`, `.git_exclude(false)`

Closes #136

## Test plan
- [ ] Open a task whose repo has a `.env` file in `.gitignore`
- [ ] Verify `.env` appears in the file browser
- [ ] Verify `node_modules/` and other normally-ignored dirs also appear (expected, since max_depth=1 keeps it shallow)