### PR TITLE
fix: parse version strings from CLI output, not just bare semver

### DIFF
--- a/src/lib/agents.test.ts
+++ b/src/lib/agents.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'vitest'
+import { compareVersions, meetsVersionReq } from './agents'
+
+describe('agent version helpers', () => {
+  test('compares plain semantic versions', () => {
+    expect(compareVersions('2.1.112', '2.1.111')).toBeGreaterThan(0)
+    expect(compareVersions('2.1.111', '2.1.111')).toBe(0)
+    expect(compareVersions('2.1.110', '2.1.111')).toBeLessThan(0)
+  })
+
+  test('extracts semantic versions from cli output text', () => {
+    expect(compareVersions('v2.1.112', '2.1.111')).toBeGreaterThan(0)
+    expect(compareVersions('claude 2.1.112', '2.1.111')).toBeGreaterThan(0)
+    expect(compareVersions('Claude Code v2.1.112 (abc123)', '2.1.111')).toBeGreaterThan(0)
+  })
+
+  test('treats unparseable versions as not meeting requirements', () => {
+    expect(Number.isNaN(compareVersions('Claude Code', '2.1.111'))).toBe(true)
+    expect(meetsVersionReq('Claude Code', '2.1.111')).toBe(false)
+  })
+})

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -18,9 +18,19 @@ export function agentIcon(agentType: string): string {
   return AGENT_ICONS[agentType] || GENERIC_ICON
 }
 
+function parseVersionParts(version: string): number[] {
+  const match = version.match(/\d+(?:\.\d+)+/)
+  if (!match) return []
+  return match[0]
+    .split('.')
+    .map(part => Number.parseInt(part, 10))
+    .filter(part => Number.isFinite(part))
+}
+
 export function compareVersions(a: string, b: string): number {
-  const pa = a.split('.').map(Number)
-  const pb = b.split('.').map(Number)
+  const pa = parseVersionParts(a)
+  const pb = parseVersionParts(b)
+  if (pa.length === 0 || pb.length === 0) return Number.NaN
   for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
     const na = pa[i] ?? 0
     const nb = pb[i] ?? 0


### PR DESCRIPTION
## Summary

- `compareVersions` previously split on `.` directly, breaking when CLI output includes prefixes like `v`, `claude`, or suffixes like `(abc123)`
- Extracts the first `\d+(\.\d+)+` sequence so strings like `Claude Code v2.1.112 (abc123)` compare correctly
- Returns `NaN` for unparseable inputs so `meetsVersionReq` fails safely instead of silently passing
- Adds `agents.test.ts` covering plain semver, prefixed output strings, and unparseable inputs