### PR TITLE
feat: multi-agent support, per-session models, policy engine rewrite, and Quick Open recent files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Move db init into async spawn to prevent startup crash on macOS
 - Chat search position no longer jumps to last match when new agent messages arrive
 - File browser now shows .env and other gitignored files
+- Quick open now boosts project-scoped recent files, including ignored files like `.env` when recently opened, without indexing build output or `node_modules`
 
 ## 0.7.1 — 2026-04-17
 

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,5 +1,13 @@
 #!/bin/bash
 set -e
 
+echo "Running Rust formatter..."
+cargo fmt --manifest-path src-tauri/Cargo.toml
+
+if ! git diff --quiet -- src-tauri; then
+  echo "Restaging Rust files changed by formatter..."
+  git add src-tauri
+fi
+
 echo "Running pre-commit checks..."
 bash scripts/check.sh

--- a/src-tauri/src/agent/claude.rs
+++ b/src-tauri/src/agent/claude.rs
@@ -9,10 +9,18 @@ use super::{Agent, AgentKind, InputMode, SessionArgs};
 pub struct Claude;
 
 impl Agent for Claude {
-    fn kind(&self) -> AgentKind { AgentKind::Claude }
-    fn display_name(&self) -> &'static str { "Claude Code" }
-    fn cli_binary(&self) -> &'static str { "claude" }
-    fn input_mode(&self) -> InputMode { InputMode::StreamJsonStdin }
+    fn kind(&self) -> AgentKind {
+        AgentKind::Claude
+    }
+    fn display_name(&self) -> &'static str {
+        "Claude Code"
+    }
+    fn cli_binary(&self) -> &'static str {
+        "claude"
+    }
+    fn input_mode(&self) -> InputMode {
+        InputMode::StreamJsonStdin
+    }
 
     fn install_hint(&self) -> &'static str {
         "npm i -g @anthropic-ai/claude-code"
@@ -29,22 +37,41 @@ impl Agent for Claude {
     fn available_models(&self) -> Vec<crate::agent::ModelOption> {
         use crate::agent::ModelOption;
         vec![
-            ModelOption::new("claude-opus-4-7", "Claude Opus 4.7", "Latest and most capable")
-                .with_min_version("2.1.111"),
-            ModelOption::new("claude-opus-4-6", "Claude Opus 4.6", "Most capable for complex tasks"),
-            ModelOption::new("claude-sonnet-4-6", "Claude Sonnet 4.6", "Best for everyday tasks"),
-            ModelOption::new("claude-haiku-4-5", "Claude Haiku 4.5", "Fastest for quick answers"),
+            ModelOption::new(
+                "claude-opus-4-7",
+                "Claude Opus 4.7",
+                "Latest and most capable",
+            )
+            .with_min_version("2.1.111"),
+            ModelOption::new(
+                "claude-opus-4-6",
+                "Claude Opus 4.6",
+                "Most capable for complex tasks",
+            ),
+            ModelOption::new(
+                "claude-sonnet-4-6",
+                "Claude Sonnet 4.6",
+                "Best for everyday tasks",
+            ),
+            ModelOption::new(
+                "claude-haiku-4-5",
+                "Claude Haiku 4.5",
+                "Fastest for quick answers",
+            ),
         ]
     }
 
     fn build_session_args(&self, args: &SessionArgs<'_>) -> Vec<String> {
         let mut v = vec![
             "-p".into(),
-            "--output-format".into(), "stream-json".into(),
-            "--input-format".into(), "stream-json".into(),
+            "--output-format".into(),
+            "stream-json".into(),
+            "--input-format".into(),
+            "stream-json".into(),
             "--verbose".into(),
             "--include-partial-messages".into(),
-            "--permission-prompt-tool".into(), "stdio".into(),
+            "--permission-prompt-tool".into(),
+            "stdio".into(),
         ];
 
         if args.plan_mode {
@@ -65,12 +92,24 @@ impl Agent for Claude {
         v
     }
 
-    fn supports_plan_mode(&self) -> bool { true }
-    fn supports_effort(&self) -> bool { true }
-    fn supports_skills(&self) -> bool { true }
-    fn supports_attachments(&self) -> bool { true }
-    fn supports_fork(&self) -> bool { true }
-    fn uses_claude_jsonl(&self) -> bool { true }
+    fn supports_plan_mode(&self) -> bool {
+        true
+    }
+    fn supports_effort(&self) -> bool {
+        true
+    }
+    fn supports_skills(&self) -> bool {
+        true
+    }
+    fn supports_attachments(&self) -> bool {
+        true
+    }
+    fn supports_fork(&self) -> bool {
+        true
+    }
+    fn uses_claude_jsonl(&self) -> bool {
+        true
+    }
 
     fn extract_resume_id(&self, v: &serde_json::Value) -> Option<String> {
         let t = v.get("type")?.as_str()?;

--- a/src-tauri/src/agent/codex.rs
+++ b/src-tauri/src/agent/codex.rs
@@ -12,10 +12,18 @@ use super::{Agent, AgentKind, InputMode, SessionArgs};
 pub struct Codex;
 
 impl Agent for Codex {
-    fn kind(&self) -> AgentKind { AgentKind::Codex }
-    fn display_name(&self) -> &'static str { "Codex" }
-    fn cli_binary(&self) -> &'static str { "codex" }
-    fn input_mode(&self) -> InputMode { InputMode::PositionalOrStdin }
+    fn kind(&self) -> AgentKind {
+        AgentKind::Codex
+    }
+    fn display_name(&self) -> &'static str {
+        "Codex"
+    }
+    fn cli_binary(&self) -> &'static str {
+        "codex"
+    }
+    fn input_mode(&self) -> InputMode {
+        InputMode::PositionalOrStdin
+    }
 
     fn install_hint(&self) -> &'static str {
         "npm i -g @openai/codex"
@@ -29,11 +37,31 @@ impl Agent for Codex {
         use crate::agent::ModelOption;
         vec![
             ModelOption::new("gpt-5.4", "GPT-5.4", "Latest frontier agentic coding model"),
-            ModelOption::new("gpt-5.4-mini", "GPT-5.4 Mini", "Smaller frontier agentic coding model"),
-            ModelOption::new("gpt-5.3-codex", "GPT-5.3 Codex", "Codex-optimized agentic coding model"),
-            ModelOption::new("gpt-5.3-codex-spark", "GPT-5.3 Codex Spark", "Lightweight Codex model"),
-            ModelOption::new("gpt-5.2-codex", "GPT-5.2 Codex", "Codex-optimized agentic coding model"),
-            ModelOption::new("gpt-5.2", "GPT-5.2", "Optimized for professional work and long-running tasks"),
+            ModelOption::new(
+                "gpt-5.4-mini",
+                "GPT-5.4 Mini",
+                "Smaller frontier agentic coding model",
+            ),
+            ModelOption::new(
+                "gpt-5.3-codex",
+                "GPT-5.3 Codex",
+                "Codex-optimized agentic coding model",
+            ),
+            ModelOption::new(
+                "gpt-5.3-codex-spark",
+                "GPT-5.3 Codex Spark",
+                "Lightweight Codex model",
+            ),
+            ModelOption::new(
+                "gpt-5.2-codex",
+                "GPT-5.2 Codex",
+                "Codex-optimized agentic coding model",
+            ),
+            ModelOption::new(
+                "gpt-5.2",
+                "GPT-5.2",
+                "Optimized for professional work and long-running tasks",
+            ),
         ]
     }
 
@@ -60,7 +88,9 @@ impl Agent for Codex {
         v
     }
 
-    fn supports_attachments(&self) -> bool { true }
+    fn supports_attachments(&self) -> bool {
+        true
+    }
 
     fn extract_resume_id(&self, v: &serde_json::Value) -> Option<String> {
         if v.get("type")?.as_str()? == "thread.started" {

--- a/src-tauri/src/agent/cursor.rs
+++ b/src-tauri/src/agent/cursor.rs
@@ -12,10 +12,18 @@ use super::{Agent, AgentKind, InputMode, SessionArgs};
 pub struct Cursor;
 
 impl Agent for Cursor {
-    fn kind(&self) -> AgentKind { AgentKind::Cursor }
-    fn display_name(&self) -> &'static str { "Cursor Agent" }
-    fn cli_binary(&self) -> &'static str { "agent" }
-    fn input_mode(&self) -> InputMode { InputMode::PositionalOrStdin }
+    fn kind(&self) -> AgentKind {
+        AgentKind::Cursor
+    }
+    fn display_name(&self) -> &'static str {
+        "Cursor Agent"
+    }
+    fn cli_binary(&self) -> &'static str {
+        "agent"
+    }
+    fn input_mode(&self) -> InputMode {
+        InputMode::PositionalOrStdin
+    }
 
     fn install_hint(&self) -> &'static str {
         "curl https://cursor.com/install -fsSL | bash"
@@ -45,19 +53,24 @@ impl Agent for Cursor {
         // Output format (one per line):
         //   <id> - <Name>  (default)
         // Skip "Available models" header and "Tip:" footer.
-        output.lines()
+        output
+            .lines()
             .filter_map(|line| {
                 let line = line.trim();
                 let sep = line.find(" - ")?;
                 let id = line[..sep].trim();
-                if id.is_empty() { return None; }
+                if id.is_empty() {
+                    return None;
+                }
                 // Strip trailing "(default)" from the display name
                 let name = line[sep + 3..]
                     .trim()
                     .trim_end_matches("(default)")
                     .trim()
                     .to_string();
-                if name.is_empty() { return None; }
+                if name.is_empty() {
+                    return None;
+                }
                 Some(crate::agent::ModelOption::new(id, &name, ""))
             })
             .collect()
@@ -66,7 +79,8 @@ impl Agent for Cursor {
     fn build_session_args(&self, args: &SessionArgs<'_>) -> Vec<String> {
         let mut v = vec![
             "-p".into(),
-            "--output-format".into(), "stream-json".into(),
+            "--output-format".into(),
+            "stream-json".into(),
             "--stream-partial-output".into(),
             "--force".into(),
             "--trust".into(),
@@ -90,7 +104,9 @@ impl Agent for Cursor {
         v
     }
 
-    fn supports_plan_mode(&self) -> bool { true }
+    fn supports_plan_mode(&self) -> bool {
+        true
+    }
 
     fn extract_resume_id(&self, v: &serde_json::Value) -> Option<String> {
         let t = v.get("type")?.as_str()?;

--- a/src-tauri/src/agent/gemini.rs
+++ b/src-tauri/src/agent/gemini.rs
@@ -11,10 +11,18 @@ use super::{Agent, AgentKind, InputMode, SessionArgs};
 pub struct Gemini;
 
 impl Agent for Gemini {
-    fn kind(&self) -> AgentKind { AgentKind::Gemini }
-    fn display_name(&self) -> &'static str { "Gemini CLI" }
-    fn cli_binary(&self) -> &'static str { "gemini" }
-    fn input_mode(&self) -> InputMode { InputMode::PositionalOrStdin }
+    fn kind(&self) -> AgentKind {
+        AgentKind::Gemini
+    }
+    fn display_name(&self) -> &'static str {
+        "Gemini CLI"
+    }
+    fn cli_binary(&self) -> &'static str {
+        "gemini"
+    }
+    fn input_mode(&self) -> InputMode {
+        InputMode::PositionalOrStdin
+    }
 
     fn install_hint(&self) -> &'static str {
         "npm i -g @google/gemini-cli"
@@ -28,15 +36,24 @@ impl Agent for Gemini {
         use crate::agent::ModelOption;
         vec![
             ModelOption::new("auto", "Auto", "Automatic model selection based on task"),
-            ModelOption::new("pro", "Gemini Pro", "Gemini 3 Pro - Complex reasoning tasks"),
+            ModelOption::new(
+                "pro",
+                "Gemini Pro",
+                "Gemini 3 Pro - Complex reasoning tasks",
+            ),
             ModelOption::new("flash", "Gemini Flash", "Gemini 2.5 Flash - Fast responses"),
-            ModelOption::new("flash-lite", "Gemini Flash Lite", "Lightweight flash variant"),
+            ModelOption::new(
+                "flash-lite",
+                "Gemini Flash Lite",
+                "Lightweight flash variant",
+            ),
         ]
     }
 
     fn build_session_args(&self, args: &SessionArgs<'_>) -> Vec<String> {
         let mut v: Vec<String> = vec![
-            "--output-format".into(), "stream-json".into(),
+            "--output-format".into(),
+            "stream-json".into(),
             "--yolo".into(),
         ];
 
@@ -58,13 +75,23 @@ impl Agent for Gemini {
         v
     }
 
-    fn supports_plan_mode(&self) -> bool { true }
-    fn supports_attachments(&self) -> bool { true }
+    fn supports_plan_mode(&self) -> bool {
+        true
+    }
+    fn supports_attachments(&self) -> bool {
+        true
+    }
 
     fn extract_resume_id(&self, v: &serde_json::Value) -> Option<String> {
         // Gemini stream-json emits an init event with session metadata.
         // Try common field names for the session identifier.
-        v.get("sessionId").and_then(|s| s.as_str()).map(str::to_string)
-            .or_else(|| v.get("session_id").and_then(|s| s.as_str()).map(str::to_string))
+        v.get("sessionId")
+            .and_then(|s| s.as_str())
+            .map(str::to_string)
+            .or_else(|| {
+                v.get("session_id")
+                    .and_then(|s| s.as_str())
+                    .map(str::to_string)
+            })
     }
 }

--- a/src-tauri/src/agent/mod.rs
+++ b/src-tauri/src/agent/mod.rs
@@ -49,7 +49,13 @@ impl AgentKind {
     }
 
     pub fn all() -> &'static [AgentKind] {
-        &[Self::Claude, Self::Codex, Self::Gemini, Self::OpenCode, Self::Cursor]
+        &[
+            Self::Claude,
+            Self::Codex,
+            Self::Gemini,
+            Self::OpenCode,
+            Self::Cursor,
+        ]
     }
 
     /// Return a boxed trait object for this agent kind.
@@ -86,7 +92,12 @@ pub struct ModelOption {
 
 impl ModelOption {
     pub fn new(id: &str, label: &str, description: &str) -> Self {
-        Self { id: id.into(), label: label.into(), description: description.into(), min_version: None }
+        Self {
+            id: id.into(),
+            label: label.into(),
+            description: description.into(),
+            min_version: None,
+        }
     }
 
     pub fn with_min_version(mut self, version: &str) -> Self {
@@ -140,14 +151,18 @@ pub trait Agent: Send + Sync {
     fn build_session_args(&self, args: &SessionArgs<'_>) -> Vec<String>;
 
     /// Arguments to check the CLI version (e.g. `["--version"]`).
-    fn version_args(&self) -> &[&str] { &["--version"] }
+    fn version_args(&self) -> &[&str] {
+        &["--version"]
+    }
 
     /// Human-readable install instructions.
     fn install_hint(&self) -> &'static str;
 
     /// Command to update the CLI to the latest version.
     /// Defaults to `install_hint` if not overridden.
-    fn update_hint(&self) -> &'static str { self.install_hint() }
+    fn update_hint(&self) -> &'static str {
+        self.install_hint()
+    }
 
     /// Static fallback model list (first = default). Used when dynamic listing
     /// is unavailable or fails.
@@ -155,36 +170,62 @@ pub trait Agent: Send + Sync {
 
     /// CLI args to dynamically list models (e.g. `["--list-models"]`).
     /// Returns `None` if the agent has no such command.
-    fn model_list_args(&self) -> Option<Vec<String>> { None }
+    fn model_list_args(&self) -> Option<Vec<String>> {
+        None
+    }
 
     /// Parse the stdout of the model-listing command into `ModelOption`s.
-    fn parse_model_list(&self, _output: &str) -> Vec<ModelOption> { vec![] }
+    fn parse_model_list(&self, _output: &str) -> Vec<ModelOption> {
+        vec![]
+    }
 
     /// URL to the agent's official documentation / install page.
-    fn docs_url(&self) -> &'static str { "" }
+    fn docs_url(&self) -> &'static str {
+        ""
+    }
 
     // ── Capability flags ─────────────────────────────────────────────────
     // Override only the ones that differ from the defaults.
 
-    fn supports_streaming(&self) -> bool { true }
-    fn supports_resume(&self) -> bool { true }
-    fn supports_plan_mode(&self) -> bool { false }
-    fn supports_model_selection(&self) -> bool { true }
-    fn supports_effort(&self) -> bool { false }
-    fn supports_skills(&self) -> bool { false }
-    fn supports_attachments(&self) -> bool { false }
-    fn supports_fork(&self) -> bool { false }
+    fn supports_streaming(&self) -> bool {
+        true
+    }
+    fn supports_resume(&self) -> bool {
+        true
+    }
+    fn supports_plan_mode(&self) -> bool {
+        false
+    }
+    fn supports_model_selection(&self) -> bool {
+        true
+    }
+    fn supports_effort(&self) -> bool {
+        false
+    }
+    fn supports_skills(&self) -> bool {
+        false
+    }
+    fn supports_attachments(&self) -> bool {
+        false
+    }
+    fn supports_fork(&self) -> bool {
+        false
+    }
 
     /// Whether this agent uses Claude Code's on-disk JSONL transcript
     /// format at ~/.claude/projects/. Gates transcript manipulation
     /// in fork operations.
-    fn uses_claude_jsonl(&self) -> bool { false }
+    fn uses_claude_jsonl(&self) -> bool {
+        false
+    }
 
     /// Extract the agent's native resume/session ID from a parsed NDJSON event.
     /// Called on each line during streaming; returns `Some(id)` on the first
     /// event that carries one (e.g. Claude's `system.init`, Codex's
     /// `thread.started`, OpenCode's `step_start`).
-    fn extract_resume_id(&self, _v: &serde_json::Value) -> Option<String> { None }
+    fn extract_resume_id(&self, _v: &serde_json::Value) -> Option<String> {
+        None
+    }
 }
 
 #[cfg(test)]
@@ -230,14 +271,20 @@ mod tests {
     #[test]
     fn claude_build_args_plan_mode() {
         let agent = Claude;
-        let args = agent.build_session_args(&SessionArgs { plan_mode: true, ..default_args() });
+        let args = agent.build_session_args(&SessionArgs {
+            plan_mode: true,
+            ..default_args()
+        });
         assert!(args.contains(&"plan".to_string()));
     }
 
     #[test]
     fn claude_build_args_resume() {
         let agent = Claude;
-        let args = agent.build_session_args(&SessionArgs { resume_session_id: Some("sess-1"), ..default_args() });
+        let args = agent.build_session_args(&SessionArgs {
+            resume_session_id: Some("sess-1"),
+            ..default_args()
+        });
         assert!(args.contains(&"--resume".to_string()));
         assert!(args.contains(&"sess-1".to_string()));
     }
@@ -245,7 +292,10 @@ mod tests {
     #[test]
     fn claude_build_args_model() {
         let agent = Claude;
-        let args = agent.build_session_args(&SessionArgs { model: Some("opus"), ..default_args() });
+        let args = agent.build_session_args(&SessionArgs {
+            model: Some("opus"),
+            ..default_args()
+        });
         assert!(args.contains(&"--model".to_string()));
         assert!(args.contains(&"opus".to_string()));
     }
@@ -253,7 +303,10 @@ mod tests {
     #[test]
     fn claude_build_args_thinking() {
         let agent = Claude;
-        let args = agent.build_session_args(&SessionArgs { thinking_mode: true, ..default_args() });
+        let args = agent.build_session_args(&SessionArgs {
+            thinking_mode: true,
+            ..default_args()
+        });
         assert!(args.contains(&"--effort".to_string()));
         assert!(args.contains(&"max".to_string()));
     }
@@ -261,7 +314,10 @@ mod tests {
     #[test]
     fn claude_build_args_fast() {
         let agent = Claude;
-        let args = agent.build_session_args(&SessionArgs { fast_mode: true, ..default_args() });
+        let args = agent.build_session_args(&SessionArgs {
+            fast_mode: true,
+            ..default_args()
+        });
         assert!(args.contains(&"--effort".to_string()));
         assert!(args.contains(&"low".to_string()));
     }
@@ -303,7 +359,10 @@ mod tests {
     #[test]
     fn codex_build_args_basic() {
         let agent = Codex;
-        let args = agent.build_session_args(&SessionArgs { message: "fix the bug", ..default_args() });
+        let args = agent.build_session_args(&SessionArgs {
+            message: "fix the bug",
+            ..default_args()
+        });
         assert!(args.contains(&"exec".to_string()));
         assert!(args.contains(&"--json".to_string()));
         assert!(args.contains(&"--full-auto".to_string()));
@@ -313,7 +372,10 @@ mod tests {
     #[test]
     fn codex_build_args_resume() {
         let agent = Codex;
-        let args = agent.build_session_args(&SessionArgs { resume_session_id: Some("t-1"), ..default_args() });
+        let args = agent.build_session_args(&SessionArgs {
+            resume_session_id: Some("t-1"),
+            ..default_args()
+        });
         assert!(args.contains(&"resume".to_string()));
         assert!(args.contains(&"t-1".to_string()));
     }
@@ -348,7 +410,10 @@ mod tests {
     #[test]
     fn cursor_build_args_basic() {
         let agent = Cursor;
-        let args = agent.build_session_args(&SessionArgs { message: "hello", ..default_args() });
+        let args = agent.build_session_args(&SessionArgs {
+            message: "hello",
+            ..default_args()
+        });
         assert!(args.contains(&"-p".to_string()));
         assert!(args.contains(&"stream-json".to_string()));
         assert!(args.contains(&"--force".to_string()));
@@ -358,7 +423,10 @@ mod tests {
     #[test]
     fn cursor_build_args_plan_mode() {
         let agent = Cursor;
-        let args = agent.build_session_args(&SessionArgs { plan_mode: true, ..default_args() });
+        let args = agent.build_session_args(&SessionArgs {
+            plan_mode: true,
+            ..default_args()
+        });
         assert!(args.contains(&"--mode".to_string()));
         assert!(args.contains(&"plan".to_string()));
     }
@@ -404,7 +472,10 @@ mod tests {
     #[test]
     fn opencode_build_args_basic() {
         let agent = OpenCode;
-        let args = agent.build_session_args(&SessionArgs { message: "do it", ..default_args() });
+        let args = agent.build_session_args(&SessionArgs {
+            message: "do it",
+            ..default_args()
+        });
         assert!(args.contains(&"run".to_string()));
         assert!(args.contains(&"--format".to_string()));
         assert!(args.contains(&"json".to_string()));
@@ -414,7 +485,10 @@ mod tests {
     #[test]
     fn opencode_build_args_plan_mode() {
         let agent = OpenCode;
-        let args = agent.build_session_args(&SessionArgs { plan_mode: true, ..default_args() });
+        let args = agent.build_session_args(&SessionArgs {
+            plan_mode: true,
+            ..default_args()
+        });
         assert!(args.contains(&"--agent".to_string()));
         assert!(args.contains(&"plan".to_string()));
     }
@@ -422,7 +496,10 @@ mod tests {
     #[test]
     fn opencode_build_args_resume() {
         let agent = OpenCode;
-        let args = agent.build_session_args(&SessionArgs { resume_session_id: Some("oc-1"), ..default_args() });
+        let args = agent.build_session_args(&SessionArgs {
+            resume_session_id: Some("oc-1"),
+            ..default_args()
+        });
         assert!(args.contains(&"--session".to_string()));
         assert!(args.contains(&"oc-1".to_string()));
     }
@@ -455,7 +532,8 @@ mod tests {
     #[test]
     fn opencode_parse_model_list() {
         let agent = OpenCode;
-        let output = "anthropic/claude-sonnet-4-5\nopenai/gpt-5.3\nsome migration message with spaces\n";
+        let output =
+            "anthropic/claude-sonnet-4-5\nopenai/gpt-5.3\nsome migration message with spaces\n";
         let models = agent.parse_model_list(output);
         assert_eq!(models.len(), 2);
         assert_eq!(models[0].id, "anthropic/claude-sonnet-4-5");
@@ -468,7 +546,10 @@ mod tests {
     #[test]
     fn gemini_build_args_basic() {
         let agent = Gemini;
-        let args = agent.build_session_args(&SessionArgs { message: "hello", ..default_args() });
+        let args = agent.build_session_args(&SessionArgs {
+            message: "hello",
+            ..default_args()
+        });
         assert!(args.contains(&"stream-json".to_string()));
         assert!(args.contains(&"--yolo".to_string()));
         assert!(args.contains(&"-p".to_string()));
@@ -478,7 +559,10 @@ mod tests {
     #[test]
     fn gemini_build_args_plan_mode() {
         let agent = Gemini;
-        let args = agent.build_session_args(&SessionArgs { plan_mode: true, ..default_args() });
+        let args = agent.build_session_args(&SessionArgs {
+            plan_mode: true,
+            ..default_args()
+        });
         assert!(args.contains(&"--approval-mode".to_string()));
         assert!(args.contains(&"plan".to_string()));
     }
@@ -486,7 +570,10 @@ mod tests {
     #[test]
     fn gemini_build_args_resume() {
         let agent = Gemini;
-        let args = agent.build_session_args(&SessionArgs { resume_session_id: Some("g-1"), ..default_args() });
+        let args = agent.build_session_args(&SessionArgs {
+            resume_session_id: Some("g-1"),
+            ..default_args()
+        });
         assert!(args.contains(&"--resume".to_string()));
         assert!(args.contains(&"g-1".to_string()));
     }
@@ -494,7 +581,10 @@ mod tests {
     #[test]
     fn gemini_build_args_model() {
         let agent = Gemini;
-        let args = agent.build_session_args(&SessionArgs { model: Some("pro"), ..default_args() });
+        let args = agent.build_session_args(&SessionArgs {
+            model: Some("pro"),
+            ..default_args()
+        });
         assert!(args.contains(&"-m".to_string()));
         assert!(args.contains(&"pro".to_string()));
     }
@@ -537,9 +627,18 @@ mod tests {
     fn all_agents_have_display_name_and_binary() {
         for &kind in AgentKind::all() {
             let agent = kind.implementation();
-            assert!(!agent.display_name().is_empty(), "{kind:?} has empty display_name");
-            assert!(!agent.cli_binary().is_empty(), "{kind:?} has empty cli_binary");
-            assert!(!agent.install_hint().is_empty(), "{kind:?} has empty install_hint");
+            assert!(
+                !agent.display_name().is_empty(),
+                "{kind:?} has empty display_name"
+            );
+            assert!(
+                !agent.cli_binary().is_empty(),
+                "{kind:?} has empty cli_binary"
+            );
+            assert!(
+                !agent.install_hint().is_empty(),
+                "{kind:?} has empty install_hint"
+            );
         }
     }
 }

--- a/src-tauri/src/agent/opencode.rs
+++ b/src-tauri/src/agent/opencode.rs
@@ -13,10 +13,18 @@ use super::{Agent, AgentKind, InputMode, SessionArgs};
 pub struct OpenCode;
 
 impl Agent for OpenCode {
-    fn kind(&self) -> AgentKind { AgentKind::OpenCode }
-    fn display_name(&self) -> &'static str { "OpenCode" }
-    fn cli_binary(&self) -> &'static str { "opencode" }
-    fn input_mode(&self) -> InputMode { InputMode::PositionalOrStdin }
+    fn kind(&self) -> AgentKind {
+        AgentKind::OpenCode
+    }
+    fn display_name(&self) -> &'static str {
+        "OpenCode"
+    }
+    fn cli_binary(&self) -> &'static str {
+        "opencode"
+    }
+    fn input_mode(&self) -> InputMode {
+        InputMode::PositionalOrStdin
+    }
 
     fn install_hint(&self) -> &'static str {
         "curl -fsSL https://opencode.ai/install | bash"
@@ -39,11 +47,14 @@ impl Agent for OpenCode {
     fn parse_model_list(&self, output: &str) -> Vec<crate::agent::ModelOption> {
         // Output format (one per line): provider/model-id
         // Ignore migration messages and any line that isn't provider/model format.
-        output.lines()
+        output
+            .lines()
             .filter_map(|line| {
                 let line = line.trim();
                 // Must contain exactly one '/' and no whitespace
-                if !line.contains('/') || line.contains(' ') { return None; }
+                if !line.contains('/') || line.contains(' ') {
+                    return None;
+                }
                 let label = line.split('/').next_back().unwrap_or(line).to_string();
                 Some(crate::agent::ModelOption::new(line, &label, ""))
             })
@@ -71,8 +82,12 @@ impl Agent for OpenCode {
         v
     }
 
-    fn supports_plan_mode(&self) -> bool { true }
-    fn supports_attachments(&self) -> bool { true }
+    fn supports_plan_mode(&self) -> bool {
+        true
+    }
+    fn supports_attachments(&self) -> bool {
+        true
+    }
 
     fn extract_resume_id(&self, v: &serde_json::Value) -> Option<String> {
         v.get("sessionID")?.as_str().map(str::to_string)

--- a/src-tauri/src/claude_jsonl.rs
+++ b/src-tauri/src/claude_jsonl.rs
@@ -126,11 +126,10 @@ pub fn truncate_after_message(
             .map(|u| u == last_kept_uuid)
             .unwrap_or(false);
 
-        let serialized =
-            serde_json::to_string(&value).map_err(|e| JsonlError::MalformedLine {
-                line_no,
-                reason: e.to_string(),
-            })?;
+        let serialized = serde_json::to_string(&value).map_err(|e| JsonlError::MalformedLine {
+            line_no,
+            reason: e.to_string(),
+        })?;
         writeln!(out, "{serialized}").map_err(|e| JsonlError::Io(e.to_string()))?;
 
         if uuid_match {

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -324,39 +324,103 @@ pub struct Step {
 pub enum DbWrite {
     // Projects
     InsertProject(Project),
-    UpdateProjectBaseBranch { id: String, base_branch: String },
-    UpdateProjectHooks { id: String, setup_hook: String, destroy_hook: String, start_command: String, auto_start: bool },
-    UpdateProjectDefaultAgent { id: String, default_agent_type: String },
-    DeleteProject { id: String },
+    UpdateProjectBaseBranch {
+        id: String,
+        base_branch: String,
+    },
+    UpdateProjectHooks {
+        id: String,
+        setup_hook: String,
+        destroy_hook: String,
+        start_command: String,
+        auto_start: bool,
+    },
+    UpdateProjectDefaultAgent {
+        id: String,
+        default_agent_type: String,
+    },
+    DeleteProject {
+        id: String,
+    },
 
     // Tasks
     InsertTask(Task),
-    UpdateTaskName { id: String, name: String },
-    SetMergeBaseSha { id: String, sha: String },
-    DeleteTask { id: String },
-    ArchiveTask { id: String, archived_at: i64, last_commit_message: Option<String> },
-    RestoreTask { id: String },
+    UpdateTaskName {
+        id: String,
+        name: String,
+    },
+    SetMergeBaseSha {
+        id: String,
+        sha: String,
+    },
+    DeleteTask {
+        id: String,
+    },
+    ArchiveTask {
+        id: String,
+        archived_at: i64,
+        last_commit_message: Option<String>,
+    },
+    RestoreTask {
+        id: String,
+    },
 
     // Sessions
     CreateSession(Session),
-    UpdateSessionName { id: String, name: String },
-    UpdateSessionStatus { id: String, status: String },
-    UpdateSessionModel { id: String, model: Option<String> },
-    SetResumeSessionId { id: String, resume_session_id: String },
-    EndSession { id: String, ended_at: i64 },
-    AccumulateSessionCost { id: String, cost: f64 },
-    CloseSession { id: String },
+    UpdateSessionName {
+        id: String,
+        name: String,
+    },
+    UpdateSessionStatus {
+        id: String,
+        status: String,
+    },
+    UpdateSessionModel {
+        id: String,
+        model: Option<String>,
+    },
+    SetResumeSessionId {
+        id: String,
+        resume_session_id: String,
+    },
+    EndSession {
+        id: String,
+        ended_at: i64,
+    },
+    AccumulateSessionCost {
+        id: String,
+        cost: f64,
+    },
+    CloseSession {
+        id: String,
+    },
 
     // Output
-    InsertOutputLines { session_id: String, lines: Vec<(String, i64)> },
-    DeleteOutputLines { session_id: String },
+    InsertOutputLines {
+        session_id: String,
+        lines: Vec<(String, i64)>,
+    },
+    DeleteOutputLines {
+        session_id: String,
+    },
 
     // Turn snapshots (per-turn worktree state for forking)
-    InsertTurnSnapshot { session_id: String, message_uuid: String, stash_sha: String, created_at: i64 },
-    DeleteTurnSnapshotsForSession { session_id: String },
+    InsertTurnSnapshot {
+        session_id: String,
+        message_uuid: String,
+        stash_sha: String,
+        created_at: i64,
+    },
+    DeleteTurnSnapshotsForSession {
+        session_id: String,
+    },
 
     // Policy
-    SetTrustLevel { task_id: String, trust_level: String, updated_at: i64 },
+    SetTrustLevel {
+        task_id: String,
+        trust_level: String,
+        updated_at: i64,
+    },
     InsertAuditEntry {
         session_id: String,
         task_id: String,
@@ -369,10 +433,26 @@ pub enum DbWrite {
 
     // Steps
     InsertStep(Step),
-    UpdateStep { id: String, message: String, armed: bool, model: Option<String>, plan_mode: Option<bool>, thinking_mode: Option<bool>, fast_mode: Option<bool>, attachments_json: Option<String> },
-    DeleteStep { id: String },
-    ReorderSteps { session_id: String, ids: Vec<String> },
-    DisarmAllSteps { session_id: String },
+    UpdateStep {
+        id: String,
+        message: String,
+        armed: bool,
+        model: Option<String>,
+        plan_mode: Option<bool>,
+        thinking_mode: Option<bool>,
+        fast_mode: Option<bool>,
+        attachments_json: Option<String>,
+    },
+    DeleteStep {
+        id: String,
+    },
+    ReorderSteps {
+        session_id: String,
+        ids: Vec<String>,
+    },
+    DisarmAllSteps {
+        session_id: String,
+    },
 
     // Startup recovery
     ResetRunningSessions,
@@ -420,7 +500,13 @@ async fn process_write(pool: &SqlitePool, write: DbWrite) -> Result<(), sqlx::Er
                 .execute(pool)
                 .await?;
         }
-        DbWrite::UpdateProjectHooks { id, setup_hook, destroy_hook, start_command, auto_start } => {
+        DbWrite::UpdateProjectHooks {
+            id,
+            setup_hook,
+            destroy_hook,
+            start_command,
+            auto_start,
+        } => {
             sqlx::query("UPDATE projects SET setup_hook = ?, destroy_hook = ?, start_command = ?, auto_start = ? WHERE id = ?")
                 .bind(&setup_hook)
                 .bind(&destroy_hook)
@@ -430,7 +516,10 @@ async fn process_write(pool: &SqlitePool, write: DbWrite) -> Result<(), sqlx::Er
                 .execute(pool)
                 .await?;
         }
-        DbWrite::UpdateProjectDefaultAgent { id, default_agent_type } => {
+        DbWrite::UpdateProjectDefaultAgent {
+            id,
+            default_agent_type,
+        } => {
             sqlx::query("UPDATE projects SET default_agent_type = ? WHERE id = ?")
                 .bind(&default_agent_type)
                 .bind(&id)
@@ -443,12 +532,16 @@ async fn process_write(pool: &SqlitePool, write: DbWrite) -> Result<(), sqlx::Er
                 "DELETE FROM policy_audit_log WHERE task_id IN \
                  (SELECT id FROM tasks WHERE project_id = ?)",
             )
-            .bind(&id).execute(pool).await?;
+            .bind(&id)
+            .execute(pool)
+            .await?;
             sqlx::query(
                 "DELETE FROM task_trust_levels WHERE task_id IN \
                  (SELECT id FROM tasks WHERE project_id = ?)",
             )
-            .bind(&id).execute(pool).await?;
+            .bind(&id)
+            .execute(pool)
+            .await?;
             sqlx::query(
                 "DELETE FROM steps WHERE session_id IN \
                  (SELECT s.id FROM sessions s JOIN tasks t ON s.task_id = t.id WHERE t.project_id = ?)",
@@ -468,11 +561,17 @@ async fn process_write(pool: &SqlitePool, write: DbWrite) -> Result<(), sqlx::Er
                 "DELETE FROM sessions WHERE task_id IN \
                  (SELECT id FROM tasks WHERE project_id = ?)",
             )
-            .bind(&id).execute(pool).await?;
+            .bind(&id)
+            .execute(pool)
+            .await?;
             sqlx::query("DELETE FROM tasks WHERE project_id = ?")
-                .bind(&id).execute(pool).await?;
+                .bind(&id)
+                .execute(pool)
+                .await?;
             sqlx::query("DELETE FROM projects WHERE id = ?")
-                .bind(&id).execute(pool).await?;
+                .bind(&id)
+                .execute(pool)
+                .await?;
         }
 
         // -- Tasks --
@@ -509,38 +608,58 @@ async fn process_write(pool: &SqlitePool, write: DbWrite) -> Result<(), sqlx::Er
         }
         DbWrite::DeleteTask { id } => {
             sqlx::query("DELETE FROM policy_audit_log WHERE task_id = ?")
-                .bind(&id).execute(pool).await?;
+                .bind(&id)
+                .execute(pool)
+                .await?;
             sqlx::query("DELETE FROM task_trust_levels WHERE task_id = ?")
-                .bind(&id).execute(pool).await?;
+                .bind(&id)
+                .execute(pool)
+                .await?;
             sqlx::query(
                 "DELETE FROM steps WHERE session_id IN \
                  (SELECT id FROM sessions WHERE task_id = ?)",
             )
-            .bind(&id).execute(pool).await?;
+            .bind(&id)
+            .execute(pool)
+            .await?;
             sqlx::query(
                 "DELETE FROM output_lines WHERE session_id IN \
                  (SELECT id FROM sessions WHERE task_id = ?)",
             )
-            .bind(&id).execute(pool).await?;
+            .bind(&id)
+            .execute(pool)
+            .await?;
             sqlx::query(
                 "DELETE FROM turn_snapshots WHERE session_id IN \
                  (SELECT id FROM sessions WHERE task_id = ?)",
             )
-            .bind(&id).execute(pool).await?;
+            .bind(&id)
+            .execute(pool)
+            .await?;
             sqlx::query("DELETE FROM sessions WHERE task_id = ?")
-                .bind(&id).execute(pool).await?;
+                .bind(&id)
+                .execute(pool)
+                .await?;
             sqlx::query("DELETE FROM tasks WHERE id = ?")
-                .bind(&id).execute(pool).await?;
+                .bind(&id)
+                .execute(pool)
+                .await?;
         }
 
-        DbWrite::ArchiveTask { id, archived_at, last_commit_message } => {
+        DbWrite::ArchiveTask {
+            id,
+            archived_at,
+            last_commit_message,
+        } => {
             sqlx::query("UPDATE tasks SET archived = 1, archived_at = ?, last_commit_message = ? WHERE id = ?")
                 .bind(archived_at).bind(&last_commit_message).bind(&id).execute(pool).await?;
         }
 
         DbWrite::RestoreTask { id } => {
             sqlx::query("UPDATE tasks SET archived = 0, archived_at = NULL WHERE id = ?")
-                .bind(&id).execute(pool).await?;
+                .bind(&id)
+                .execute(pool)
+                .await?;
         }
 
         // -- Sessions --
@@ -585,7 +704,10 @@ async fn process_write(pool: &SqlitePool, write: DbWrite) -> Result<(), sqlx::Er
                 .execute(pool)
                 .await?;
         }
-        DbWrite::SetResumeSessionId { id, resume_session_id } => {
+        DbWrite::SetResumeSessionId {
+            id,
+            resume_session_id,
+        } => {
             sqlx::query("UPDATE sessions SET resume_session_id = ? WHERE id = ?")
                 .bind(&resume_session_id)
                 .bind(&id)
@@ -637,7 +759,12 @@ async fn process_write(pool: &SqlitePool, write: DbWrite) -> Result<(), sqlx::Er
                 .await?;
         }
 
-        DbWrite::InsertTurnSnapshot { session_id, message_uuid, stash_sha, created_at } => {
+        DbWrite::InsertTurnSnapshot {
+            session_id,
+            message_uuid,
+            stash_sha,
+            created_at,
+        } => {
             sqlx::query(
                 "INSERT OR REPLACE INTO turn_snapshots (session_id, message_uuid, stash_sha, created_at) \
                  VALUES (?, ?, ?, ?)",
@@ -657,7 +784,11 @@ async fn process_write(pool: &SqlitePool, write: DbWrite) -> Result<(), sqlx::Er
         }
 
         // -- Policy --
-        DbWrite::SetTrustLevel { task_id, trust_level, updated_at } => {
+        DbWrite::SetTrustLevel {
+            task_id,
+            trust_level,
+            updated_at,
+        } => {
             sqlx::query(
                 "INSERT INTO task_trust_levels (task_id, trust_level, updated_at) \
                  VALUES (?, ?, ?) \
@@ -669,7 +800,15 @@ async fn process_write(pool: &SqlitePool, write: DbWrite) -> Result<(), sqlx::Er
             .execute(pool)
             .await?;
         }
-        DbWrite::InsertAuditEntry { session_id, task_id, tool_name, tool_input_summary, decision, reason, created_at } => {
+        DbWrite::InsertAuditEntry {
+            session_id,
+            task_id,
+            tool_name,
+            tool_input_summary,
+            decision,
+            reason,
+            created_at,
+        } => {
             sqlx::query(
                 "INSERT INTO policy_audit_log (session_id, task_id, tool_name, tool_input_summary, decision, reason, created_at) \
                  VALUES (?, ?, ?, ?, ?, ?, ?)",
@@ -705,7 +844,16 @@ async fn process_write(pool: &SqlitePool, write: DbWrite) -> Result<(), sqlx::Er
             .execute(pool)
             .await?;
         }
-        DbWrite::UpdateStep { id, message, armed, model, plan_mode, thinking_mode, fast_mode, attachments_json } => {
+        DbWrite::UpdateStep {
+            id,
+            message,
+            armed,
+            model,
+            plan_mode,
+            thinking_mode,
+            fast_mode,
+            attachments_json,
+        } => {
             sqlx::query("UPDATE steps SET message = ?, armed = ?, model = ?, plan_mode = ?, thinking_mode = ?, fast_mode = ?, attachments_json = ? WHERE id = ?")
                 .bind(&message)
                 .bind(armed)
@@ -796,13 +944,12 @@ pub async fn list_tasks_for_project(
 }
 
 pub async fn next_port_offset(pool: &SqlitePool, project_id: &str) -> Result<i64, String> {
-    let row: Option<(i64,)> = sqlx::query_as(
-        "SELECT COALESCE(MAX(port_offset), -1) FROM tasks WHERE project_id = ?",
-    )
-    .bind(project_id)
-    .fetch_optional(pool)
-    .await
-    .map_err(|e| e.to_string())?;
+    let row: Option<(i64,)> =
+        sqlx::query_as("SELECT COALESCE(MAX(port_offset), -1) FROM tasks WHERE project_id = ?")
+            .bind(project_id)
+            .fetch_optional(pool)
+            .await
+            .map_err(|e| e.to_string())?;
 
     Ok(row.map(|(max,)| max + 1).unwrap_or(0))
 }
@@ -865,25 +1012,22 @@ pub async fn get_turn_snapshot(
 // Steps
 
 pub async fn list_steps(pool: &SqlitePool, session_id: &str) -> Result<Vec<Step>, String> {
-    sqlx::query_as::<_, Step>(
-        "SELECT * FROM steps WHERE session_id = ? ORDER BY sort_order ASC",
-    )
-    .bind(session_id)
-    .fetch_all(pool)
-    .await
-    .map_err(|e| e.to_string())
+    sqlx::query_as::<_, Step>("SELECT * FROM steps WHERE session_id = ? ORDER BY sort_order ASC")
+        .bind(session_id)
+        .fetch_all(pool)
+        .await
+        .map_err(|e| e.to_string())
 }
 
 // Policy
 
 pub async fn get_trust_level(pool: &SqlitePool, task_id: &str) -> Result<String, String> {
-    let row: Option<(String,)> = sqlx::query_as(
-        "SELECT trust_level FROM task_trust_levels WHERE task_id = ?",
-    )
-    .bind(task_id)
-    .fetch_optional(pool)
-    .await
-    .map_err(|e| e.to_string())?;
+    let row: Option<(String,)> =
+        sqlx::query_as("SELECT trust_level FROM task_trust_levels WHERE task_id = ?")
+            .bind(task_id)
+            .fetch_optional(pool)
+            .await
+            .map_err(|e| e.to_string())?;
 
     Ok(row.map(|(tl,)| tl).unwrap_or_else(|| "normal".into()))
 }
@@ -1059,8 +1203,12 @@ mod tests {
         p2.created_at = 2000;
         p2.repo_path = "/tmp/b".into();
 
-        process_write(&pool, DbWrite::InsertProject(p1)).await.unwrap();
-        process_write(&pool, DbWrite::InsertProject(p2)).await.unwrap();
+        process_write(&pool, DbWrite::InsertProject(p1))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::InsertProject(p2))
+            .await
+            .unwrap();
 
         let projects = list_projects(&pool).await.unwrap();
         assert_eq!(projects.len(), 2);
@@ -1070,9 +1218,15 @@ mod tests {
     #[tokio::test]
     async fn delete_project_cascades() {
         let pool = test_pool().await;
-        process_write(&pool, DbWrite::InsertProject(make_project())).await.unwrap();
-        process_write(&pool, DbWrite::InsertTask(make_task("p-001"))).await.unwrap();
-        process_write(&pool, DbWrite::CreateSession(make_session("t-001"))).await.unwrap();
+        process_write(&pool, DbWrite::InsertProject(make_project()))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::InsertTask(make_task("p-001")))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::CreateSession(make_session("t-001")))
+            .await
+            .unwrap();
         process_write(
             &pool,
             DbWrite::InsertOutputLines {
@@ -1098,8 +1252,12 @@ mod tests {
     #[tokio::test]
     async fn insert_and_get_task() {
         let pool = test_pool().await;
-        process_write(&pool, DbWrite::InsertProject(make_project())).await.unwrap();
-        process_write(&pool, DbWrite::InsertTask(make_task("p-001"))).await.unwrap();
+        process_write(&pool, DbWrite::InsertProject(make_project()))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::InsertTask(make_task("p-001")))
+            .await
+            .unwrap();
 
         let t = get_task(&pool, "t-001").await.unwrap().unwrap();
         assert_eq!(t.project_id, "p-001");
@@ -1110,8 +1268,12 @@ mod tests {
     #[tokio::test]
     async fn update_task_name() {
         let pool = test_pool().await;
-        process_write(&pool, DbWrite::InsertProject(make_project())).await.unwrap();
-        process_write(&pool, DbWrite::InsertTask(make_task("p-001"))).await.unwrap();
+        process_write(&pool, DbWrite::InsertProject(make_project()))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::InsertTask(make_task("p-001")))
+            .await
+            .unwrap();
 
         process_write(
             &pool,
@@ -1134,8 +1296,12 @@ mod tests {
         p2.id = "p-002".into();
         p2.repo_path = "/tmp/other".into();
 
-        process_write(&pool, DbWrite::InsertProject(make_project())).await.unwrap();
-        process_write(&pool, DbWrite::InsertProject(p2)).await.unwrap();
+        process_write(&pool, DbWrite::InsertProject(make_project()))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::InsertProject(p2))
+            .await
+            .unwrap();
 
         let mut t1 = make_task("p-001");
         t1.id = "t-001".into();
@@ -1153,9 +1319,15 @@ mod tests {
     #[tokio::test]
     async fn delete_task_cascades() {
         let pool = test_pool().await;
-        process_write(&pool, DbWrite::InsertProject(make_project())).await.unwrap();
-        process_write(&pool, DbWrite::InsertTask(make_task("p-001"))).await.unwrap();
-        process_write(&pool, DbWrite::CreateSession(make_session("t-001"))).await.unwrap();
+        process_write(&pool, DbWrite::InsertProject(make_project()))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::InsertTask(make_task("p-001")))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::CreateSession(make_session("t-001")))
+            .await
+            .unwrap();
         process_write(
             &pool,
             DbWrite::InsertOutputLines {
@@ -1180,9 +1352,15 @@ mod tests {
     #[tokio::test]
     async fn archive_task_sets_flag_and_preserves_data() {
         let pool = test_pool().await;
-        process_write(&pool, DbWrite::InsertProject(make_project())).await.unwrap();
-        process_write(&pool, DbWrite::InsertTask(make_task("p-001"))).await.unwrap();
-        process_write(&pool, DbWrite::CreateSession(make_session("t-001"))).await.unwrap();
+        process_write(&pool, DbWrite::InsertProject(make_project()))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::InsertTask(make_task("p-001")))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::CreateSession(make_session("t-001")))
+            .await
+            .unwrap();
         process_write(
             &pool,
             DbWrite::InsertOutputLines {
@@ -1193,9 +1371,16 @@ mod tests {
         .await
         .unwrap();
 
-        process_write(&pool, DbWrite::ArchiveTask { id: "t-001".into(), archived_at: 9999, last_commit_message: Some("test commit".into()) })
-            .await
-            .unwrap();
+        process_write(
+            &pool,
+            DbWrite::ArchiveTask {
+                id: "t-001".into(),
+                archived_at: 9999,
+                last_commit_message: Some("test commit".into()),
+            },
+        )
+        .await
+        .unwrap();
 
         // Task still exists and is archived
         let task = get_task(&pool, "t-001").await.unwrap().unwrap();
@@ -1209,14 +1394,29 @@ mod tests {
     #[tokio::test]
     async fn restore_task_clears_archived_flag() {
         let pool = test_pool().await;
-        process_write(&pool, DbWrite::InsertProject(make_project())).await.unwrap();
-        process_write(&pool, DbWrite::InsertTask(make_task("p-001"))).await.unwrap();
+        process_write(&pool, DbWrite::InsertProject(make_project()))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::InsertTask(make_task("p-001")))
+            .await
+            .unwrap();
 
-        process_write(&pool, DbWrite::ArchiveTask { id: "t-001".into(), archived_at: 9999, last_commit_message: Some("test commit".into()) }).await.unwrap();
+        process_write(
+            &pool,
+            DbWrite::ArchiveTask {
+                id: "t-001".into(),
+                archived_at: 9999,
+                last_commit_message: Some("test commit".into()),
+            },
+        )
+        .await
+        .unwrap();
         let task = get_task(&pool, "t-001").await.unwrap().unwrap();
         assert!(task.archived);
 
-        process_write(&pool, DbWrite::RestoreTask { id: "t-001".into() }).await.unwrap();
+        process_write(&pool, DbWrite::RestoreTask { id: "t-001".into() })
+            .await
+            .unwrap();
         let task = get_task(&pool, "t-001").await.unwrap().unwrap();
         assert!(!task.archived);
     }
@@ -1224,7 +1424,9 @@ mod tests {
     #[tokio::test]
     async fn archived_tasks_sort_after_active() {
         let pool = test_pool().await;
-        process_write(&pool, DbWrite::InsertProject(make_project())).await.unwrap();
+        process_write(&pool, DbWrite::InsertProject(make_project()))
+            .await
+            .unwrap();
 
         let mut t1 = make_task("p-001");
         t1.id = "t-old".into();
@@ -1239,9 +1441,16 @@ mod tests {
         process_write(&pool, DbWrite::InsertTask(t1)).await.unwrap();
         process_write(&pool, DbWrite::InsertTask(t2)).await.unwrap();
         process_write(&pool, DbWrite::InsertTask(t3)).await.unwrap();
-        process_write(&pool, DbWrite::ArchiveTask { id: "t-archived".into(), archived_at: 9999, last_commit_message: None })
-            .await
-            .unwrap();
+        process_write(
+            &pool,
+            DbWrite::ArchiveTask {
+                id: "t-archived".into(),
+                archived_at: 9999,
+                last_commit_message: None,
+            },
+        )
+        .await
+        .unwrap();
 
         let tasks = list_tasks_for_project(&pool, "p-001").await.unwrap();
         assert_eq!(tasks.len(), 3);
@@ -1258,9 +1467,15 @@ mod tests {
     #[tokio::test]
     async fn session_lifecycle() {
         let pool = test_pool().await;
-        process_write(&pool, DbWrite::InsertProject(make_project())).await.unwrap();
-        process_write(&pool, DbWrite::InsertTask(make_task("p-001"))).await.unwrap();
-        process_write(&pool, DbWrite::CreateSession(make_session("t-001"))).await.unwrap();
+        process_write(&pool, DbWrite::InsertProject(make_project()))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::InsertTask(make_task("p-001")))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::CreateSession(make_session("t-001")))
+            .await
+            .unwrap();
 
         let s = get_session(&pool, "s-001").await.unwrap().unwrap();
         assert_eq!(s.status, "running");
@@ -1300,8 +1515,12 @@ mod tests {
     #[tokio::test]
     async fn multiple_sessions_per_task() {
         let pool = test_pool().await;
-        process_write(&pool, DbWrite::InsertProject(make_project())).await.unwrap();
-        process_write(&pool, DbWrite::InsertTask(make_task("p-001"))).await.unwrap();
+        process_write(&pool, DbWrite::InsertProject(make_project()))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::InsertTask(make_task("p-001")))
+            .await
+            .unwrap();
 
         let mut s1 = make_session("t-001");
         s1.id = "s-001".into();
@@ -1310,8 +1529,12 @@ mod tests {
         s2.id = "s-002".into();
         s2.started_at = 2000;
 
-        process_write(&pool, DbWrite::CreateSession(s1)).await.unwrap();
-        process_write(&pool, DbWrite::CreateSession(s2)).await.unwrap();
+        process_write(&pool, DbWrite::CreateSession(s1))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::CreateSession(s2))
+            .await
+            .unwrap();
 
         let sessions = list_sessions_for_task(&pool, "t-001").await.unwrap();
         assert_eq!(sessions.len(), 2);
@@ -1323,9 +1546,15 @@ mod tests {
     #[tokio::test]
     async fn insert_and_get_output_lines() {
         let pool = test_pool().await;
-        process_write(&pool, DbWrite::InsertProject(make_project())).await.unwrap();
-        process_write(&pool, DbWrite::InsertTask(make_task("p-001"))).await.unwrap();
-        process_write(&pool, DbWrite::CreateSession(make_session("t-001"))).await.unwrap();
+        process_write(&pool, DbWrite::InsertProject(make_project()))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::InsertTask(make_task("p-001")))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::CreateSession(make_session("t-001")))
+            .await
+            .unwrap();
 
         process_write(
             &pool,
@@ -1352,8 +1581,12 @@ mod tests {
     #[tokio::test]
     async fn reset_running_sessions() {
         let pool = test_pool().await;
-        process_write(&pool, DbWrite::InsertProject(make_project())).await.unwrap();
-        process_write(&pool, DbWrite::InsertTask(make_task("p-001"))).await.unwrap();
+        process_write(&pool, DbWrite::InsertProject(make_project()))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::InsertTask(make_task("p-001")))
+            .await
+            .unwrap();
 
         let mut s1 = make_session("t-001");
         s1.id = "s-run".into();
@@ -1362,10 +1595,16 @@ mod tests {
         s2.id = "s-done".into();
         s2.status = "done".into();
 
-        process_write(&pool, DbWrite::CreateSession(s1)).await.unwrap();
-        process_write(&pool, DbWrite::CreateSession(s2)).await.unwrap();
+        process_write(&pool, DbWrite::CreateSession(s1))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::CreateSession(s2))
+            .await
+            .unwrap();
 
-        process_write(&pool, DbWrite::ResetRunningSessions).await.unwrap();
+        process_write(&pool, DbWrite::ResetRunningSessions)
+            .await
+            .unwrap();
 
         let s = get_session(&pool, "s-run").await.unwrap().unwrap();
         assert_eq!(s.status, "idle");
@@ -1432,12 +1671,22 @@ mod tests {
     #[tokio::test]
     async fn insert_and_list_steps() {
         let pool = test_pool().await;
-        process_write(&pool, DbWrite::InsertProject(make_project())).await.unwrap();
-        process_write(&pool, DbWrite::InsertTask(make_task("p-001"))).await.unwrap();
-        process_write(&pool, DbWrite::CreateSession(make_session("t-001"))).await.unwrap();
+        process_write(&pool, DbWrite::InsertProject(make_project()))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::InsertTask(make_task("p-001")))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::CreateSession(make_session("t-001")))
+            .await
+            .unwrap();
 
-        process_write(&pool, DbWrite::InsertStep(make_step("s-001", 0))).await.unwrap();
-        process_write(&pool, DbWrite::InsertStep(make_step("s-001", 1))).await.unwrap();
+        process_write(&pool, DbWrite::InsertStep(make_step("s-001", 0)))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::InsertStep(make_step("s-001", 1)))
+            .await
+            .unwrap();
 
         let steps = list_steps(&pool, "s-001").await.unwrap();
         assert_eq!(steps.len(), 2);
@@ -1449,29 +1698,69 @@ mod tests {
     #[tokio::test]
     async fn list_steps_returns_sorted_by_sort_order() {
         let pool = test_pool().await;
-        process_write(&pool, DbWrite::InsertProject(make_project())).await.unwrap();
-        process_write(&pool, DbWrite::InsertTask(make_task("p-001"))).await.unwrap();
-        process_write(&pool, DbWrite::CreateSession(make_session("t-001"))).await.unwrap();
+        process_write(&pool, DbWrite::InsertProject(make_project()))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::InsertTask(make_task("p-001")))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::CreateSession(make_session("t-001")))
+            .await
+            .unwrap();
 
         // Insert in reverse order
-        process_write(&pool, DbWrite::InsertStep(make_step("s-001", 2))).await.unwrap();
-        process_write(&pool, DbWrite::InsertStep(make_step("s-001", 0))).await.unwrap();
-        process_write(&pool, DbWrite::InsertStep(make_step("s-001", 1))).await.unwrap();
+        process_write(&pool, DbWrite::InsertStep(make_step("s-001", 2)))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::InsertStep(make_step("s-001", 0)))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::InsertStep(make_step("s-001", 1)))
+            .await
+            .unwrap();
 
         let steps = list_steps(&pool, "s-001").await.unwrap();
-        assert_eq!(steps.iter().map(|s| s.sort_order).collect::<Vec<_>>(), vec![0, 1, 2]);
+        assert_eq!(
+            steps.iter().map(|s| s.sort_order).collect::<Vec<_>>(),
+            vec![0, 1, 2]
+        );
     }
 
     #[tokio::test]
     async fn list_steps_scoped_by_session() {
         let pool = test_pool().await;
-        process_write(&pool, DbWrite::InsertProject(make_project())).await.unwrap();
-        process_write(&pool, DbWrite::InsertTask(make_task("p-001"))).await.unwrap();
-        process_write(&pool, DbWrite::CreateSession(make_session("t-001"))).await.unwrap();
-        process_write(&pool, DbWrite::CreateSession(Session { id: "s-002".into(), ..make_session("t-001") })).await.unwrap();
+        process_write(&pool, DbWrite::InsertProject(make_project()))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::InsertTask(make_task("p-001")))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::CreateSession(make_session("t-001")))
+            .await
+            .unwrap();
+        process_write(
+            &pool,
+            DbWrite::CreateSession(Session {
+                id: "s-002".into(),
+                ..make_session("t-001")
+            }),
+        )
+        .await
+        .unwrap();
 
-        process_write(&pool, DbWrite::InsertStep(make_step("s-001", 0))).await.unwrap();
-        process_write(&pool, DbWrite::InsertStep(Step { id: "step-other".into(), session_id: "s-002".into(), ..make_step("s-002", 0) })).await.unwrap();
+        process_write(&pool, DbWrite::InsertStep(make_step("s-001", 0)))
+            .await
+            .unwrap();
+        process_write(
+            &pool,
+            DbWrite::InsertStep(Step {
+                id: "step-other".into(),
+                session_id: "s-002".into(),
+                ..make_step("s-002", 0)
+            }),
+        )
+        .await
+        .unwrap();
 
         assert_eq!(list_steps(&pool, "s-001").await.unwrap().len(), 1);
         assert_eq!(list_steps(&pool, "s-002").await.unwrap().len(), 1);
@@ -1480,21 +1769,34 @@ mod tests {
     #[tokio::test]
     async fn update_step_changes_message_and_armed() {
         let pool = test_pool().await;
-        process_write(&pool, DbWrite::InsertProject(make_project())).await.unwrap();
-        process_write(&pool, DbWrite::InsertTask(make_task("p-001"))).await.unwrap();
-        process_write(&pool, DbWrite::CreateSession(make_session("t-001"))).await.unwrap();
-        process_write(&pool, DbWrite::InsertStep(make_step("s-001", 0))).await.unwrap();
+        process_write(&pool, DbWrite::InsertProject(make_project()))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::InsertTask(make_task("p-001")))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::CreateSession(make_session("t-001")))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::InsertStep(make_step("s-001", 0)))
+            .await
+            .unwrap();
 
-        process_write(&pool, DbWrite::UpdateStep {
-            id: "step-0".into(),
-            message: "Updated message".into(),
-            armed: true,
-            model: Some("opus".into()),
-            plan_mode: Some(true),
-            thinking_mode: Some(false),
-            fast_mode: Some(true),
-            attachments_json: Some("[{\"name\":\"img.png\"}]".into()),
-        }).await.unwrap();
+        process_write(
+            &pool,
+            DbWrite::UpdateStep {
+                id: "step-0".into(),
+                message: "Updated message".into(),
+                armed: true,
+                model: Some("opus".into()),
+                plan_mode: Some(true),
+                thinking_mode: Some(false),
+                fast_mode: Some(true),
+                attachments_json: Some("[{\"name\":\"img.png\"}]".into()),
+            },
+        )
+        .await
+        .unwrap();
 
         let steps = list_steps(&pool, "s-001").await.unwrap();
         assert_eq!(steps[0].message, "Updated message");
@@ -1508,13 +1810,30 @@ mod tests {
     #[tokio::test]
     async fn delete_step_removes_it() {
         let pool = test_pool().await;
-        process_write(&pool, DbWrite::InsertProject(make_project())).await.unwrap();
-        process_write(&pool, DbWrite::InsertTask(make_task("p-001"))).await.unwrap();
-        process_write(&pool, DbWrite::CreateSession(make_session("t-001"))).await.unwrap();
-        process_write(&pool, DbWrite::InsertStep(make_step("s-001", 0))).await.unwrap();
-        process_write(&pool, DbWrite::InsertStep(make_step("s-001", 1))).await.unwrap();
+        process_write(&pool, DbWrite::InsertProject(make_project()))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::InsertTask(make_task("p-001")))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::CreateSession(make_session("t-001")))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::InsertStep(make_step("s-001", 0)))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::InsertStep(make_step("s-001", 1)))
+            .await
+            .unwrap();
 
-        process_write(&pool, DbWrite::DeleteStep { id: "step-0".into() }).await.unwrap();
+        process_write(
+            &pool,
+            DbWrite::DeleteStep {
+                id: "step-0".into(),
+            },
+        )
+        .await
+        .unwrap();
 
         let steps = list_steps(&pool, "s-001").await.unwrap();
         assert_eq!(steps.len(), 1);
@@ -1524,38 +1843,75 @@ mod tests {
     #[tokio::test]
     async fn reorder_steps_updates_sort_order() {
         let pool = test_pool().await;
-        process_write(&pool, DbWrite::InsertProject(make_project())).await.unwrap();
-        process_write(&pool, DbWrite::InsertTask(make_task("p-001"))).await.unwrap();
-        process_write(&pool, DbWrite::CreateSession(make_session("t-001"))).await.unwrap();
-        process_write(&pool, DbWrite::InsertStep(make_step("s-001", 0))).await.unwrap();
-        process_write(&pool, DbWrite::InsertStep(make_step("s-001", 1))).await.unwrap();
-        process_write(&pool, DbWrite::InsertStep(make_step("s-001", 2))).await.unwrap();
+        process_write(&pool, DbWrite::InsertProject(make_project()))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::InsertTask(make_task("p-001")))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::CreateSession(make_session("t-001")))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::InsertStep(make_step("s-001", 0)))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::InsertStep(make_step("s-001", 1)))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::InsertStep(make_step("s-001", 2)))
+            .await
+            .unwrap();
 
         // Reverse the order
-        process_write(&pool, DbWrite::ReorderSteps {
-            session_id: "s-001".into(),
-            ids: vec!["step-2".into(), "step-1".into(), "step-0".into()],
-        }).await.unwrap();
+        process_write(
+            &pool,
+            DbWrite::ReorderSteps {
+                session_id: "s-001".into(),
+                ids: vec!["step-2".into(), "step-1".into(), "step-0".into()],
+            },
+        )
+        .await
+        .unwrap();
 
         let steps = list_steps(&pool, "s-001").await.unwrap();
-        assert_eq!(steps.iter().map(|s| s.id.as_str()).collect::<Vec<_>>(), vec!["step-2", "step-1", "step-0"]);
+        assert_eq!(
+            steps.iter().map(|s| s.id.as_str()).collect::<Vec<_>>(),
+            vec!["step-2", "step-1", "step-0"]
+        );
     }
 
     #[tokio::test]
     async fn disarm_all_steps_sets_armed_false() {
         let pool = test_pool().await;
-        process_write(&pool, DbWrite::InsertProject(make_project())).await.unwrap();
-        process_write(&pool, DbWrite::InsertTask(make_task("p-001"))).await.unwrap();
-        process_write(&pool, DbWrite::CreateSession(make_session("t-001"))).await.unwrap();
+        process_write(&pool, DbWrite::InsertProject(make_project()))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::InsertTask(make_task("p-001")))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::CreateSession(make_session("t-001")))
+            .await
+            .unwrap();
 
         let mut armed_step = make_step("s-001", 0);
         armed_step.armed = true;
-        process_write(&pool, DbWrite::InsertStep(armed_step)).await.unwrap();
+        process_write(&pool, DbWrite::InsertStep(armed_step))
+            .await
+            .unwrap();
         let mut armed_step2 = make_step("s-001", 1);
         armed_step2.armed = true;
-        process_write(&pool, DbWrite::InsertStep(armed_step2)).await.unwrap();
+        process_write(&pool, DbWrite::InsertStep(armed_step2))
+            .await
+            .unwrap();
 
-        process_write(&pool, DbWrite::DisarmAllSteps { session_id: "s-001".into() }).await.unwrap();
+        process_write(
+            &pool,
+            DbWrite::DisarmAllSteps {
+                session_id: "s-001".into(),
+            },
+        )
+        .await
+        .unwrap();
 
         let steps = list_steps(&pool, "s-001").await.unwrap();
         assert!(steps.iter().all(|s| !s.armed));
@@ -1564,12 +1920,22 @@ mod tests {
     #[tokio::test]
     async fn delete_task_cascades_to_steps() {
         let pool = test_pool().await;
-        process_write(&pool, DbWrite::InsertProject(make_project())).await.unwrap();
-        process_write(&pool, DbWrite::InsertTask(make_task("p-001"))).await.unwrap();
-        process_write(&pool, DbWrite::CreateSession(make_session("t-001"))).await.unwrap();
-        process_write(&pool, DbWrite::InsertStep(make_step("s-001", 0))).await.unwrap();
+        process_write(&pool, DbWrite::InsertProject(make_project()))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::InsertTask(make_task("p-001")))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::CreateSession(make_session("t-001")))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::InsertStep(make_step("s-001", 0)))
+            .await
+            .unwrap();
 
-        process_write(&pool, DbWrite::DeleteTask { id: "t-001".into() }).await.unwrap();
+        process_write(&pool, DbWrite::DeleteTask { id: "t-001".into() })
+            .await
+            .unwrap();
 
         let steps = list_steps(&pool, "s-001").await.unwrap();
         assert_eq!(steps.len(), 0);
@@ -1578,12 +1944,22 @@ mod tests {
     #[tokio::test]
     async fn delete_project_cascades_to_steps() {
         let pool = test_pool().await;
-        process_write(&pool, DbWrite::InsertProject(make_project())).await.unwrap();
-        process_write(&pool, DbWrite::InsertTask(make_task("p-001"))).await.unwrap();
-        process_write(&pool, DbWrite::CreateSession(make_session("t-001"))).await.unwrap();
-        process_write(&pool, DbWrite::InsertStep(make_step("s-001", 0))).await.unwrap();
+        process_write(&pool, DbWrite::InsertProject(make_project()))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::InsertTask(make_task("p-001")))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::CreateSession(make_session("t-001")))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::InsertStep(make_step("s-001", 0)))
+            .await
+            .unwrap();
 
-        process_write(&pool, DbWrite::DeleteProject { id: "p-001".into() }).await.unwrap();
+        process_write(&pool, DbWrite::DeleteProject { id: "p-001".into() })
+            .await
+            .unwrap();
 
         let steps = list_steps(&pool, "s-001").await.unwrap();
         assert_eq!(steps.len(), 0);

--- a/src-tauri/src/git_ops.rs
+++ b/src-tauri/src/git_ops.rs
@@ -329,8 +329,7 @@ pub fn get_file_context(
     } else {
         // Read from worktree (current version)
         let full_path = std::path::Path::new(worktree_path).join(file_path);
-        std::fs::read_to_string(&full_path)
-            .map_err(|e| format!("Failed to read file: {e}"))?
+        std::fs::read_to_string(&full_path).map_err(|e| format!("Failed to read file: {e}"))?
     };
 
     let lines: Vec<String> = content.lines().map(|l| l.to_string()).collect();
@@ -347,8 +346,7 @@ fn generate_untracked_diff(worktree_path: &str, file_path: &str) -> Result<Strin
         return Ok(String::new());
     }
 
-    let content = std::fs::read_to_string(&full_path)
-        .map_err(|_| "Binary file".to_string())?;
+    let content = std::fs::read_to_string(&full_path).map_err(|_| "Binary file".to_string())?;
 
     let line_count = content.lines().count();
     let mut diff = format!("--- /dev/null\n+++ b/{file_path}\n@@ -0,0 +1,{line_count} @@\n");
@@ -465,10 +463,7 @@ fn parse_hunk_header(line: &str) -> Option<DiffHunk> {
 
 fn parse_range(s: &str) -> (u32, u32) {
     if let Some((start, count)) = s.split_once(',') {
-        (
-            start.parse().unwrap_or(1),
-            count.parse().unwrap_or(1),
-        )
+        (start.parse().unwrap_or(1), count.parse().unwrap_or(1))
     } else {
         (s.parse().unwrap_or(1), 1)
     }
@@ -502,7 +497,11 @@ pub fn find_merge_base(worktree_path: &str, base_branch: &str) -> Option<String>
         .ok()?;
 
     if remote_out.status.success() {
-        return Some(String::from_utf8_lossy(&remote_out.stdout).trim().to_string());
+        return Some(
+            String::from_utf8_lossy(&remote_out.stdout)
+                .trim()
+                .to_string(),
+        );
     }
 
     let local = git(worktree_path)
@@ -554,7 +553,13 @@ pub fn get_branch_commits(
 pub fn get_commit_files(worktree_path: &str, commit_hash: &str) -> Result<GitStatus, String> {
     // Get file list with status
     let output = git(worktree_path)
-        .args(["diff-tree", "--no-commit-id", "-r", "--name-status", commit_hash])
+        .args([
+            "diff-tree",
+            "--no-commit-id",
+            "-r",
+            "--name-status",
+            commit_hash,
+        ])
         .output()
         .map_err(|e| format!("Failed to get commit files: {e}"))?;
 
@@ -563,7 +568,9 @@ pub fn get_commit_files(worktree_path: &str, commit_hash: &str) -> Result<GitSta
 
     for line in stdout.lines() {
         let parts: Vec<&str> = line.splitn(2, '\t').collect();
-        if parts.len() != 2 { continue; }
+        if parts.len() != 2 {
+            continue;
+        }
         let status_char = parts[0].chars().next().unwrap_or('M');
         let status = match status_char {
             'A' => "A",
@@ -581,7 +588,13 @@ pub fn get_commit_files(worktree_path: &str, commit_hash: &str) -> Result<GitSta
 
     // Get stats
     let stat_output = git(worktree_path)
-        .args(["diff-tree", "--no-commit-id", "-r", "--numstat", commit_hash])
+        .args([
+            "diff-tree",
+            "--no-commit-id",
+            "-r",
+            "--numstat",
+            commit_hash,
+        ])
         .output()
         .map_err(|e| format!("Failed to get commit stats: {e}"))?;
 
@@ -592,7 +605,9 @@ pub fn get_commit_files(worktree_path: &str, commit_hash: &str) -> Result<GitSta
 
     for line in stat_stdout.lines() {
         let parts: Vec<&str> = line.split('\t').collect();
-        if parts.len() != 3 { continue; }
+        if parts.len() != 3 {
+            continue;
+        }
         let ins = parts[0].parse::<u32>().unwrap_or(0);
         let del = parts[1].parse::<u32>().unwrap_or(0);
         total_ins += ins;
@@ -849,15 +864,21 @@ fn parse_log_output(text: &str) -> Result<Vec<BranchCommit>, String> {
                 for part in stat.split(',') {
                     let part = part.trim();
                     if part.contains("changed") {
-                        files_changed = part.split_whitespace().next()
+                        files_changed = part
+                            .split_whitespace()
+                            .next()
                             .and_then(|n| n.parse().ok())
                             .unwrap_or(0);
                     } else if part.contains("insertion") {
-                        insertions = part.split_whitespace().next()
+                        insertions = part
+                            .split_whitespace()
+                            .next()
                             .and_then(|n| n.parse().ok())
                             .unwrap_or(0);
                     } else if part.contains("deletion") {
-                        deletions = part.split_whitespace().next()
+                        deletions = part
+                            .split_whitespace()
+                            .next()
                             .and_then(|n| n.parse().ok())
                             .unwrap_or(0);
                     }
@@ -892,7 +913,9 @@ pub fn stage_files(worktree_path: &str, paths: &[String]) -> Result<(), String> 
         cmd.arg(p);
     }
 
-    let output = cmd.output().map_err(|e| format!("Failed to stage files: {e}"))?;
+    let output = cmd
+        .output()
+        .map_err(|e| format!("Failed to stage files: {e}"))?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(format!("git add failed: {stderr}"));
@@ -922,7 +945,9 @@ pub fn unstage_files(worktree_path: &str, paths: &[String]) -> Result<(), String
         cmd.arg(p);
     }
 
-    let output = cmd.output().map_err(|e| format!("Failed to unstage files: {e}"))?;
+    let output = cmd
+        .output()
+        .map_err(|e| format!("Failed to unstage files: {e}"))?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(format!("git restore --staged failed: {stderr}"));
@@ -948,7 +973,9 @@ pub fn commit(worktree_path: &str, message: &str) -> Result<String, String> {
         .output()
         .map_err(|e| format!("Failed to get commit hash: {e}"))?;
 
-    Ok(String::from_utf8_lossy(&hash_output.stdout).trim().to_string())
+    Ok(String::from_utf8_lossy(&hash_output.stdout)
+        .trim()
+        .to_string())
 }
 
 /// Push branch to remote. Uses -u to set upstream on first push.
@@ -1004,8 +1031,14 @@ mod tests {
 
         let rp = repo_path.to_str().unwrap();
         git(rp).args(["init"]).output().unwrap();
-        git(rp).args(["config", "user.email", "test@test.com"]).output().unwrap();
-        git(rp).args(["config", "user.name", "Test"]).output().unwrap();
+        git(rp)
+            .args(["config", "user.email", "test@test.com"])
+            .output()
+            .unwrap();
+        git(rp)
+            .args(["config", "user.name", "Test"])
+            .output()
+            .unwrap();
 
         fs::write(repo_path.join("README.md"), "# test\n").unwrap();
         git(rp).args(["add", "."]).output().unwrap();
@@ -1045,7 +1078,11 @@ mod tests {
         git(&rp).args(["add", "staged.txt"]).output().unwrap();
 
         let status = get_git_status(&rp).unwrap();
-        let staged = status.files.iter().find(|f| f.path == "staged.txt").unwrap();
+        let staged = status
+            .files
+            .iter()
+            .find(|f| f.path == "staged.txt")
+            .unwrap();
         assert_eq!(staged.staging, "staged");
         assert_eq!(staged.status, "A");
     }

--- a/src-tauri/src/github.rs
+++ b/src-tauri/src/github.rs
@@ -81,9 +81,7 @@ fn parse_github_url(url: &str) -> Result<Option<GitHubRepo>, String> {
 
     // HTTPS: https://github.com/owner/repo.git
     if url.contains("github.com") {
-        let cleaned = url
-            .trim_end_matches(".git")
-            .trim_end_matches('/');
+        let cleaned = url.trim_end_matches(".git").trim_end_matches('/');
 
         // Extract path after github.com
         if let Some(idx) = cleaned.find("github.com/") {
@@ -108,7 +106,12 @@ fn parse_github_url(url: &str) -> Result<Option<GitHubRepo>, String> {
 /// Get the PR for the current branch (if one exists).
 pub fn get_pr_for_branch(worktree_path: &str) -> Result<Option<PrInfo>, String> {
     let output = gh(worktree_path)
-        .args(["pr", "view", "--json", "number,url,state,title,mergeable,isDraft"])
+        .args([
+            "pr",
+            "view",
+            "--json",
+            "number,url,state,title,mergeable,isDraft",
+        ])
         .output()
         .map_err(|e| format!("Failed to check PR: {e}"))?;
 
@@ -145,14 +148,7 @@ pub fn create_pr(
 
     let output = gh(worktree_path)
         .args([
-            "pr",
-            "create",
-            "--title",
-            title,
-            "--body",
-            body,
-            "--base",
-            base,
+            "pr", "create", "--title", title, "--body", body, "--base", base,
         ])
         .output()
         .map_err(|e| format!("Failed to create PR: {e}"))?;
@@ -317,8 +313,7 @@ pub fn get_ci_checks(worktree_path: &str) -> Result<Vec<CiCheck>, String> {
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let checks: Vec<serde_json::Value> =
-        serde_json::from_str(&stdout).unwrap_or_default();
+    let checks: Vec<serde_json::Value> = serde_json::from_str(&stdout).unwrap_or_default();
 
     Ok(checks
         .iter()
@@ -373,7 +368,8 @@ pub fn has_conflicts(worktree_path: &str) -> Result<bool, String> {
     Ok(stdout.lines().any(|line| {
         let bytes = line.as_bytes();
         bytes.len() >= 2
-            && (bytes[0] == b'U' || bytes[1] == b'U'
+            && (bytes[0] == b'U'
+                || bytes[1] == b'U'
                 || (bytes[0] == b'A' && bytes[1] == b'A')
                 || (bytes[0] == b'D' && bytes[1] == b'D'))
     }))
@@ -435,6 +431,9 @@ mod tests {
 
     #[test]
     fn merge_error_passthrough() {
-        assert_eq!(parse_merge_error("some unknown error"), "some unknown error");
+        assert_eq!(
+            parse_merge_error("some unknown error"),
+            "some unknown error"
+        );
     }
 }

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -1,11 +1,12 @@
-use crate::db::{
-    self, DbWriteTx, OutputLine, Project, Session, Step, Task,
-};
+use crate::db::{self, DbWriteTx, OutputLine, Project, Session, Step, Task};
 use crate::git_ops;
 use crate::github;
-use crate::pty::{self, ActivePtyMap};
-use crate::task::{self, ActiveMap, ApprovalResponse, HookPtyMap, PendingApprovalEntry, PendingApprovalMeta, PendingApprovals, SetupInProgress};
 use crate::lsp::LspMap;
+use crate::pty::{self, ActivePtyMap};
+use crate::task::{
+    self, ActiveMap, ApprovalResponse, HookPtyMap, PendingApprovalEntry, PendingApprovalMeta,
+    PendingApprovals, SetupInProgress,
+};
 use crate::tsgo_check::TsgoCheckMap;
 use crate::watcher::FileWatcherMap;
 use crate::worktree;
@@ -110,7 +111,17 @@ pub async fn delete_project(
 
     let tasks = db::list_tasks_for_project(pool.inner(), &id).await?;
     for t in &tasks {
-        task::delete_task(&app, db_tx.inner(), active.inner(), &project.repo_path, t, &project.destroy_hook, true, false).await?;
+        task::delete_task(
+            &app,
+            db_tx.inner(),
+            active.inner(),
+            &project.repo_path,
+            t,
+            &project.destroy_hook,
+            true,
+            false,
+        )
+        .await?;
     }
 
     db_tx
@@ -143,7 +154,13 @@ pub async fn update_project_hooks(
     auto_start: bool,
 ) -> Result<(), String> {
     db_tx
-        .send(db::DbWrite::UpdateProjectHooks { id, setup_hook, destroy_hook, start_command, auto_start })
+        .send(db::DbWrite::UpdateProjectHooks {
+            id,
+            setup_hook,
+            destroy_hook,
+            start_command,
+            auto_start,
+        })
         .await
         .map_err(|e| format!("DB write failed: {e}"))
 }
@@ -155,7 +172,10 @@ pub async fn update_project_default_agent(
     default_agent_type: String,
 ) -> Result<(), String> {
     db_tx
-        .send(db::DbWrite::UpdateProjectDefaultAgent { id, default_agent_type })
+        .send(db::DbWrite::UpdateProjectDefaultAgent {
+            id,
+            default_agent_type,
+        })
         .await
         .map_err(|e| format!("DB write failed: {e}"))
 }
@@ -213,7 +233,11 @@ pub async fn import_project_config(
         .await
         .map_err(|e| format!("DB write failed: {e}"))?;
 
-    Ok(ImportedHooks { setup_hook: setup, destroy_hook: destroy, start_command: start })
+    Ok(ImportedHooks {
+        setup_hook: setup,
+        destroy_hook: destroy,
+        start_command: start,
+    })
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -263,9 +287,11 @@ pub async fn create_task(
             setup_hook: project.setup_hook,
             port_offset,
             from_task_window,
-            agent_type: agent_type.unwrap_or_else(|| crate::agent::AgentKind::Claude.as_str().to_string()),
+            agent_type: agent_type
+                .unwrap_or_else(|| crate::agent::AgentKind::Claude.as_str().to_string()),
         },
-    ).await?;
+    )
+    .await?;
 
     // For task windows: store label → taskId so the close handler works
     if from_task_window {
@@ -374,7 +400,17 @@ pub async fn delete_task(
         .await?
         .ok_or_else(|| format!("Project {} not found", t.project_id))?;
 
-    task::delete_task(&app, db_tx.inner(), active.inner(), &project.repo_path, &t, &project.destroy_hook, delete_branch, skip_destroy_hook.unwrap_or(false)).await
+    task::delete_task(
+        &app,
+        db_tx.inner(),
+        active.inner(),
+        &project.repo_path,
+        &t,
+        &project.destroy_hook,
+        delete_branch,
+        skip_destroy_hook.unwrap_or(false),
+    )
+    .await
 }
 
 #[tauri::command]
@@ -394,7 +430,16 @@ pub async fn archive_task(
         .await?
         .ok_or_else(|| format!("Project {} not found", t.project_id))?;
 
-    task::archive_task(&app, db_tx.inner(), active.inner(), &t, &project.destroy_hook, &project.repo_path, skip_destroy_hook.unwrap_or(false)).await
+    task::archive_task(
+        &app,
+        db_tx.inner(),
+        active.inner(),
+        &t,
+        &project.destroy_hook,
+        &project.repo_path,
+        skip_destroy_hook.unwrap_or(false),
+    )
+    .await
 }
 
 #[tauri::command]
@@ -413,11 +458,9 @@ pub async fn check_task_worktree(
     let wtp = t.worktree_path.clone();
     let rp = project.repo_path.clone();
     let branch = t.branch.clone();
-    tokio::task::spawn_blocking(move || {
-        worktree::check_worktree_exists(&rp, &wtp, &branch)
-    })
-    .await
-    .map_err(|e| format!("Join error: {e}"))
+    tokio::task::spawn_blocking(move || worktree::check_worktree_exists(&rp, &wtp, &branch))
+        .await
+        .map_err(|e| format!("Join error: {e}"))
 }
 
 #[tauri::command]
@@ -474,13 +517,7 @@ pub async fn rename_task(
         })
         .await
         .map_err(|e| format!("DB write failed: {e}"))?;
-    let _ = app.emit(
-        "task-name",
-        crate::stream::TaskNameEvent {
-            task_id,
-            name,
-        },
-    );
+    let _ = app.emit("task-name", crate::stream::TaskNameEvent { task_id, name });
     Ok(())
 }
 
@@ -631,17 +668,17 @@ pub async fn update_session_model(
     model: Option<String>,
 ) -> Result<(), String> {
     db_tx
-        .send(db::DbWrite::UpdateSessionModel { id: session_id, model })
+        .send(db::DbWrite::UpdateSessionModel {
+            id: session_id,
+            model,
+        })
         .await
         .map_err(|e| format!("DB write failed: {e}"))
 }
 
 /// Close a session (hides from UI, persists in DB as 'closed')
 #[tauri::command]
-pub async fn close_session(
-    db_tx: State<'_, DbWriteTx>,
-    session_id: String,
-) -> Result<(), String> {
+pub async fn close_session(db_tx: State<'_, DbWriteTx>, session_id: String) -> Result<(), String> {
     db_tx
         .send(db::DbWrite::CloseSession { id: session_id })
         .await
@@ -650,10 +687,7 @@ pub async fn close_session(
 
 /// Clear a session's Claude context (reset session_id + delete output lines)
 #[tauri::command]
-pub async fn clear_session(
-    db_tx: State<'_, DbWriteTx>,
-    session_id: String,
-) -> Result<(), String> {
+pub async fn clear_session(db_tx: State<'_, DbWriteTx>, session_id: String) -> Result<(), String> {
     // Clear the resume_session_id so next message starts fresh
     db_tx
         .send(db::DbWrite::SetResumeSessionId {
@@ -665,9 +699,7 @@ pub async fn clear_session(
 
     // Clear persisted output lines
     db_tx
-        .send(db::DbWrite::DeleteOutputLines {
-            session_id,
-        })
+        .send(db::DbWrite::DeleteOutputLines { session_id })
         .await
         .map_err(|e| format!("DB write failed: {e}"))?;
 
@@ -687,9 +719,7 @@ pub async fn abort_message(
 
 /// Return session IDs that currently have an active process
 #[tauri::command]
-pub async fn get_active_sessions(
-    active: State<'_, ActiveMap>,
-) -> Result<Vec<String>, String> {
+pub async fn get_active_sessions(active: State<'_, ActiveMap>) -> Result<Vec<String>, String> {
     Ok(task::get_active_session_ids(active.inner()))
 }
 
@@ -703,7 +733,10 @@ pub async fn respond_to_approval(
     updated_input: Option<serde_json::Value>,
 ) -> Result<(), String> {
     if let Some((_, tx)) = pending.remove(&request_id) {
-        let _ = tx.send(ApprovalResponse { behavior, updated_input });
+        let _ = tx.send(ApprovalResponse {
+            behavior,
+            updated_input,
+        });
         Ok(())
     } else {
         Err(format!("No pending approval with id {request_id}"))
@@ -715,7 +748,10 @@ pub async fn respond_to_approval(
 pub async fn get_pending_approvals(
     pending_meta: State<'_, PendingApprovalMeta>,
 ) -> Result<Vec<PendingApprovalEntry>, String> {
-    Ok(pending_meta.iter().map(|entry| entry.value().clone()).collect())
+    Ok(pending_meta
+        .iter()
+        .map(|entry| entry.value().clone())
+        .collect())
 }
 
 #[tauri::command]
@@ -755,7 +791,11 @@ pub async fn set_trust_level(
     // Validate
     match trust_level.as_str() {
         "normal" | "full_auto" | "supervised" => {}
-        _ => return Err(format!("Invalid trust level: {trust_level}. Must be normal, full_auto, or supervised")),
+        _ => {
+            return Err(format!(
+                "Invalid trust level: {trust_level}. Must be normal, full_auto, or supervised"
+            ))
+        }
     }
 
     db_tx
@@ -792,17 +832,12 @@ pub async fn get_audit_log(
 // ---------------------------------------------------------------------------
 
 #[tauri::command]
-pub async fn get_diff(
-    pool: State<'_, SqlitePool>,
-    task_id: String,
-) -> Result<String, String> {
+pub async fn get_diff(pool: State<'_, SqlitePool>, task_id: String) -> Result<String, String> {
     let t = db::get_task(pool.inner(), &task_id)
         .await?
         .ok_or_else(|| format!("Task {task_id} not found"))?;
 
-    flatten_join(
-        tokio::task::spawn_blocking(move || worktree::get_diff(&t.worktree_path)).await,
-    )
+    flatten_join(tokio::task::spawn_blocking(move || worktree::get_diff(&t.worktree_path)).await)
 }
 
 #[tauri::command]
@@ -868,9 +903,13 @@ pub async fn get_repo_info(path: String) -> Result<RepoInfo, String> {
 
             // Add remote branches first (strip origin/ prefix, skip HEAD pointer and arrows)
             for line in String::from_utf8_lossy(&remote_output.stdout).lines() {
-                if line.contains("->") || line == "origin" { continue; }
+                if line.contains("->") || line == "origin" {
+                    continue;
+                }
                 let name = line.strip_prefix("origin/").unwrap_or(line);
-                if name == "HEAD" || name.is_empty() { continue; }
+                if name == "HEAD" || name.is_empty() {
+                    continue;
+                }
                 if seen.insert(name.to_string()) {
                     branches.push(name.to_string());
                 }
@@ -938,8 +977,15 @@ pub async fn get_file_diff(
         .ok_or_else(|| format!("Task {task_id} not found"))?;
 
     flatten_join(
-        tokio::task::spawn_blocking(move || git_ops::get_file_diff(&t.worktree_path, &file_path, context_lines, ignore_whitespace))
-            .await,
+        tokio::task::spawn_blocking(move || {
+            git_ops::get_file_diff(
+                &t.worktree_path,
+                &file_path,
+                context_lines,
+                ignore_whitespace,
+            )
+        })
+        .await,
     )
 }
 
@@ -997,8 +1043,7 @@ pub async fn git_unstage(
         .ok_or_else(|| format!("Task {task_id} not found"))?;
 
     flatten_join(
-        tokio::task::spawn_blocking(move || git_ops::unstage_files(&t.worktree_path, &paths))
-            .await,
+        tokio::task::spawn_blocking(move || git_ops::unstage_files(&t.worktree_path, &paths)).await,
     )
 }
 
@@ -1018,31 +1063,21 @@ pub async fn git_commit(
 }
 
 #[tauri::command]
-pub async fn git_push(
-    pool: State<'_, SqlitePool>,
-    task_id: String,
-) -> Result<(), String> {
+pub async fn git_push(pool: State<'_, SqlitePool>, task_id: String) -> Result<(), String> {
     let t = db::get_task(pool.inner(), &task_id)
         .await?
         .ok_or_else(|| format!("Task {task_id} not found"))?;
 
-    flatten_join(
-        tokio::task::spawn_blocking(move || git_ops::push_branch(&t.worktree_path)).await,
-    )
+    flatten_join(tokio::task::spawn_blocking(move || git_ops::push_branch(&t.worktree_path)).await)
 }
 
 #[tauri::command]
-pub async fn git_pull(
-    pool: State<'_, SqlitePool>,
-    task_id: String,
-) -> Result<String, String> {
+pub async fn git_pull(pool: State<'_, SqlitePool>, task_id: String) -> Result<String, String> {
     let t = db::get_task(pool.inner(), &task_id)
         .await?
         .ok_or_else(|| format!("Task {task_id} not found"))?;
 
-    flatten_join(
-        tokio::task::spawn_blocking(move || git_ops::pull_branch(&t.worktree_path)).await,
-    )
+    flatten_join(tokio::task::spawn_blocking(move || git_ops::pull_branch(&t.worktree_path)).await)
 }
 
 #[tauri::command]
@@ -1099,8 +1134,7 @@ pub async fn get_branch_commits(
             let merge_base = match cached {
                 Some(ref sha) => sha.clone(),
                 None => {
-                    let sha = git_ops::find_merge_base(&wt, &base)
-                        .unwrap_or_default();
+                    let sha = git_ops::find_merge_base(&wt, &base).unwrap_or_default();
                     if !sha.is_empty() {
                         let _ = tx.try_send(db::DbWrite::SetMergeBaseSha {
                             id: tid,
@@ -1111,7 +1145,11 @@ pub async fn get_branch_commits(
                 }
             };
 
-            let cached_ref = if merge_base.is_empty() { None } else { Some(merge_base.as_str()) };
+            let cached_ref = if merge_base.is_empty() {
+                None
+            } else {
+                Some(merge_base.as_str())
+            };
             git_ops::get_branch_commits(&wt, &base, cached_ref)
         })
         .await,
@@ -1129,8 +1167,10 @@ pub async fn get_commit_files(
         .ok_or_else(|| format!("Task {task_id} not found"))?;
 
     flatten_join(
-        tokio::task::spawn_blocking(move || git_ops::get_commit_files(&t.worktree_path, &commit_hash))
-            .await,
+        tokio::task::spawn_blocking(move || {
+            git_ops::get_commit_files(&t.worktree_path, &commit_hash)
+        })
+        .await,
     )
 }
 
@@ -1149,9 +1189,15 @@ pub async fn get_commit_file_diff(
 
     flatten_join(
         tokio::task::spawn_blocking(move || {
-            git_ops::get_commit_file_diff(&t.worktree_path, &commit_hash, &file_path, context_lines, ignore_whitespace)
+            git_ops::get_commit_file_diff(
+                &t.worktree_path,
+                &commit_hash,
+                &file_path,
+                context_lines,
+                ignore_whitespace,
+            )
         })
-            .await,
+        .await,
     )
 }
 
@@ -1231,17 +1277,12 @@ pub async fn create_pull_request(
 }
 
 #[tauri::command]
-pub async fn mark_pr_ready(
-    pool: State<'_, SqlitePool>,
-    task_id: String,
-) -> Result<(), String> {
+pub async fn mark_pr_ready(pool: State<'_, SqlitePool>, task_id: String) -> Result<(), String> {
     let t = db::get_task(pool.inner(), &task_id)
         .await?
         .ok_or_else(|| format!("Task {task_id} not found"))?;
 
-    flatten_join(
-        tokio::task::spawn_blocking(move || github::mark_pr_ready(&t.worktree_path)).await,
-    )
+    flatten_join(tokio::task::spawn_blocking(move || github::mark_pr_ready(&t.worktree_path)).await)
 }
 
 #[tauri::command]
@@ -1258,7 +1299,10 @@ pub async fn merge_pull_request(
     let force = force.unwrap_or(false);
     let delete_branch = delete_branch.unwrap_or(false);
     flatten_join(
-        tokio::task::spawn_blocking(move || github::merge_pr(&t.worktree_path, force, delete_branch)).await,
+        tokio::task::spawn_blocking(move || {
+            github::merge_pr(&t.worktree_path, force, delete_branch)
+        })
+        .await,
     )
 }
 
@@ -1313,9 +1357,7 @@ pub async fn get_ci_checks(
         .await?
         .ok_or_else(|| format!("Task {task_id} not found"))?;
 
-    flatten_join(
-        tokio::task::spawn_blocking(move || github::get_ci_checks(&t.worktree_path)).await,
-    )
+    flatten_join(tokio::task::spawn_blocking(move || github::get_ci_checks(&t.worktree_path)).await)
 }
 
 #[tauri::command]
@@ -1333,17 +1375,12 @@ pub async fn get_branch_url(
 }
 
 #[tauri::command]
-pub async fn has_conflicts(
-    pool: State<'_, SqlitePool>,
-    task_id: String,
-) -> Result<bool, String> {
+pub async fn has_conflicts(pool: State<'_, SqlitePool>, task_id: String) -> Result<bool, String> {
     let t = db::get_task(pool.inner(), &task_id)
         .await?
         .ok_or_else(|| format!("Task {task_id} not found"))?;
 
-    flatten_join(
-        tokio::task::spawn_blocking(move || github::has_conflicts(&t.worktree_path)).await,
-    )
+    flatten_join(tokio::task::spawn_blocking(move || github::has_conflicts(&t.worktree_path)).await)
 }
 
 // ---------------------------------------------------------------------------
@@ -1372,7 +1409,17 @@ pub async fn pty_spawn(
     let direct = direct_command.unwrap_or(false);
     flatten_join(
         tokio::task::spawn_blocking(move || {
-            pty::spawn_pty(app, map, task_id, t.worktree_path, rows, cols, initial_command, env_vars, direct)
+            pty::spawn_pty(
+                app,
+                map,
+                task_id,
+                t.worktree_path,
+                rows,
+                cols,
+                initial_command,
+                env_vars,
+                direct,
+            )
         })
         .await,
     )
@@ -1400,8 +1447,7 @@ pub async fn pty_resize(
 ) -> Result<(), String> {
     let map = pty_map.inner().clone();
     flatten_join(
-        tokio::task::spawn_blocking(move || pty::resize_pty(&map, &terminal_id, rows, cols))
-            .await,
+        tokio::task::spawn_blocking(move || pty::resize_pty(&map, &terminal_id, rows, cols)).await,
     )
 }
 
@@ -1411,9 +1457,7 @@ pub async fn pty_close(
     terminal_id: String,
 ) -> Result<(), String> {
     let map = pty_map.inner().clone();
-    flatten_join(
-        tokio::task::spawn_blocking(move || pty::close_pty(&map, &terminal_id)).await,
-    )
+    flatten_join(tokio::task::spawn_blocking(move || pty::close_pty(&map, &terminal_id)).await)
 }
 
 // ---------------------------------------------------------------------------
@@ -1425,9 +1469,13 @@ pub async fn read_clipboard() -> Result<String, String> {
     #[cfg(target_os = "macos")]
     let output = std::process::Command::new("pbpaste").output();
     #[cfg(target_os = "linux")]
-    let output = std::process::Command::new("xclip").args(["-selection", "clipboard", "-o"]).output();
+    let output = std::process::Command::new("xclip")
+        .args(["-selection", "clipboard", "-o"])
+        .output();
     #[cfg(target_os = "windows")]
-    let output = std::process::Command::new("powershell").args(["-command", "Get-Clipboard"]).output();
+    let output = std::process::Command::new("powershell")
+        .args(["-command", "Get-Clipboard"])
+        .output();
 
     let output = output.map_err(|e| format!("Failed to read clipboard: {e}"))?;
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
@@ -1536,7 +1584,10 @@ pub async fn list_agent_skills() -> Result<Vec<AgentSkill>, String> {
 
     for line in text.lines() {
         let trimmed = line.trim();
-        if let Some(rest) = trimmed.strip_prefix("- `/").or_else(|| trimmed.strip_prefix("- `/")) {
+        if let Some(rest) = trimmed
+            .strip_prefix("- `/")
+            .or_else(|| trimmed.strip_prefix("- `/"))
+        {
             if let Some(idx) = rest.find('`') {
                 let name = rest[..idx].to_string();
                 let desc = rest[idx + 1..]
@@ -1545,7 +1596,10 @@ pub async fn list_agent_skills() -> Result<Vec<AgentSkill>, String> {
                     .trim()
                     .to_string();
                 if !name.is_empty() {
-                    skills.push(AgentSkill { name, description: desc });
+                    skills.push(AgentSkill {
+                        name,
+                        description: desc,
+                    });
                 }
             }
         }
@@ -1577,7 +1631,13 @@ fn check_agent_impl(agent: &dyn crate::agent::Agent) -> Result<String, String> {
     let output = std::process::Command::new(agent.cli_binary())
         .args(agent.version_args())
         .output()
-        .map_err(|_| format!("{} CLI not found. {}", agent.display_name(), agent.install_hint()))?;
+        .map_err(|_| {
+            format!(
+                "{} CLI not found. {}",
+                agent.display_name(),
+                agent.install_hint()
+            )
+        })?;
     if !output.status.success() {
         return Err(format!("{} CLI returned an error", agent.display_name()));
     }
@@ -1601,7 +1661,8 @@ pub fn detect_all_agents() -> Vec<AgentInfo> {
             let installed = cli_version.is_some();
 
             let models = if installed {
-                agent.model_list_args()
+                agent
+                    .model_list_args()
                     .and_then(|args| {
                         std::process::Command::new(agent.cli_binary())
                             .args(&args)
@@ -1645,10 +1706,15 @@ pub async fn list_available_agents(cache: State<'_, AgentCache>) -> Result<Vec<A
 /// Kick off a background re-detection and return immediately.
 /// Results arrive via the `agents-updated` event.
 #[tauri::command]
-pub async fn refresh_agents(cache: State<'_, AgentCache>, app: tauri::AppHandle) -> Result<(), String> {
+pub async fn refresh_agents(
+    cache: State<'_, AgentCache>,
+    app: tauri::AppHandle,
+) -> Result<(), String> {
     let cache = std::sync::Arc::clone(&*cache);
     tauri::async_runtime::spawn(async move {
-        let agents = tokio::task::spawn_blocking(detect_all_agents).await.unwrap_or_default();
+        let agents = tokio::task::spawn_blocking(detect_all_agents)
+            .await
+            .unwrap_or_default();
         *cache.write().unwrap() = agents.clone();
         let _ = app.emit("agents-updated", agents);
     });
@@ -1734,8 +1800,9 @@ pub async fn check_gitignored(
                 .stdout(std::process::Stdio::piped())
                 .stderr(std::process::Stdio::null());
 
-            let mut child =
-                cmd.spawn().map_err(|e| format!("Failed to run git check-ignore: {e}"))?;
+            let mut child = cmd
+                .spawn()
+                .map_err(|e| format!("Failed to run git check-ignore: {e}"))?;
             {
                 use std::io::Write;
                 let stdin = child.stdin.as_mut().unwrap();
@@ -1781,7 +1848,11 @@ pub async fn open_in_finder(path: String) -> Result<(), String> {
 #[tauri::command]
 pub async fn open_in_app(path: String, app: String) -> Result<(), String> {
     #[cfg(target_os = "macos")]
-    let result = std::process::Command::new("open").arg("-a").arg(&app).arg(&path).spawn();
+    let result = std::process::Command::new("open")
+        .arg("-a")
+        .arg(&app)
+        .arg(&path)
+        .spawn();
     #[cfg(not(target_os = "macos"))]
     let result = std::process::Command::new(&app).arg(&path).spawn();
 
@@ -1836,7 +1907,9 @@ pub async fn list_directory(
                 if entry.path() == base {
                     continue;
                 }
-                let meta = entry.metadata().map_err(|e| format!("Metadata error: {e}"))?;
+                let meta = entry
+                    .metadata()
+                    .map_err(|e| format!("Metadata error: {e}"))?;
                 let name = entry.file_name().to_string_lossy().to_string();
                 let rel = entry
                     .path()
@@ -1850,15 +1923,19 @@ pub async fn list_directory(
                     relative_path: rel,
                     is_dir: meta.is_dir(),
                     is_symlink: meta.is_symlink(),
-                    size: if meta.is_file() { Some(meta.len()) } else { None },
+                    size: if meta.is_file() {
+                        Some(meta.len())
+                    } else {
+                        None
+                    },
                 });
             }
 
             // Sort: directories first, then alphabetical (case-insensitive)
             entries.sort_by(|a, b| {
-                b.is_dir.cmp(&a.is_dir).then_with(|| {
-                    a.name.to_lowercase().cmp(&b.name.to_lowercase())
-                })
+                b.is_dir
+                    .cmp(&a.is_dir)
+                    .then_with(|| a.name.to_lowercase().cmp(&b.name.to_lowercase()))
             });
 
             Ok(entries)
@@ -1895,7 +1972,11 @@ pub async fn read_worktree_file(
         .map_err(|e| format!("Failed to read {relative_path}: {e}"))?;
 
     let truncated = bytes.len() > limit;
-    let slice = if truncated { &bytes[..limit] } else { &bytes[..] };
+    let slice = if truncated {
+        &bytes[..limit]
+    } else {
+        &bytes[..]
+    };
 
     let text = String::from_utf8(slice.to_vec())
         .map_err(|_| "Binary file — preview not available".to_string())?;
@@ -1921,8 +2002,8 @@ pub async fn resolve_worktree_file_path(
 
     let canonical_base = std::fs::canonicalize(&t.worktree_path)
         .map_err(|e| format!("Cannot resolve worktree: {e}"))?;
-    let canonical_file = std::fs::canonicalize(&full_path)
-        .map_err(|e| format!("Cannot resolve file: {e}"))?;
+    let canonical_file =
+        std::fs::canonicalize(&full_path).map_err(|e| format!("Cannot resolve file: {e}"))?;
 
     if !canonical_file.starts_with(&canonical_base) {
         return Err("Path escapes worktree boundary".into());
@@ -2005,10 +2086,7 @@ pub async fn lsp_send(
 }
 
 #[tauri::command]
-pub async fn lsp_stop(
-    lsp_map: State<'_, LspMap>,
-    task_id: String,
-) -> Result<(), String> {
+pub async fn lsp_stop(lsp_map: State<'_, LspMap>, task_id: String) -> Result<(), String> {
     crate::lsp::stop_server(&lsp_map, &task_id).await;
     Ok(())
 }
@@ -2051,13 +2129,22 @@ pub async fn debug_navigate_to_task(
     session_id: String,
 ) -> Result<(), String> {
     #[derive(Clone, Serialize)]
-    struct Payload { task_id: String, session_id: String }
+    struct Payload {
+        task_id: String,
+        session_id: String,
+    }
     if let Some(w) = app.get_webview_window("main") {
         let _ = w.show();
         let _ = w.set_focus();
     }
-    app.emit("navigate-to-task", Payload { task_id, session_id })
-        .map_err(|e| e.to_string())
+    app.emit(
+        "navigate-to-task",
+        Payload {
+            task_id,
+            session_id,
+        },
+    )
+    .map_err(|e| e.to_string())
 }
 
 // ── Steps ──────────────────────────────────────────────────────────────
@@ -2117,16 +2204,22 @@ pub async fn update_step(
     attachments_json: Option<String>,
 ) -> Result<(), String> {
     db_tx
-        .send(db::DbWrite::UpdateStep { id, message, armed, model, plan_mode, thinking_mode, fast_mode, attachments_json })
+        .send(db::DbWrite::UpdateStep {
+            id,
+            message,
+            armed,
+            model,
+            plan_mode,
+            thinking_mode,
+            fast_mode,
+            attachments_json,
+        })
         .await
         .map_err(|e| format!("DB write failed: {e}"))
 }
 
 #[tauri::command]
-pub async fn delete_step(
-    db_tx: State<'_, DbWriteTx>,
-    id: String,
-) -> Result<(), String> {
+pub async fn delete_step(db_tx: State<'_, DbWriteTx>, id: String) -> Result<(), String> {
     db_tx
         .send(db::DbWrite::DeleteStep { id })
         .await
@@ -2169,18 +2262,20 @@ pub async fn open_task_window(
     let label = format!("task-{task_id}");
 
     if let Some(win) = app.get_webview_window(&label) {
-        win.set_focus().map_err(|e| format!("Failed to focus window: {e}"))?;
+        win.set_focus()
+            .map_err(|e| format!("Failed to focus window: {e}"))?;
         return Ok(());
     }
 
     let title = task_name.unwrap_or_else(|| "Task".into());
     let url = format!("index.html?windowType=task&taskId={task_id}&windowLabel={label}");
 
-    let builder = tauri::WebviewWindowBuilder::new(&app, &label, tauri::WebviewUrl::App(url.into()))
-        .title(&title)
-        .inner_size(1200.0, 800.0)
-        .min_inner_size(800.0, 600.0)
-        .visible(false);
+    let builder =
+        tauri::WebviewWindowBuilder::new(&app, &label, tauri::WebviewUrl::App(url.into()))
+            .title(&title)
+            .inner_size(1200.0, 800.0)
+            .min_inner_size(800.0, 600.0)
+            .visible(false);
     #[cfg(target_os = "macos")]
     let builder = builder
         .hidden_title(true)
@@ -2203,21 +2298,17 @@ pub async fn open_task_window(
 }
 
 #[tauri::command]
-pub async fn open_new_task_window(
-    app: AppHandle,
-    project_id: String,
-) -> Result<(), String> {
+pub async fn open_new_task_window(app: AppHandle, project_id: String) -> Result<(), String> {
     let id = Uuid::new_v4().to_string();
     let label = format!("task-new-{id}");
-    let url = format!(
-        "index.html?windowType=task&projectId={project_id}&windowLabel={label}"
-    );
+    let url = format!("index.html?windowType=task&projectId={project_id}&windowLabel={label}");
 
-    let builder = tauri::WebviewWindowBuilder::new(&app, &label, tauri::WebviewUrl::App(url.into()))
-        .title("New Task")
-        .inner_size(1200.0, 800.0)
-        .min_inner_size(800.0, 600.0)
-        .visible(false);
+    let builder =
+        tauri::WebviewWindowBuilder::new(&app, &label, tauri::WebviewUrl::App(url.into()))
+            .title("New Task")
+            .inner_size(1200.0, 800.0)
+            .min_inner_size(800.0, 600.0)
+            .visible(false);
     #[cfg(target_os = "macos")]
     let builder = builder
         .hidden_title(true)
@@ -2244,7 +2335,9 @@ pub async fn force_close_task_window(
             );
         }
     }
-    window.destroy().map_err(|e| format!("Failed to destroy window: {e}"))
+    window
+        .destroy()
+        .map_err(|e| format!("Failed to destroy window: {e}"))
 }
 
 #[cfg(test)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,9 +15,9 @@ mod tsgo_check;
 mod watcher;
 mod worktree;
 
+use dashmap::DashMap;
 #[cfg(target_os = "macos")]
 use tauri::menu::{MenuBuilder, MenuItemBuilder, PredefinedMenuItem, SubmenuBuilder};
-use dashmap::DashMap;
 use tauri::{Emitter, Manager, RunEvent, WindowEvent};
 use tauri_plugin_sql::Builder as SqlBuilder;
 use tauri_plugin_updater::UpdaterExt;
@@ -82,8 +82,8 @@ pub fn run() {
                 let quick_open_item = MenuItemBuilder::with_id("quick-open", "Go to File…")
                     .accelerator("CmdOrCtrl+P")
                     .build(app)?;
-                let update_item = MenuItemBuilder::with_id("check-updates", "Check for Updates…")
-                    .build(app)?;
+                let update_item =
+                    MenuItemBuilder::with_id("check-updates", "Check for Updates…").build(app)?;
                 let app_menu = SubmenuBuilder::new(app, "Verun")
                     .item(&PredefinedMenuItem::about(app, Some("About Verun"), None)?)
                     .item(&update_item)
@@ -121,9 +121,10 @@ pub fn run() {
                 app.set_menu(menu)?;
             }
 
-            let app_data_dir = app.path().app_data_dir().map_err(|e| {
-                std::io::Error::other(format!("Failed to get app data dir: {e}"))
-            })?;
+            let app_data_dir = app
+                .path()
+                .app_data_dir()
+                .map_err(|e| std::io::Error::other(format!("Failed to get app data dir: {e}")))?;
 
             std::fs::create_dir_all(&app_data_dir).map_err(|e| {
                 std::io::Error::other(format!("Failed to create app data dir: {e}"))

--- a/src-tauri/src/lsp.rs
+++ b/src-tauri/src/lsp.rs
@@ -98,7 +98,13 @@ const TSGO_PLATFORM_DIR: &str = "native-preview-darwin-x64";
 const TSGO_PLATFORM_DIR: &str = "native-preview-unsupported";
 
 fn tsgo_rel_path() -> [&'static str; 5] {
-    ["node_modules", "@typescript", TSGO_PLATFORM_DIR, "lib", "tsgo"]
+    [
+        "node_modules",
+        "@typescript",
+        TSGO_PLATFORM_DIR,
+        "lib",
+        "tsgo",
+    ]
 }
 
 pub fn resolve_lsp_binary(app: &AppHandle) -> Result<std::path::PathBuf, String> {
@@ -153,14 +159,8 @@ pub async fn start_server(
         .spawn()
         .map_err(|e| format!("Failed to spawn tsgo: {e}"))?;
 
-    let stdin = child
-        .stdin
-        .take()
-        .ok_or("Failed to capture LSP stdin")?;
-    let stdout = child
-        .stdout
-        .take()
-        .ok_or("Failed to capture LSP stdout")?;
+    let stdin = child.stdin.take().ok_or("Failed to capture LSP stdin")?;
+    let stdout = child.stdout.take().ok_or("Failed to capture LSP stdout")?;
 
     let stdin = Arc::new(TokioMutex::new(stdin));
     let child = Arc::new(TokioMutex::new(child));
@@ -198,11 +198,7 @@ pub async fn start_server(
     Ok(())
 }
 
-pub async fn send_message(
-    lsp_map: &LspMap,
-    task_id: &str,
-    message: &str,
-) -> Result<(), String> {
+pub async fn send_message(lsp_map: &LspMap, task_id: &str, message: &str) -> Result<(), String> {
     let handle = lsp_map
         .get(task_id)
         .ok_or_else(|| format!("No LSP server for task {task_id}"))?;

--- a/src-tauri/src/policy.rs
+++ b/src-tauri/src/policy.rs
@@ -356,10 +356,7 @@ fn walk_list(list: &yash_syntax::syntax::List) -> Option<&'static str> {
     walk_list_with(list, check_args)
 }
 
-fn walk_list_with(
-    list: &yash_syntax::syntax::List,
-    check: CheckFn,
-) -> Option<&'static str> {
+fn walk_list_with(list: &yash_syntax::syntax::List, check: CheckFn) -> Option<&'static str> {
     for item in &list.0 {
         let aol = &*item.and_or;
         for pipeline in std::iter::once(&aol.first).chain(aol.rest.iter().map(|(_, p)| p)) {
@@ -398,10 +395,7 @@ fn walk_pipeline_with(
     None
 }
 
-fn walk_command_with(
-    cmd: &yash_syntax::syntax::Command,
-    check: CheckFn,
-) -> Option<&'static str> {
+fn walk_command_with(cmd: &yash_syntax::syntax::Command, check: CheckFn) -> Option<&'static str> {
     use yash_syntax::syntax::{Command, CompoundCommand};
     match cmd {
         Command::Simple(sc) => {
@@ -467,8 +461,15 @@ fn check_git(args: &[String]) -> Option<&'static str> {
     let subcmd = strs.iter().find(|a| !a.starts_with('-'))?;
     match *subcmd {
         "push" => {
-            if has_long_flag(&strs, &["--force", "--force-with-lease", "--force-if-includes", "--delete"])
-                || has_short_flag(&strs, 'f')
+            if has_long_flag(
+                &strs,
+                &[
+                    "--force",
+                    "--force-with-lease",
+                    "--force-if-includes",
+                    "--delete",
+                ],
+            ) || has_short_flag(&strs, 'f')
             {
                 Some("git push --force/--delete")
             } else {
@@ -572,11 +573,14 @@ fn check_gh(args: &[String]) -> Option<&'static str> {
 
 fn check_rm(args: &[String]) -> Option<&'static str> {
     let strs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-    let has_recursive =
-        has_short_flag(&strs, 'r') || has_short_flag(&strs, 'R') || has_long_flag(&strs, &["--recursive"]);
+    let has_recursive = has_short_flag(&strs, 'r')
+        || has_short_flag(&strs, 'R')
+        || has_long_flag(&strs, &["--recursive"]);
     let has_force = has_short_flag(&strs, 'f') || has_long_flag(&strs, &["--force"]);
     if has_recursive && has_force {
-        let has_abs_path = strs.iter().any(|a| !a.starts_with('-') && a.starts_with('/'));
+        let has_abs_path = strs
+            .iter()
+            .any(|a| !a.starts_with('-') && a.starts_with('/'));
         if has_abs_path {
             return Some("rm -rf with absolute path");
         }
@@ -603,13 +607,13 @@ fn has_long_flag(args: &[&str], flags: &[&str]) -> bool {
 }
 
 fn has_short_flag(args: &[&str], ch: char) -> bool {
-    args.iter().any(|a| a.starts_with('-') && !a.starts_with("--") && a[1..].contains(ch))
+    args.iter()
+        .any(|a| a.starts_with('-') && !a.starts_with("--") && a[1..].contains(ch))
 }
 
 fn strip_outer_quotes(s: &str) -> String {
     if s.len() >= 2
-        && ((s.starts_with('"') && s.ends_with('"'))
-            || (s.starts_with('\'') && s.ends_with('\'')))
+        && ((s.starts_with('"') && s.ends_with('"')) || (s.starts_with('\'') && s.ends_with('\'')))
     {
         s[1..s.len() - 1].to_string()
     } else {
@@ -658,13 +662,25 @@ mod tests {
 
     #[test]
     fn full_auto_allows_everything() {
-        let result = evaluate("Bash", &json!({"command": "rm -rf /"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        let result = evaluate(
+            "Bash",
+            &json!({"command": "rm -rf /"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::FullAuto,
+        );
         assert_eq!(result.decision, PolicyDecision::AutoAllow);
     }
 
     #[test]
     fn supervised_requires_approval_for_everything() {
-        let result = evaluate("Read", &json!({"file_path": "/tmp/project/src/main.rs"}), WORKTREE, REPO, TrustLevel::Supervised);
+        let result = evaluate(
+            "Read",
+            &json!({"file_path": "/tmp/project/src/main.rs"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::Supervised,
+        );
         assert_eq!(result.decision, PolicyDecision::RequireApproval);
     }
 
@@ -673,26 +689,50 @@ mod tests {
     #[test]
     fn read_inside_repo_auto_allowed() {
         // Use string prefix check since test paths don't exist on disk
-        let result = evaluate("Read", &json!({"file_path": "/tmp/project/src/main.rs"}), WORKTREE, REPO, TrustLevel::Normal);
+        let result = evaluate(
+            "Read",
+            &json!({"file_path": "/tmp/project/src/main.rs"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::Normal,
+        );
         // Will fall through to string prefix check since paths don't exist
         assert_eq!(result.decision, PolicyDecision::AutoAllow);
     }
 
     #[test]
     fn read_outside_repo_requires_approval() {
-        let result = evaluate("Read", &json!({"file_path": "/etc/passwd"}), WORKTREE, REPO, TrustLevel::Normal);
+        let result = evaluate(
+            "Read",
+            &json!({"file_path": "/etc/passwd"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::Normal,
+        );
         assert_eq!(result.decision, PolicyDecision::RequireApproval);
     }
 
     #[test]
     fn grep_with_no_path_auto_allowed() {
-        let result = evaluate("Grep", &json!({"pattern": "TODO"}), WORKTREE, REPO, TrustLevel::Normal);
+        let result = evaluate(
+            "Grep",
+            &json!({"pattern": "TODO"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::Normal,
+        );
         assert_eq!(result.decision, PolicyDecision::AutoAllow);
     }
 
     #[test]
     fn glob_inside_repo_auto_allowed() {
-        let result = evaluate("Glob", &json!({"path": "/tmp/project/src"}), WORKTREE, REPO, TrustLevel::Normal);
+        let result = evaluate(
+            "Glob",
+            &json!({"path": "/tmp/project/src"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::Normal,
+        );
         assert_eq!(result.decision, PolicyDecision::AutoAllow);
     }
 
@@ -703,7 +743,9 @@ mod tests {
         let result = evaluate(
             "Edit",
             &json!({"file_path": "/tmp/project/.verun/worktrees/silly-penguin/src/lib.rs"}),
-            WORKTREE, REPO, TrustLevel::Normal,
+            WORKTREE,
+            REPO,
+            TrustLevel::Normal,
         );
         assert_eq!(result.decision, PolicyDecision::AutoAllow);
     }
@@ -713,7 +755,9 @@ mod tests {
         let result = evaluate(
             "Write",
             &json!({"file_path": "/tmp/project/src/lib.rs"}),
-            WORKTREE, REPO, TrustLevel::Normal,
+            WORKTREE,
+            REPO,
+            TrustLevel::Normal,
         );
         assert_eq!(result.decision, PolicyDecision::RequireApproval);
     }
@@ -723,7 +767,9 @@ mod tests {
         let result = evaluate(
             "Edit",
             &json!({"file_path": "/etc/hosts"}),
-            WORKTREE, REPO, TrustLevel::Normal,
+            WORKTREE,
+            REPO,
+            TrustLevel::Normal,
         );
         assert_eq!(result.decision, PolicyDecision::RequireApproval);
     }
@@ -738,87 +784,171 @@ mod tests {
 
     #[test]
     fn bash_safe_command_auto_allowed_logged() {
-        let result = evaluate("Bash", &json!({"command": "cargo test"}), WORKTREE, REPO, TrustLevel::Normal);
+        let result = evaluate(
+            "Bash",
+            &json!({"command": "cargo test"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::Normal,
+        );
         assert_eq!(result.decision, PolicyDecision::AutoAllowLogged);
     }
 
     #[test]
     fn bash_ls_auto_allowed() {
-        let result = evaluate("Bash", &json!({"command": "ls -la"}), WORKTREE, REPO, TrustLevel::Normal);
+        let result = evaluate(
+            "Bash",
+            &json!({"command": "ls -la"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::Normal,
+        );
         assert_eq!(result.decision, PolicyDecision::AutoAllowLogged);
     }
 
     #[test]
     fn bash_npm_install_auto_allowed() {
-        let result = evaluate("Bash", &json!({"command": "npm install"}), WORKTREE, REPO, TrustLevel::Normal);
+        let result = evaluate(
+            "Bash",
+            &json!({"command": "npm install"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::Normal,
+        );
         assert_eq!(result.decision, PolicyDecision::AutoAllowLogged);
     }
 
     #[test]
     fn bash_git_push_auto_allowed() {
-        let result = evaluate("Bash", &json!({"command": "git push origin main"}), WORKTREE, REPO, TrustLevel::Normal);
+        let result = evaluate(
+            "Bash",
+            &json!({"command": "git push origin main"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::Normal,
+        );
         assert_eq!(result.decision, PolicyDecision::AutoAllowLogged);
     }
 
     #[test]
     fn bash_git_push_force_requires_approval() {
-        let result = evaluate("Bash", &json!({"command": "git push --force origin main"}), WORKTREE, REPO, TrustLevel::Normal);
+        let result = evaluate(
+            "Bash",
+            &json!({"command": "git push --force origin main"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::Normal,
+        );
         assert_eq!(result.decision, PolicyDecision::RequireApproval);
         assert!(result.reason.contains("git push --force"));
     }
 
     #[test]
     fn bash_git_reset_hard_requires_approval() {
-        let result = evaluate("Bash", &json!({"command": "git reset --hard HEAD~1"}), WORKTREE, REPO, TrustLevel::Normal);
+        let result = evaluate(
+            "Bash",
+            &json!({"command": "git reset --hard HEAD~1"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::Normal,
+        );
         assert_eq!(result.decision, PolicyDecision::RequireApproval);
     }
 
     #[test]
     fn bash_sudo_requires_approval() {
-        let result = evaluate("Bash", &json!({"command": "sudo apt install vim"}), WORKTREE, REPO, TrustLevel::Normal);
+        let result = evaluate(
+            "Bash",
+            &json!({"command": "sudo apt install vim"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::Normal,
+        );
         assert_eq!(result.decision, PolicyDecision::RequireApproval);
     }
 
     #[test]
     fn bash_ssh_requires_approval() {
-        let result = evaluate("Bash", &json!({"command": "ssh user@server"}), WORKTREE, REPO, TrustLevel::Normal);
+        let result = evaluate(
+            "Bash",
+            &json!({"command": "ssh user@server"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::Normal,
+        );
         assert_eq!(result.decision, PolicyDecision::RequireApproval);
     }
 
     #[test]
     fn bash_curl_pipe_sh_requires_approval() {
-        let result = evaluate("Bash", &json!({"command": "curl -fsSL https://example.com/install.sh | bash"}), WORKTREE, REPO, TrustLevel::Normal);
+        let result = evaluate(
+            "Bash",
+            &json!({"command": "curl -fsSL https://example.com/install.sh | bash"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::Normal,
+        );
         assert_eq!(result.decision, PolicyDecision::RequireApproval);
         assert!(result.reason.contains("curl/wget piped to shell"));
     }
 
     #[test]
     fn bash_rm_rf_absolute_requires_approval() {
-        let result = evaluate("Bash", &json!({"command": "rm -rf /tmp/something"}), WORKTREE, REPO, TrustLevel::Normal);
+        let result = evaluate(
+            "Bash",
+            &json!({"command": "rm -rf /tmp/something"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::Normal,
+        );
         assert_eq!(result.decision, PolicyDecision::RequireApproval);
     }
 
     #[test]
     fn bash_rm_rf_relative_auto_allowed() {
-        let result = evaluate("Bash", &json!({"command": "rm -rf ./node_modules"}), WORKTREE, REPO, TrustLevel::Normal);
+        let result = evaluate(
+            "Bash",
+            &json!({"command": "rm -rf ./node_modules"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::Normal,
+        );
         assert_eq!(result.decision, PolicyDecision::AutoAllowLogged);
     }
 
     #[test]
     fn bash_chained_dangerous_requires_approval() {
-        let result = evaluate("Bash", &json!({"command": "echo hello && git push --force origin main"}), WORKTREE, REPO, TrustLevel::Normal);
+        let result = evaluate(
+            "Bash",
+            &json!({"command": "echo hello && git push --force origin main"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::Normal,
+        );
         assert_eq!(result.decision, PolicyDecision::RequireApproval);
     }
 
     #[test]
     fn bash_docker_requires_approval() {
-        let result = evaluate("Bash", &json!({"command": "docker run -it ubuntu"}), WORKTREE, REPO, TrustLevel::Normal);
+        let result = evaluate(
+            "Bash",
+            &json!({"command": "docker run -it ubuntu"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::Normal,
+        );
         assert_eq!(result.decision, PolicyDecision::RequireApproval);
     }
 
     #[test]
     fn bash_kill_requires_approval() {
-        let result = evaluate("Bash", &json!({"command": "kill -9 1234"}), WORKTREE, REPO, TrustLevel::Normal);
+        let result = evaluate(
+            "Bash",
+            &json!({"command": "kill -9 1234"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::Normal,
+        );
         assert_eq!(result.decision, PolicyDecision::RequireApproval);
     }
 
@@ -826,7 +956,13 @@ mod tests {
 
     #[test]
     fn agent_auto_allowed() {
-        let result = evaluate("Agent", &json!({"prompt": "search for bugs"}), WORKTREE, REPO, TrustLevel::Normal);
+        let result = evaluate(
+            "Agent",
+            &json!({"prompt": "search for bugs"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::Normal,
+        );
         assert_eq!(result.decision, PolicyDecision::AutoAllow);
     }
 
@@ -834,7 +970,13 @@ mod tests {
 
     #[test]
     fn mcp_tool_requires_approval() {
-        let result = evaluate("mcp__slack__send_message", &json!({}), WORKTREE, REPO, TrustLevel::Normal);
+        let result = evaluate(
+            "mcp__slack__send_message",
+            &json!({}),
+            WORKTREE,
+            REPO,
+            TrustLevel::Normal,
+        );
         assert_eq!(result.decision, PolicyDecision::RequireApproval);
         assert!(result.reason.contains("MCP tool"));
     }
@@ -843,13 +985,25 @@ mod tests {
 
     #[test]
     fn web_search_requires_approval() {
-        let result = evaluate("WebSearch", &json!({"query": "rust async"}), WORKTREE, REPO, TrustLevel::Normal);
+        let result = evaluate(
+            "WebSearch",
+            &json!({"query": "rust async"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::Normal,
+        );
         assert_eq!(result.decision, PolicyDecision::RequireApproval);
     }
 
     #[test]
     fn web_fetch_requires_approval() {
-        let result = evaluate("WebFetch", &json!({"url": "https://example.com"}), WORKTREE, REPO, TrustLevel::Normal);
+        let result = evaluate(
+            "WebFetch",
+            &json!({"url": "https://example.com"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::Normal,
+        );
         assert_eq!(result.decision, PolicyDecision::RequireApproval);
     }
 
@@ -857,7 +1011,13 @@ mod tests {
 
     #[test]
     fn unknown_tool_requires_approval() {
-        let result = evaluate("SomeFutureTool", &json!({}), WORKTREE, REPO, TrustLevel::Normal);
+        let result = evaluate(
+            "SomeFutureTool",
+            &json!({}),
+            WORKTREE,
+            REPO,
+            TrustLevel::Normal,
+        );
         assert_eq!(result.decision, PolicyDecision::RequireApproval);
     }
 
@@ -923,49 +1083,88 @@ mod tests {
 
     #[test]
     fn deny_git_push_force() {
-        assert_eq!(matches_deny_pattern("git push --force"), Some("git push --force/--delete"));
-        assert_eq!(matches_deny_pattern("git push -f origin main"), Some("git push --force/--delete"));
-        assert_eq!(matches_deny_pattern("git push --force-with-lease"), Some("git push --force/--delete"));
-        assert_eq!(matches_deny_pattern("git push --force-if-includes"), Some("git push --force/--delete"));
-        assert_eq!(matches_deny_pattern("git push --delete origin branch"), Some("git push --force/--delete"));
+        assert_eq!(
+            matches_deny_pattern("git push --force"),
+            Some("git push --force/--delete")
+        );
+        assert_eq!(
+            matches_deny_pattern("git push -f origin main"),
+            Some("git push --force/--delete")
+        );
+        assert_eq!(
+            matches_deny_pattern("git push --force-with-lease"),
+            Some("git push --force/--delete")
+        );
+        assert_eq!(
+            matches_deny_pattern("git push --force-if-includes"),
+            Some("git push --force/--delete")
+        );
+        assert_eq!(
+            matches_deny_pattern("git push --delete origin branch"),
+            Some("git push --force/--delete")
+        );
     }
 
     // -- Deny pattern: git branch --
 
     #[test]
     fn deny_git_branch_delete() {
-        assert_eq!(matches_deny_pattern("git branch -d my-feature"), Some("git branch delete"));
-        assert_eq!(matches_deny_pattern("git branch --delete my-feature"), Some("git branch delete"));
+        assert_eq!(
+            matches_deny_pattern("git branch -d my-feature"),
+            Some("git branch delete")
+        );
+        assert_eq!(
+            matches_deny_pattern("git branch --delete my-feature"),
+            Some("git branch delete")
+        );
     }
 
     #[test]
     fn deny_git_branch_force_delete() {
-        assert_eq!(matches_deny_pattern("git branch -D my-feature"), Some("git branch force-delete"));
+        assert_eq!(
+            matches_deny_pattern("git branch -D my-feature"),
+            Some("git branch force-delete")
+        );
     }
 
     #[test]
     fn deny_git_branch_combined_flags() {
-        assert_eq!(matches_deny_pattern("git branch -Dr origin/old"), Some("git branch force-delete"));
+        assert_eq!(
+            matches_deny_pattern("git branch -Dr origin/old"),
+            Some("git branch force-delete")
+        );
     }
 
     // -- Deny pattern: git worktree --
 
     #[test]
     fn deny_git_worktree_remove() {
-        assert_eq!(matches_deny_pattern("git worktree remove /tmp/wt"), Some("git worktree remove"));
-        assert_eq!(matches_deny_pattern("git worktree remove --force /tmp/wt"), Some("git worktree remove"));
+        assert_eq!(
+            matches_deny_pattern("git worktree remove /tmp/wt"),
+            Some("git worktree remove")
+        );
+        assert_eq!(
+            matches_deny_pattern("git worktree remove --force /tmp/wt"),
+            Some("git worktree remove")
+        );
     }
 
     #[test]
     fn deny_git_worktree_prune() {
-        assert_eq!(matches_deny_pattern("git worktree prune"), Some("git worktree prune"));
+        assert_eq!(
+            matches_deny_pattern("git worktree prune"),
+            Some("git worktree prune")
+        );
     }
 
     // -- Deny pattern: git reset/clean/checkout --
 
     #[test]
     fn deny_git_reset_hard() {
-        assert_eq!(matches_deny_pattern("git reset --hard HEAD~1"), Some("git reset --hard"));
+        assert_eq!(
+            matches_deny_pattern("git reset --hard HEAD~1"),
+            Some("git reset --hard")
+        );
     }
 
     #[test]
@@ -978,51 +1177,96 @@ mod tests {
 
     #[test]
     fn deny_git_checkout_discard_all() {
-        assert_eq!(matches_deny_pattern("git checkout -- ."), Some("git checkout (discard all)"));
+        assert_eq!(
+            matches_deny_pattern("git checkout -- ."),
+            Some("git checkout (discard all)")
+        );
     }
 
     // -- Deny pattern: new git operations --
 
     #[test]
     fn deny_git_stash_destructive() {
-        assert_eq!(matches_deny_pattern("git stash drop"), Some("git stash drop/clear"));
-        assert_eq!(matches_deny_pattern("git stash clear"), Some("git stash drop/clear"));
-        assert_eq!(matches_deny_pattern("git stash drop stash@{0}"), Some("git stash drop/clear"));
+        assert_eq!(
+            matches_deny_pattern("git stash drop"),
+            Some("git stash drop/clear")
+        );
+        assert_eq!(
+            matches_deny_pattern("git stash clear"),
+            Some("git stash drop/clear")
+        );
+        assert_eq!(
+            matches_deny_pattern("git stash drop stash@{0}"),
+            Some("git stash drop/clear")
+        );
     }
 
     #[test]
     fn deny_git_tag_delete() {
-        assert_eq!(matches_deny_pattern("git tag -d v1.0"), Some("git tag delete"));
-        assert_eq!(matches_deny_pattern("git tag --delete v1.0"), Some("git tag delete"));
+        assert_eq!(
+            matches_deny_pattern("git tag -d v1.0"),
+            Some("git tag delete")
+        );
+        assert_eq!(
+            matches_deny_pattern("git tag --delete v1.0"),
+            Some("git tag delete")
+        );
     }
 
     #[test]
     fn deny_git_remote_remove() {
-        assert_eq!(matches_deny_pattern("git remote remove origin"), Some("git remote remove"));
-        assert_eq!(matches_deny_pattern("git remote rm origin"), Some("git remote remove"));
+        assert_eq!(
+            matches_deny_pattern("git remote remove origin"),
+            Some("git remote remove")
+        );
+        assert_eq!(
+            matches_deny_pattern("git remote rm origin"),
+            Some("git remote remove")
+        );
     }
 
     #[test]
     fn deny_git_reflog_expire() {
-        assert_eq!(matches_deny_pattern("git reflog expire --expire=all --all"), Some("git reflog expire/delete"));
-        assert_eq!(matches_deny_pattern("git reflog delete HEAD@{0}"), Some("git reflog expire/delete"));
+        assert_eq!(
+            matches_deny_pattern("git reflog expire --expire=all --all"),
+            Some("git reflog expire/delete")
+        );
+        assert_eq!(
+            matches_deny_pattern("git reflog delete HEAD@{0}"),
+            Some("git reflog expire/delete")
+        );
     }
 
     #[test]
     fn deny_git_gc_prune() {
-        assert_eq!(matches_deny_pattern("git gc --prune=now"), Some("git gc --prune"));
-        assert_eq!(matches_deny_pattern("git gc --prune"), Some("git gc --prune"));
+        assert_eq!(
+            matches_deny_pattern("git gc --prune=now"),
+            Some("git gc --prune")
+        );
+        assert_eq!(
+            matches_deny_pattern("git gc --prune"),
+            Some("git gc --prune")
+        );
     }
 
     #[test]
     fn deny_git_filter_branch() {
-        assert_eq!(matches_deny_pattern("git filter-branch --force HEAD"), Some("git filter-branch"));
+        assert_eq!(
+            matches_deny_pattern("git filter-branch --force HEAD"),
+            Some("git filter-branch")
+        );
     }
 
     #[test]
     fn deny_git_update_ref() {
-        assert_eq!(matches_deny_pattern("git update-ref -d refs/heads/main"), Some("git update-ref delete"));
-        assert_eq!(matches_deny_pattern("git update-ref --delete refs/heads/main"), Some("git update-ref delete"));
+        assert_eq!(
+            matches_deny_pattern("git update-ref -d refs/heads/main"),
+            Some("git update-ref delete")
+        );
+        assert_eq!(
+            matches_deny_pattern("git update-ref --delete refs/heads/main"),
+            Some("git update-ref delete")
+        );
     }
 
     // -- Deny pattern: compound commands (AST-based) --
@@ -1094,19 +1338,28 @@ mod tests {
 
     #[test]
     fn deny_gh_repo_delete() {
-        assert_eq!(matches_deny_pattern("gh repo delete myorg/myrepo --yes"), Some("gh repo delete"));
+        assert_eq!(
+            matches_deny_pattern("gh repo delete myorg/myrepo --yes"),
+            Some("gh repo delete")
+        );
     }
 
     #[test]
     fn deny_gh_release_delete() {
-        assert_eq!(matches_deny_pattern("gh release delete v1.0"), Some("gh release delete"));
+        assert_eq!(
+            matches_deny_pattern("gh release delete v1.0"),
+            Some("gh release delete")
+        );
     }
 
     // -- Deny pattern: rm, ssh, docker, etc. --
 
     #[test]
     fn deny_rm_rf_absolute() {
-        assert_eq!(matches_deny_pattern("rm -rf /tmp/something"), Some("rm -rf with absolute path"));
+        assert_eq!(
+            matches_deny_pattern("rm -rf /tmp/something"),
+            Some("rm -rf with absolute path")
+        );
     }
 
     #[test]
@@ -1117,13 +1370,22 @@ mod tests {
     #[test]
     fn deny_ssh_scp() {
         assert_eq!(matches_deny_pattern("ssh user@host"), Some("ssh/scp"));
-        assert_eq!(matches_deny_pattern("scp file user@host:/tmp"), Some("ssh/scp"));
+        assert_eq!(
+            matches_deny_pattern("scp file user@host:/tmp"),
+            Some("ssh/scp")
+        );
     }
 
     #[test]
     fn deny_docker_kubectl() {
-        assert_eq!(matches_deny_pattern("docker run -it ubuntu"), Some("docker/kubectl"));
-        assert_eq!(matches_deny_pattern("kubectl delete pod"), Some("docker/kubectl"));
+        assert_eq!(
+            matches_deny_pattern("docker run -it ubuntu"),
+            Some("docker/kubectl")
+        );
+        assert_eq!(
+            matches_deny_pattern("kubectl delete pod"),
+            Some("docker/kubectl")
+        );
     }
 
     #[test]
@@ -1135,43 +1397,79 @@ mod tests {
 
     #[test]
     fn deny_chmod_chown() {
-        assert_eq!(matches_deny_pattern("chmod 777 /tmp/file"), Some("chmod/chown"));
-        assert_eq!(matches_deny_pattern("chown root:root /tmp/file"), Some("chmod/chown"));
+        assert_eq!(
+            matches_deny_pattern("chmod 777 /tmp/file"),
+            Some("chmod/chown")
+        );
+        assert_eq!(
+            matches_deny_pattern("chown root:root /tmp/file"),
+            Some("chmod/chown")
+        );
     }
 
     // -- Integration: evaluate() with Bash tool --
 
     #[test]
     fn bash_git_branch_delete_requires_approval() {
-        let result = evaluate("Bash", &json!({"command": "git branch -d my-feature"}), WORKTREE, REPO, TrustLevel::Normal);
+        let result = evaluate(
+            "Bash",
+            &json!({"command": "git branch -d my-feature"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::Normal,
+        );
         assert_eq!(result.decision, PolicyDecision::RequireApproval);
         assert!(result.reason.contains("git branch delete"));
     }
 
     #[test]
     fn bash_git_branch_force_delete_requires_approval() {
-        let result = evaluate("Bash", &json!({"command": "git branch -D my-feature"}), WORKTREE, REPO, TrustLevel::Normal);
+        let result = evaluate(
+            "Bash",
+            &json!({"command": "git branch -D my-feature"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::Normal,
+        );
         assert_eq!(result.decision, PolicyDecision::RequireApproval);
         assert!(result.reason.contains("git branch force-delete"));
     }
 
     #[test]
     fn bash_git_worktree_remove_requires_approval() {
-        let result = evaluate("Bash", &json!({"command": "git worktree remove /tmp/some-worktree"}), WORKTREE, REPO, TrustLevel::Normal);
+        let result = evaluate(
+            "Bash",
+            &json!({"command": "git worktree remove /tmp/some-worktree"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::Normal,
+        );
         assert_eq!(result.decision, PolicyDecision::RequireApproval);
         assert!(result.reason.contains("git worktree remove"));
     }
 
     #[test]
     fn bash_git_worktree_prune_requires_approval() {
-        let result = evaluate("Bash", &json!({"command": "git worktree prune"}), WORKTREE, REPO, TrustLevel::Normal);
+        let result = evaluate(
+            "Bash",
+            &json!({"command": "git worktree prune"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::Normal,
+        );
         assert_eq!(result.decision, PolicyDecision::RequireApproval);
         assert!(result.reason.contains("git worktree prune"));
     }
 
     #[test]
     fn bash_git_branch_list_auto_allowed() {
-        let result = evaluate("Bash", &json!({"command": "git branch -a"}), WORKTREE, REPO, TrustLevel::Normal);
+        let result = evaluate(
+            "Bash",
+            &json!({"command": "git branch -a"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::Normal,
+        );
         assert_eq!(result.decision, PolicyDecision::AutoAllowLogged);
     }
 
@@ -1199,7 +1497,13 @@ mod tests {
 
     #[test]
     fn hard_block_worktree_prune_full_auto() {
-        let r = evaluate("Bash", &json!({"command": "git worktree prune"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        let r = evaluate(
+            "Bash",
+            &json!({"command": "git worktree prune"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::FullAuto,
+        );
         assert_eq!(r.decision, PolicyDecision::RequireApproval);
         assert!(r.reason.contains("hard-blocked"));
         assert!(r.reason.contains("verun-managed"));
@@ -1207,34 +1511,64 @@ mod tests {
 
     #[test]
     fn hard_block_worktree_prune_normal() {
-        let r = evaluate("Bash", &json!({"command": "git worktree prune"}), WORKTREE, REPO, TrustLevel::Normal);
+        let r = evaluate(
+            "Bash",
+            &json!({"command": "git worktree prune"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::Normal,
+        );
         assert_eq!(r.decision, PolicyDecision::RequireApproval);
         assert!(r.reason.contains("hard-blocked"));
     }
 
     #[test]
     fn hard_block_worktree_prune_supervised() {
-        let r = evaluate("Bash", &json!({"command": "git worktree prune"}), WORKTREE, REPO, TrustLevel::Supervised);
+        let r = evaluate(
+            "Bash",
+            &json!({"command": "git worktree prune"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::Supervised,
+        );
         assert_eq!(r.decision, PolicyDecision::RequireApproval);
     }
 
     #[test]
     fn hard_block_worktree_remove_full_auto() {
-        let r = evaluate("Bash", &json!({"command": "git worktree remove /tmp/wt"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        let r = evaluate(
+            "Bash",
+            &json!({"command": "git worktree remove /tmp/wt"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::FullAuto,
+        );
         assert_eq!(r.decision, PolicyDecision::RequireApproval);
         assert!(r.reason.contains("hard-blocked"));
     }
 
     #[test]
     fn hard_block_worktree_remove_normal() {
-        let r = evaluate("Bash", &json!({"command": "git worktree remove /tmp/wt"}), WORKTREE, REPO, TrustLevel::Normal);
+        let r = evaluate(
+            "Bash",
+            &json!({"command": "git worktree remove /tmp/wt"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::Normal,
+        );
         assert_eq!(r.decision, PolicyDecision::RequireApproval);
         assert!(r.reason.contains("hard-blocked"));
     }
 
     #[test]
     fn hard_block_worktree_remove_force_flag() {
-        let r = evaluate("Bash", &json!({"command": "git worktree remove --force /tmp/wt"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        let r = evaluate(
+            "Bash",
+            &json!({"command": "git worktree remove --force /tmp/wt"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::FullAuto,
+        );
         assert_eq!(r.decision, PolicyDecision::RequireApproval);
     }
 
@@ -1242,19 +1576,37 @@ mod tests {
 
     #[test]
     fn hard_block_git_c_worktree_prune() {
-        let r = evaluate("Bash", &json!({"command": "git -C /other/project worktree prune"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        let r = evaluate(
+            "Bash",
+            &json!({"command": "git -C /other/project worktree prune"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::FullAuto,
+        );
         assert_eq!(r.decision, PolicyDecision::RequireApproval);
     }
 
     #[test]
     fn hard_block_git_c_worktree_remove() {
-        let r = evaluate("Bash", &json!({"command": "git -C /other/repo worktree remove /tmp/wt"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        let r = evaluate(
+            "Bash",
+            &json!({"command": "git -C /other/repo worktree remove /tmp/wt"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::FullAuto,
+        );
         assert_eq!(r.decision, PolicyDecision::RequireApproval);
     }
 
     #[test]
     fn hard_block_git_multiple_c_flags() {
-        let r = evaluate("Bash", &json!({"command": "git -C /a -C /b worktree prune"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        let r = evaluate(
+            "Bash",
+            &json!({"command": "git -C /a -C /b worktree prune"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::FullAuto,
+        );
         assert_eq!(r.decision, PolicyDecision::RequireApproval);
     }
 
@@ -1267,32 +1619,62 @@ mod tests {
 
     #[test]
     fn hard_block_rm_verun_relative() {
-        let r = evaluate("Bash", &json!({"command": "rm -rf .verun/worktrees/some-task"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        let r = evaluate(
+            "Bash",
+            &json!({"command": "rm -rf .verun/worktrees/some-task"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::FullAuto,
+        );
         assert_eq!(r.decision, PolicyDecision::RequireApproval);
         assert!(r.reason.contains(".verun"));
     }
 
     #[test]
     fn hard_block_rm_verun_absolute() {
-        let r = evaluate("Bash", &json!({"command": "rm -rf /projects/repo/.verun/worktrees"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        let r = evaluate(
+            "Bash",
+            &json!({"command": "rm -rf /projects/repo/.verun/worktrees"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::FullAuto,
+        );
         assert_eq!(r.decision, PolicyDecision::RequireApproval);
     }
 
     #[test]
     fn hard_block_rm_verun_without_rf() {
-        let r = evaluate("Bash", &json!({"command": "rm .verun/worktrees/task/.git"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        let r = evaluate(
+            "Bash",
+            &json!({"command": "rm .verun/worktrees/task/.git"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::FullAuto,
+        );
         assert_eq!(r.decision, PolicyDecision::RequireApproval);
     }
 
     #[test]
     fn hard_block_rm_verun_parent() {
-        let r = evaluate("Bash", &json!({"command": "rm -rf .verun"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        let r = evaluate(
+            "Bash",
+            &json!({"command": "rm -rf .verun"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::FullAuto,
+        );
         assert_eq!(r.decision, PolicyDecision::RequireApproval);
     }
 
     #[test]
     fn hard_block_rm_verun_sibling_worktree() {
-        let r = evaluate("Bash", &json!({"command": "rm -rf ../other-task/.verun"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        let r = evaluate(
+            "Bash",
+            &json!({"command": "rm -rf ../other-task/.verun"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::FullAuto,
+        );
         assert_eq!(r.decision, PolicyDecision::RequireApproval);
     }
 
@@ -1300,37 +1682,73 @@ mod tests {
 
     #[test]
     fn hard_block_worktree_in_subshell() {
-        let r = evaluate("Bash", &json!({"command": "(git worktree prune)"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        let r = evaluate(
+            "Bash",
+            &json!({"command": "(git worktree prune)"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::FullAuto,
+        );
         assert_eq!(r.decision, PolicyDecision::RequireApproval);
     }
 
     #[test]
     fn hard_block_worktree_in_brace_group() {
-        let r = evaluate("Bash", &json!({"command": "{ git worktree remove /tmp/wt; }"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        let r = evaluate(
+            "Bash",
+            &json!({"command": "{ git worktree remove /tmp/wt; }"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::FullAuto,
+        );
         assert_eq!(r.decision, PolicyDecision::RequireApproval);
     }
 
     #[test]
     fn hard_block_worktree_chained_and() {
-        let r = evaluate("Bash", &json!({"command": "echo ok && git worktree remove /tmp/wt"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        let r = evaluate(
+            "Bash",
+            &json!({"command": "echo ok && git worktree remove /tmp/wt"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::FullAuto,
+        );
         assert_eq!(r.decision, PolicyDecision::RequireApproval);
     }
 
     #[test]
     fn hard_block_worktree_chained_or() {
-        let r = evaluate("Bash", &json!({"command": "false || git worktree prune"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        let r = evaluate(
+            "Bash",
+            &json!({"command": "false || git worktree prune"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::FullAuto,
+        );
         assert_eq!(r.decision, PolicyDecision::RequireApproval);
     }
 
     #[test]
     fn hard_block_worktree_chained_semicolon() {
-        let r = evaluate("Bash", &json!({"command": "echo ok; git worktree prune"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        let r = evaluate(
+            "Bash",
+            &json!({"command": "echo ok; git worktree prune"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::FullAuto,
+        );
         assert_eq!(r.decision, PolicyDecision::RequireApproval);
     }
 
     #[test]
     fn hard_block_rm_verun_chained() {
-        let r = evaluate("Bash", &json!({"command": "echo ok && rm -rf .verun/worktrees/task"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        let r = evaluate(
+            "Bash",
+            &json!({"command": "echo ok && rm -rf .verun/worktrees/task"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::FullAuto,
+        );
         assert_eq!(r.decision, PolicyDecision::RequireApproval);
     }
 
@@ -1338,37 +1756,73 @@ mod tests {
 
     #[test]
     fn hard_block_env_worktree_prune() {
-        let r = evaluate("Bash", &json!({"command": "env git worktree prune"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        let r = evaluate(
+            "Bash",
+            &json!({"command": "env git worktree prune"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::FullAuto,
+        );
         assert_eq!(r.decision, PolicyDecision::RequireApproval);
     }
 
     #[test]
     fn hard_block_env_with_vars_worktree() {
-        let r = evaluate("Bash", &json!({"command": "env GIT_TERMINAL_PROMPT=0 git worktree prune"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        let r = evaluate(
+            "Bash",
+            &json!({"command": "env GIT_TERMINAL_PROMPT=0 git worktree prune"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::FullAuto,
+        );
         assert_eq!(r.decision, PolicyDecision::RequireApproval);
     }
 
     #[test]
     fn hard_block_command_worktree() {
-        let r = evaluate("Bash", &json!({"command": "command git worktree remove /tmp/wt"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        let r = evaluate(
+            "Bash",
+            &json!({"command": "command git worktree remove /tmp/wt"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::FullAuto,
+        );
         assert_eq!(r.decision, PolicyDecision::RequireApproval);
     }
 
     #[test]
     fn hard_block_sudo_worktree_prune() {
-        let r = evaluate("Bash", &json!({"command": "sudo git worktree prune"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        let r = evaluate(
+            "Bash",
+            &json!({"command": "sudo git worktree prune"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::FullAuto,
+        );
         assert_eq!(r.decision, PolicyDecision::RequireApproval);
     }
 
     #[test]
     fn hard_block_sudo_u_worktree_prune() {
-        let r = evaluate("Bash", &json!({"command": "sudo -u root git worktree prune"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        let r = evaluate(
+            "Bash",
+            &json!({"command": "sudo -u root git worktree prune"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::FullAuto,
+        );
         assert_eq!(r.decision, PolicyDecision::RequireApproval);
     }
 
     #[test]
     fn hard_block_sudo_rm_verun() {
-        let r = evaluate("Bash", &json!({"command": "sudo rm -rf .verun/worktrees"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        let r = evaluate(
+            "Bash",
+            &json!({"command": "sudo rm -rf .verun/worktrees"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::FullAuto,
+        );
         assert_eq!(r.decision, PolicyDecision::RequireApproval);
     }
 
@@ -1376,19 +1830,37 @@ mod tests {
 
     #[test]
     fn hard_block_bash_c_worktree() {
-        let r = evaluate("Bash", &json!({"command": "bash -c 'git worktree prune'"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        let r = evaluate(
+            "Bash",
+            &json!({"command": "bash -c 'git worktree prune'"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::FullAuto,
+        );
         assert_eq!(r.decision, PolicyDecision::RequireApproval);
     }
 
     #[test]
     fn hard_block_sh_c_worktree() {
-        let r = evaluate("Bash", &json!({"command": "sh -c 'git worktree remove /tmp/wt'"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        let r = evaluate(
+            "Bash",
+            &json!({"command": "sh -c 'git worktree remove /tmp/wt'"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::FullAuto,
+        );
         assert_eq!(r.decision, PolicyDecision::RequireApproval);
     }
 
     #[test]
     fn hard_block_bash_c_rm_verun() {
-        let r = evaluate("Bash", &json!({"command": "bash -c 'rm -rf .verun'"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        let r = evaluate(
+            "Bash",
+            &json!({"command": "bash -c 'rm -rf .verun'"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::FullAuto,
+        );
         assert_eq!(r.decision, PolicyDecision::RequireApproval);
     }
 
@@ -1396,49 +1868,97 @@ mod tests {
 
     #[test]
     fn full_auto_allows_non_worktree_destructive() {
-        let r = evaluate("Bash", &json!({"command": "git push --force"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        let r = evaluate(
+            "Bash",
+            &json!({"command": "git push --force"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::FullAuto,
+        );
         assert_eq!(r.decision, PolicyDecision::AutoAllow);
     }
 
     #[test]
     fn full_auto_allows_worktree_list() {
-        let r = evaluate("Bash", &json!({"command": "git worktree list"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        let r = evaluate(
+            "Bash",
+            &json!({"command": "git worktree list"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::FullAuto,
+        );
         assert_eq!(r.decision, PolicyDecision::AutoAllow);
     }
 
     #[test]
     fn full_auto_allows_worktree_add() {
-        let r = evaluate("Bash", &json!({"command": "git worktree add /tmp/new-wt feature-branch"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        let r = evaluate(
+            "Bash",
+            &json!({"command": "git worktree add /tmp/new-wt feature-branch"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::FullAuto,
+        );
         assert_eq!(r.decision, PolicyDecision::AutoAllow);
     }
 
     #[test]
     fn full_auto_allows_rm_without_verun() {
-        let r = evaluate("Bash", &json!({"command": "rm -rf ./node_modules"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        let r = evaluate(
+            "Bash",
+            &json!({"command": "rm -rf ./node_modules"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::FullAuto,
+        );
         assert_eq!(r.decision, PolicyDecision::AutoAllow);
     }
 
     #[test]
     fn full_auto_allows_git_status() {
-        let r = evaluate("Bash", &json!({"command": "git status"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        let r = evaluate(
+            "Bash",
+            &json!({"command": "git status"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::FullAuto,
+        );
         assert_eq!(r.decision, PolicyDecision::AutoAllow);
     }
 
     #[test]
     fn full_auto_allows_git_c_safe_op() {
-        let r = evaluate("Bash", &json!({"command": "git -C /other/repo status"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        let r = evaluate(
+            "Bash",
+            &json!({"command": "git -C /other/repo status"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::FullAuto,
+        );
         assert_eq!(r.decision, PolicyDecision::AutoAllow);
     }
 
     #[test]
     fn hard_block_does_not_affect_non_bash_tools() {
-        let r = evaluate("Read", &json!({"file_path": "/tmp/project/src/main.rs"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        let r = evaluate(
+            "Read",
+            &json!({"file_path": "/tmp/project/src/main.rs"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::FullAuto,
+        );
         assert_eq!(r.decision, PolicyDecision::AutoAllow);
     }
 
     #[test]
     fn hard_block_does_not_affect_write_tool() {
-        let r = evaluate("Write", &json!({"file_path": "/tmp/.verun/foo"}), WORKTREE, REPO, TrustLevel::FullAuto);
+        let r = evaluate(
+            "Write",
+            &json!({"file_path": "/tmp/.verun/foo"}),
+            WORKTREE,
+            REPO,
+            TrustLevel::FullAuto,
+        );
         assert_eq!(r.decision, PolicyDecision::AutoAllow);
     }
 }

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -212,10 +212,19 @@ pub fn spawn_pty(
         } else {
             None
         };
-        let _ = app.emit("pty-exited", PtyExitedEvent { terminal_id: tid, exit_code });
+        let _ = app.emit(
+            "pty-exited",
+            PtyExitedEvent {
+                terminal_id: tid,
+                exit_code,
+            },
+        );
     });
 
-    Ok(SpawnResult { terminal_id, shell_name })
+    Ok(SpawnResult {
+        terminal_id,
+        shell_name,
+    })
 }
 
 /// Write user input to the PTY.
@@ -243,7 +252,12 @@ pub fn write_pty(map: &ActivePtyMap, terminal_id: &str, data: &[u8]) -> Result<(
 }
 
 /// Resize the PTY.
-pub fn resize_pty(map: &ActivePtyMap, terminal_id: &str, rows: u16, cols: u16) -> Result<(), String> {
+pub fn resize_pty(
+    map: &ActivePtyMap,
+    terminal_id: &str,
+    rows: u16,
+    cols: u16,
+) -> Result<(), String> {
     let handle = map
         .get(terminal_id)
         .ok_or_else(|| format!("Terminal {terminal_id} not found"))?;

--- a/src-tauri/src/snapshots.rs
+++ b/src-tauri/src/snapshots.rs
@@ -266,8 +266,7 @@ mod tests {
         let sha = snapshot_turn(dir.path(), "sess", "msg1").unwrap().unwrap();
 
         // Snapshot tree should contain BOTH README.md (modified) and new.txt.
-        let tree_listing =
-            run_git(dir.path(), &["ls-tree", "-r", &sha]).unwrap();
+        let tree_listing = run_git(dir.path(), &["ls-tree", "-r", &sha]).unwrap();
         assert!(tree_listing.contains("README.md"));
         assert!(tree_listing.contains("new.txt"));
 
@@ -283,10 +282,16 @@ mod tests {
         );
         // Read status without our run_git trim() so we see the leading space
         // that distinguishes ` M` (unstaged) from `M ` (staged).
-        let raw = git(dir.path()).args(["status", "--porcelain"]).output().unwrap();
+        let raw = git(dir.path())
+            .args(["status", "--porcelain"])
+            .output()
+            .unwrap();
         let real_status = String::from_utf8_lossy(&raw.stdout).into_owned();
         let lines: Vec<&str> = real_status.lines().collect();
-        let readme = lines.iter().find(|l| l.contains("README.md")).expect("README.md status missing");
+        let readme = lines
+            .iter()
+            .find(|l| l.contains("README.md"))
+            .expect("README.md status missing");
         assert!(
             readme.starts_with(" M"),
             "expected unstaged modification, got: {readme:?}"
@@ -315,7 +320,13 @@ mod tests {
         let new_path = new_dir.path().join("restored");
         restore_into_new_worktree(dir.path(), &new_path, &sha).unwrap();
 
-        assert_eq!(fs::read_to_string(new_path.join("README.md")).unwrap(), "hello\nv2\n");
-        assert_eq!(fs::read_to_string(new_path.join("untracked.txt")).unwrap(), "extra\n");
+        assert_eq!(
+            fs::read_to_string(new_path.join("README.md")).unwrap(),
+            "hello\nv2\n"
+        );
+        assert_eq!(
+            fs::read_to_string(new_path.join("untracked.txt")).unwrap(),
+            "extra\n"
+        );
     }
 }

--- a/src-tauri/src/stream.rs
+++ b/src-tauri/src/stream.rs
@@ -155,7 +155,11 @@ pub struct PolicyAutoApprovedEvent {
 fn parse_sdk_event(line: &str) -> Vec<OutputItem> {
     let v: serde_json::Value = match serde_json::from_str(line) {
         Ok(v) => v,
-        Err(_) => return vec![OutputItem::Raw { text: line.to_string() }],
+        Err(_) => {
+            return vec![OutputItem::Raw {
+                text: line.to_string(),
+            }]
+        }
     };
 
     let msg_type = v.get("type").and_then(|t| t.as_str()).unwrap_or("");
@@ -183,7 +187,9 @@ fn parse_sdk_event(line: &str) -> Vec<OutputItem> {
         // -- System messages --
         "system" => {
             if v.get("subtype").and_then(|s| s.as_str()) == Some("init") {
-                vec![OutputItem::System { text: "Initializing session...".into() }]
+                vec![OutputItem::System {
+                    text: "Initializing session...".into(),
+                }]
             } else {
                 vec![]
             }
@@ -193,7 +199,9 @@ fn parse_sdk_event(line: &str) -> Vec<OutputItem> {
         // Text is already delivered via stream_event deltas; skip result.result to avoid duplication.
         "result" => {
             // Claude/Cursor use `subtype`, Gemini uses `status` at top level
-            let status_str = v.get("subtype").and_then(|s| s.as_str())
+            let status_str = v
+                .get("subtype")
+                .and_then(|s| s.as_str())
                 .or_else(|| v.get("status").and_then(|s| s.as_str()))
                 .unwrap_or("unknown");
             let status = match status_str {
@@ -204,18 +212,25 @@ fn parse_sdk_event(line: &str) -> Vec<OutputItem> {
             // Claude/Cursor: `usage`, Gemini: `stats`
             let usage = v.get("usage").or_else(|| v.get("stats"));
             // Claude: snake_case, Cursor: camelCase
-            let input_tokens = usage.and_then(|u|
-                u.get("input_tokens").or_else(|| u.get("inputTokens"))
-            ).and_then(|t| t.as_u64());
-            let output_tokens = usage.and_then(|u|
-                u.get("output_tokens").or_else(|| u.get("outputTokens"))
-            ).and_then(|t| t.as_u64());
-            let cache_read_tokens = usage.and_then(|u|
-                u.get("cache_read_input_tokens").or_else(|| u.get("cacheReadTokens")).or_else(|| u.get("cached"))
-            ).and_then(|t| t.as_u64());
-            let cache_write_tokens = usage.and_then(|u|
-                u.get("cache_creation_input_tokens").or_else(|| u.get("cacheWriteTokens"))
-            ).and_then(|t| t.as_u64());
+            let input_tokens = usage
+                .and_then(|u| u.get("input_tokens").or_else(|| u.get("inputTokens")))
+                .and_then(|t| t.as_u64());
+            let output_tokens = usage
+                .and_then(|u| u.get("output_tokens").or_else(|| u.get("outputTokens")))
+                .and_then(|t| t.as_u64());
+            let cache_read_tokens = usage
+                .and_then(|u| {
+                    u.get("cache_read_input_tokens")
+                        .or_else(|| u.get("cacheReadTokens"))
+                        .or_else(|| u.get("cached"))
+                })
+                .and_then(|t| t.as_u64());
+            let cache_write_tokens = usage
+                .and_then(|u| {
+                    u.get("cache_creation_input_tokens")
+                        .or_else(|| u.get("cacheWriteTokens"))
+                })
+                .and_then(|t| t.as_u64());
             let error = if status == "error" {
                 v.get("error")
                     .and_then(|e| e.as_str())
@@ -223,13 +238,27 @@ fn parse_sdk_event(line: &str) -> Vec<OutputItem> {
             } else {
                 None
             };
-            vec![OutputItem::TurnEnd { status: status.to_string(), cost, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, error }]
+            vec![OutputItem::TurnEnd {
+                status: status.to_string(),
+                cost,
+                input_tokens,
+                output_tokens,
+                cache_read_tokens,
+                cache_write_tokens,
+                error,
+            }]
         }
 
         // -- Telemetry events we can surface --
         "tool_progress" => {
-            let tool = v.get("tool_name").and_then(|t| t.as_str()).unwrap_or("tool");
-            let elapsed = v.get("elapsed_time_seconds").and_then(|e| e.as_f64()).unwrap_or(0.0);
+            let tool = v
+                .get("tool_name")
+                .and_then(|t| t.as_str())
+                .unwrap_or("tool");
+            let elapsed = v
+                .get("elapsed_time_seconds")
+                .and_then(|e| e.as_f64())
+                .unwrap_or(0.0);
             vec![OutputItem::System {
                 text: format!("{tool} running ({elapsed:.0}s)"),
             }]
@@ -253,13 +282,20 @@ fn parse_sdk_event(line: &str) -> Vec<OutputItem> {
                     if let Some(tc) = tc {
                         let (tool, input) = parse_cursor_tool_call(tc);
                         vec![OutputItem::ToolStart { tool, input }]
-                    } else { vec![] }
+                    } else {
+                        vec![]
+                    }
                 }
                 "completed" => {
                     if let Some(tc) = tc {
                         let output = extract_cursor_tool_result(tc);
-                        vec![OutputItem::ToolResult { text: output, is_error: false }]
-                    } else { vec![] }
+                        vec![OutputItem::ToolResult {
+                            text: output,
+                            is_error: false,
+                        }]
+                    } else {
+                        vec![]
+                    }
                 }
                 _ => vec![],
             }
@@ -270,7 +306,9 @@ fn parse_sdk_event(line: &str) -> Vec<OutputItem> {
             if subtype == "delta" {
                 if let Some(text) = v.get("text").and_then(|t| t.as_str()) {
                     if !text.is_empty() {
-                        return vec![OutputItem::Thinking { text: text.to_string() }];
+                        return vec![OutputItem::Thinking {
+                            text: text.to_string(),
+                        }];
                     }
                 }
             }
@@ -283,7 +321,9 @@ fn parse_sdk_event(line: &str) -> Vec<OutputItem> {
             let delta = v.get("delta");
             if delta.and_then(|d| d.get("type")).and_then(|t| t.as_str()) == Some("text_delta") {
                 if let Some(text) = delta.and_then(|d| d.get("text")).and_then(|t| t.as_str()) {
-                    return vec![OutputItem::Text { text: text.to_string() }];
+                    return vec![OutputItem::Text {
+                        text: text.to_string(),
+                    }];
                 }
             }
             vec![]
@@ -291,11 +331,21 @@ fn parse_sdk_event(line: &str) -> Vec<OutputItem> {
 
         // Tool started: show the command/tool being invoked
         "item.started" => {
-            let item = match v.get("item") { Some(i) => i, None => return vec![] };
+            let item = match v.get("item") {
+                Some(i) => i,
+                None => return vec![],
+            };
             match item.get("type").and_then(|t| t.as_str()).unwrap_or("") {
                 "command_execution" => {
-                    let cmd = item.get("command").and_then(|c| c.as_str()).unwrap_or("").to_string();
-                    vec![OutputItem::ToolStart { tool: "shell".to_string(), input: cmd }]
+                    let cmd = item
+                        .get("command")
+                        .and_then(|c| c.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    vec![OutputItem::ToolStart {
+                        tool: "shell".to_string(),
+                        input: cmd,
+                    }]
                 }
                 _ => vec![],
             }
@@ -303,29 +353,61 @@ fn parse_sdk_event(line: &str) -> Vec<OutputItem> {
 
         // Completed item: agent message, command result, tool call, or tool result
         "item.completed" => {
-            let item = match v.get("item") { Some(i) => i, None => return vec![] };
+            let item = match v.get("item") {
+                Some(i) => i,
+                None => return vec![],
+            };
             match item.get("type").and_then(|t| t.as_str()).unwrap_or("") {
-                "agent_message" => {
-                    item.get("text").and_then(|t| t.as_str())
-                        .map(|text| vec![OutputItem::Text { text: text.to_string() }])
-                        .unwrap_or_default()
-                }
+                "agent_message" => item
+                    .get("text")
+                    .and_then(|t| t.as_str())
+                    .map(|text| {
+                        vec![OutputItem::Text {
+                            text: text.to_string(),
+                        }]
+                    })
+                    .unwrap_or_default(),
                 "command_execution" => {
-                    let output = item.get("aggregated_output").and_then(|o| o.as_str()).unwrap_or("").to_string();
-                    let is_error = item.get("exit_code").and_then(|c| c.as_i64()).map(|c| c != 0).unwrap_or(false);
-                    vec![OutputItem::ToolResult { text: output, is_error }]
+                    let output = item
+                        .get("aggregated_output")
+                        .and_then(|o| o.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    let is_error = item
+                        .get("exit_code")
+                        .and_then(|c| c.as_i64())
+                        .map(|c| c != 0)
+                        .unwrap_or(false);
+                    vec![OutputItem::ToolResult {
+                        text: output,
+                        is_error,
+                    }]
                 }
                 "tool_call" => {
                     let name = item.get("name").and_then(|n| n.as_str()).unwrap_or("tool");
-                    let args = item.get("arguments")
+                    let args = item
+                        .get("arguments")
                         .map(|a| serde_json::to_string_pretty(a).unwrap_or_default())
                         .unwrap_or_default();
-                    vec![OutputItem::ToolStart { tool: name.to_string(), input: args }]
+                    vec![OutputItem::ToolStart {
+                        tool: name.to_string(),
+                        input: args,
+                    }]
                 }
                 "tool_result" => {
-                    let output = item.get("output").and_then(|o| o.as_str()).unwrap_or("").to_string();
-                    let is_error = item.get("is_error").and_then(|e| e.as_bool()).unwrap_or(false);
-                    vec![OutputItem::ToolResult { text: output, is_error }]
+                    let output = item
+                        .get("output")
+                        .and_then(|o| o.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    let is_error = item
+                        .get("is_error")
+                        .and_then(|e| e.as_bool())
+                        .unwrap_or(false);
+                    vec![OutputItem::ToolResult {
+                        text: output,
+                        is_error,
+                    }]
                 }
                 _ => vec![],
             }
@@ -334,10 +416,24 @@ fn parse_sdk_event(line: &str) -> Vec<OutputItem> {
         // Turn completed: emit TurnEnd with token usage
         "turn.completed" => {
             let usage = v.get("usage");
-            let input_tokens = usage.and_then(|u| u.get("input_tokens")).and_then(|t| t.as_u64());
-            let output_tokens = usage.and_then(|u| u.get("output_tokens")).and_then(|t| t.as_u64());
-            let cache_read_tokens = usage.and_then(|u| u.get("cached_input_tokens")).and_then(|t| t.as_u64());
-            vec![OutputItem::TurnEnd { status: "completed".to_string(), cost: None, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens: None, error: None }]
+            let input_tokens = usage
+                .and_then(|u| u.get("input_tokens"))
+                .and_then(|t| t.as_u64());
+            let output_tokens = usage
+                .and_then(|u| u.get("output_tokens"))
+                .and_then(|t| t.as_u64());
+            let cache_read_tokens = usage
+                .and_then(|u| u.get("cached_input_tokens"))
+                .and_then(|t| t.as_u64());
+            vec![OutputItem::TurnEnd {
+                status: "completed".to_string(),
+                cost: None,
+                input_tokens,
+                output_tokens,
+                cache_read_tokens,
+                cache_write_tokens: None,
+                error: None,
+            }]
         }
 
         // Ignored Codex lifecycle events
@@ -345,14 +441,24 @@ fn parse_sdk_event(line: &str) -> Vec<OutputItem> {
 
         // ── OpenCode event format ────────────────────────────────────────
         "text" => {
-            let part = match v.get("part") { Some(p) => p, None => return vec![] };
+            let part = match v.get("part") {
+                Some(p) => p,
+                None => return vec![],
+            };
             // OpenCode nests the assistant text inside part — try known field names
-            let content = part.get("content").and_then(|c| c.as_str())
+            let content = part
+                .get("content")
+                .and_then(|c| c.as_str())
                 .or_else(|| part.get("text").and_then(|t| t.as_str()));
             match content {
-                Some(text) if !text.is_empty() => vec![OutputItem::Text { text: text.to_string() }],
+                Some(text) if !text.is_empty() => vec![OutputItem::Text {
+                    text: text.to_string(),
+                }],
                 _ => {
-                    eprintln!("[verun][opencode] unhandled text part: {}", serde_json::to_string(part).unwrap_or_default());
+                    eprintln!(
+                        "[verun][opencode] unhandled text part: {}",
+                        serde_json::to_string(part).unwrap_or_default()
+                    );
                     vec![]
                 }
             }
@@ -361,28 +467,49 @@ fn parse_sdk_event(line: &str) -> Vec<OutputItem> {
         "tool_use" => {
             if let Some(part) = v.get("part") {
                 // OpenCode format: { type: "tool_use", part: { tool, state: { status, input, output } } }
-                let tool = part.get("tool").and_then(|t| t.as_str()).unwrap_or("tool").to_string();
+                let tool = part
+                    .get("tool")
+                    .and_then(|t| t.as_str())
+                    .unwrap_or("tool")
+                    .to_string();
                 let state = part.get("state");
-                let status = state.and_then(|s| s.get("status")).and_then(|s| s.as_str()).unwrap_or("");
+                let status = state
+                    .and_then(|s| s.get("status"))
+                    .and_then(|s| s.as_str())
+                    .unwrap_or("");
                 if status == "completed" {
-                    let input = state.and_then(|s| s.get("input"))
+                    let input = state
+                        .and_then(|s| s.get("input"))
                         .map(|i| serde_json::to_string_pretty(i).unwrap_or_default())
                         .unwrap_or_default();
-                    let output = state.and_then(|s| s.get("output")).and_then(|o| o.as_str()).unwrap_or("").to_string();
+                    let output = state
+                        .and_then(|s| s.get("output"))
+                        .and_then(|o| o.as_str())
+                        .unwrap_or("")
+                        .to_string();
                     vec![
                         OutputItem::ToolStart { tool, input },
-                        OutputItem::ToolResult { text: output, is_error: false },
+                        OutputItem::ToolResult {
+                            text: output,
+                            is_error: false,
+                        },
                     ]
                 } else {
-                    let input = state.and_then(|s| s.get("input"))
+                    let input = state
+                        .and_then(|s| s.get("input"))
                         .map(|i| serde_json::to_string_pretty(i).unwrap_or_default())
                         .unwrap_or_default();
                     vec![OutputItem::ToolStart { tool, input }]
                 }
             } else {
                 // Gemini format: { type: "tool_use", tool_name, tool_id, parameters }
-                let tool = v.get("tool_name").and_then(|t| t.as_str()).unwrap_or("tool").to_string();
-                let input = v.get("parameters")
+                let tool = v
+                    .get("tool_name")
+                    .and_then(|t| t.as_str())
+                    .unwrap_or("tool")
+                    .to_string();
+                let input = v
+                    .get("parameters")
                     .map(|p| serde_json::to_string_pretty(p).unwrap_or_default())
                     .unwrap_or_default();
                 vec![OutputItem::ToolStart { tool, input }]
@@ -400,13 +527,27 @@ fn parse_sdk_event(line: &str) -> Vec<OutputItem> {
                 // OpenCode's `input` is a fixed overhead (not user message tokens)
                 // and `total` is the cumulative context window. Only `output` is
                 // meaningful per-turn, so we skip input to avoid misleading numbers.
-                let output_tokens = tokens.and_then(|t| t.get("output")).and_then(|t| t.as_u64());
+                let output_tokens = tokens
+                    .and_then(|t| t.get("output"))
+                    .and_then(|t| t.as_u64());
                 let input_tokens = tokens.and_then(|t| t.get("total")).and_then(|t| t.as_u64());
                 let cache = tokens.and_then(|t| t.get("cache"));
                 let cache_read_tokens = cache.and_then(|c| c.get("read")).and_then(|t| t.as_u64());
-                let cache_write_tokens = cache.and_then(|c| c.get("write")).and_then(|t| t.as_u64());
-                let cost = part.and_then(|p| p.get("cost")).and_then(|c| c.as_f64()).filter(|c| *c > 0.0);
-                vec![OutputItem::TurnEnd { status: "completed".to_string(), cost, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, error: None }]
+                let cache_write_tokens =
+                    cache.and_then(|c| c.get("write")).and_then(|t| t.as_u64());
+                let cost = part
+                    .and_then(|p| p.get("cost"))
+                    .and_then(|c| c.as_f64())
+                    .filter(|c| *c > 0.0);
+                vec![OutputItem::TurnEnd {
+                    status: "completed".to_string(),
+                    cost,
+                    input_tokens,
+                    output_tokens,
+                    cache_read_tokens,
+                    cache_write_tokens,
+                    error: None,
+                }]
             } else {
                 vec![]
             }
@@ -417,18 +558,29 @@ fn parse_sdk_event(line: &str) -> Vec<OutputItem> {
         // ── Gemini CLI event format ──────────────────────────────────────
         "message" => {
             let role = v.get("role").and_then(|r| r.as_str()).unwrap_or("");
-            if role != "assistant" { return vec![] }
+            if role != "assistant" {
+                return vec![];
+            }
             match v.get("content").and_then(|c| c.as_str()) {
-                Some(text) if !text.is_empty() => vec![OutputItem::Text { text: text.to_string() }],
+                Some(text) if !text.is_empty() => vec![OutputItem::Text {
+                    text: text.to_string(),
+                }],
                 _ => vec![],
             }
         }
 
         "tool_result" if v.get("tool_id").is_some() => {
             // Gemini format: { type: "tool_result", tool_id, status, output }
-            let output = v.get("output").and_then(|o| o.as_str()).unwrap_or("").to_string();
+            let output = v
+                .get("output")
+                .and_then(|o| o.as_str())
+                .unwrap_or("")
+                .to_string();
             let is_error = v.get("status").and_then(|s| s.as_str()) == Some("error");
-            vec![OutputItem::ToolResult { text: output, is_error }]
+            vec![OutputItem::ToolResult {
+                text: output,
+                is_error,
+            }]
         }
 
         _ => vec![],
@@ -457,7 +609,9 @@ fn parse_stream_event(v: &serde_json::Value) -> Vec<OutputItem> {
                     if text.is_empty() {
                         vec![]
                     } else {
-                        vec![OutputItem::Text { text: text.to_string() }]
+                        vec![OutputItem::Text {
+                            text: text.to_string(),
+                        }]
                     }
                 }
                 "thinking_delta" => {
@@ -465,7 +619,9 @@ fn parse_stream_event(v: &serde_json::Value) -> Vec<OutputItem> {
                     if text.is_empty() {
                         vec![]
                     } else {
-                        vec![OutputItem::Thinking { text: text.to_string() }]
+                        vec![OutputItem::Thinking {
+                            text: text.to_string(),
+                        }]
                     }
                 }
                 "input_json_delta" => {
@@ -484,8 +640,13 @@ fn parse_stream_event(v: &serde_json::Value) -> Vec<OutputItem> {
             match block_type {
                 "tool_use" | "server_tool_use" | "mcp_tool_use" => {
                     let name = block.get("name").and_then(|n| n.as_str()).unwrap_or("tool");
-                    let input = block.get("input").cloned().unwrap_or(serde_json::Value::Object(Default::default()));
-                    let input_str = if input.is_object() && input.as_object().map(|o| o.is_empty()).unwrap_or(true) {
+                    let input = block
+                        .get("input")
+                        .cloned()
+                        .unwrap_or(serde_json::Value::Object(Default::default()));
+                    let input_str = if input.is_object()
+                        && input.as_object().map(|o| o.is_empty()).unwrap_or(true)
+                    {
                         String::new()
                     } else {
                         serde_json::to_string_pretty(&input).unwrap_or_default()
@@ -512,7 +673,11 @@ fn parse_stream_event(v: &serde_json::Value) -> Vec<OutputItem> {
 /// in real-time, so the snapshot is redundant for those. We skip it to avoid duplication.
 /// However, we DO extract tool_use blocks since content_block_start may not always arrive.
 fn parse_assistant_message(v: &serde_json::Value) -> Vec<OutputItem> {
-    let content = match v.get("message").and_then(|m| m.get("content")).and_then(|c| c.as_array()) {
+    let content = match v
+        .get("message")
+        .and_then(|m| m.get("content"))
+        .and_then(|c| c.as_array())
+    {
         Some(c) => c,
         None => return vec![],
     };
@@ -523,8 +688,13 @@ fn parse_assistant_message(v: &serde_json::Value) -> Vec<OutputItem> {
         match block_type {
             "tool_use" | "server_tool_use" | "mcp_tool_use" => {
                 let name = block.get("name").and_then(|n| n.as_str()).unwrap_or("tool");
-                let input = block.get("input").cloned().unwrap_or(serde_json::Value::Object(Default::default()));
-                let input_str = if input.is_object() && input.as_object().map(|o| o.is_empty()).unwrap_or(true) {
+                let input = block
+                    .get("input")
+                    .cloned()
+                    .unwrap_or(serde_json::Value::Object(Default::default()));
+                let input_str = if input.is_object()
+                    && input.as_object().map(|o| o.is_empty()).unwrap_or(true)
+                {
                     String::new()
                 } else {
                     serde_json::to_string_pretty(&input).unwrap_or_default()
@@ -542,7 +712,11 @@ fn parse_assistant_message(v: &serde_json::Value) -> Vec<OutputItem> {
 
 /// Extract text from a Cursor streaming assistant delta (has `timestamp_ms`).
 fn parse_assistant_text_only(v: &serde_json::Value) -> Vec<OutputItem> {
-    let content = match v.get("message").and_then(|m| m.get("content")).and_then(|c| c.as_array()) {
+    let content = match v
+        .get("message")
+        .and_then(|m| m.get("content"))
+        .and_then(|c| c.as_array())
+    {
         Some(c) => c,
         None => return vec![],
     };
@@ -552,14 +726,18 @@ fn parse_assistant_text_only(v: &serde_json::Value) -> Vec<OutputItem> {
             "text" => {
                 if let Some(text) = block.get("text").and_then(|t| t.as_str()) {
                     if !text.is_empty() {
-                        items.push(OutputItem::Text { text: text.to_string() });
+                        items.push(OutputItem::Text {
+                            text: text.to_string(),
+                        });
                     }
                 }
             }
             "thinking" => {
                 if let Some(text) = block.get("thinking").and_then(|t| t.as_str()) {
                     if !text.is_empty() {
-                        items.push(OutputItem::Thinking { text: text.to_string() });
+                        items.push(OutputItem::Thinking {
+                            text: text.to_string(),
+                        });
                     }
                 }
             }
@@ -571,7 +749,11 @@ fn parse_assistant_text_only(v: &serde_json::Value) -> Vec<OutputItem> {
 
 /// Parse user messages (typically tool results)
 fn parse_user_message(v: &serde_json::Value) -> Vec<OutputItem> {
-    let content = match v.get("message").and_then(|m| m.get("content")).and_then(|c| c.as_array()) {
+    let content = match v
+        .get("message")
+        .and_then(|m| m.get("content"))
+        .and_then(|c| c.as_array())
+    {
         Some(c) => c,
         None => return vec![],
     };
@@ -580,7 +762,10 @@ fn parse_user_message(v: &serde_json::Value) -> Vec<OutputItem> {
     for block in content {
         let block_type = block.get("type").and_then(|t| t.as_str()).unwrap_or("");
         if block_type == "tool_result" {
-            let is_error = block.get("is_error").and_then(|e| e.as_bool()).unwrap_or(false);
+            let is_error = block
+                .get("is_error")
+                .and_then(|e| e.as_bool())
+                .unwrap_or(false);
             let text = extract_text_content(block.get("content"));
             if !text.is_empty() {
                 items.push(OutputItem::ToolResult { text, is_error });
@@ -589,7 +774,6 @@ fn parse_user_message(v: &serde_json::Value) -> Vec<OutputItem> {
     }
     items
 }
-
 
 /// Extract text from various content formats
 fn extract_text_content(content: Option<&serde_json::Value>) -> String {
@@ -618,7 +802,10 @@ fn extract_text_content(content: Option<&serde_json::Value>) -> String {
 fn parse_cursor_tool_call(tc: &serde_json::Map<String, serde_json::Value>) -> (String, String) {
     // The object has a single key like "readToolCall", "editToolCall", "bashToolCall", etc.
     if let Some((key, val)) = tc.iter().next() {
-        let tool = key.trim_end_matches("ToolCall").trim_end_matches("Tool_call").to_string();
+        let tool = key
+            .trim_end_matches("ToolCall")
+            .trim_end_matches("Tool_call")
+            .to_string();
         let args = val.get("args");
         let input = args
             .map(|a| serde_json::to_string_pretty(a).unwrap_or_default())
@@ -632,7 +819,8 @@ fn parse_cursor_tool_call(tc: &serde_json::Map<String, serde_json::Value>) -> (S
 /// Extract result text from a Cursor completed tool_call object.
 fn extract_cursor_tool_result(tc: &serde_json::Map<String, serde_json::Value>) -> String {
     if let Some((_key, val)) = tc.iter().next() {
-        val.get("result").and_then(|r| r.as_str())
+        val.get("result")
+            .and_then(|r| r.as_str())
             .or_else(|| val.get("output").and_then(|o| o.as_str()))
             .unwrap_or("")
             .to_string()
@@ -950,7 +1138,10 @@ pub async fn stream_and_capture(
     }
 
     flush_buffer(&app, &session_id, &mut buffer);
-    StreamResult { total_cost, error: last_error }
+    StreamResult {
+        total_cost,
+        error: last_error,
+    }
 }
 
 /// Check if a line is a `control_request` for tool approval.
@@ -981,20 +1172,39 @@ async fn handle_control_request(
     let v: serde_json::Value = serde_json::from_str(line).ok()?;
 
     if v.get("type").and_then(|t| t.as_str()) != Some("control_request") {
-        return Some(ControlRequestResult { handled: false, tool_start: None });
+        return Some(ControlRequestResult {
+            handled: false,
+            tool_start: None,
+        });
     }
 
     let request = v.get("request")?;
     if request.get("subtype").and_then(|s| s.as_str()) != Some("can_use_tool") {
-        return Some(ControlRequestResult { handled: false, tool_start: None });
+        return Some(ControlRequestResult {
+            handled: false,
+            tool_start: None,
+        });
     }
 
-    let cli_request_id = v.get("request_id").and_then(|r| r.as_str()).unwrap_or("").to_string();
-    let tool_name = request.get("tool_name").and_then(|t| t.as_str()).unwrap_or("unknown").to_string();
-    let tool_input = request.get("input").cloned().unwrap_or(serde_json::Value::Null);
+    let cli_request_id = v
+        .get("request_id")
+        .and_then(|r| r.as_str())
+        .unwrap_or("")
+        .to_string();
+    let tool_name = request
+        .get("tool_name")
+        .and_then(|t| t.as_str())
+        .unwrap_or("unknown")
+        .to_string();
+    let tool_input = request
+        .get("input")
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
 
     // Build a ToolStart item so the frontend knows which tool is running
-    let input_str = if tool_input.is_null() || (tool_input.is_object() && tool_input.as_object().map(|o| o.is_empty()).unwrap_or(true)) {
+    let input_str = if tool_input.is_null()
+        || (tool_input.is_object() && tool_input.as_object().map(|o| o.is_empty()).unwrap_or(true))
+    {
         String::new()
     } else {
         serde_json::to_string_pretty(&tool_input).unwrap_or_default()
@@ -1005,19 +1215,27 @@ async fn handle_control_request(
     };
 
     // Evaluate policy
-    let result = policy::evaluate(&tool_name, &tool_input, worktree_path, repo_path, trust_level);
+    let result = policy::evaluate(
+        &tool_name,
+        &tool_input,
+        worktree_path,
+        repo_path,
+        trust_level,
+    );
     let input_summary = policy::summarize_input(&tool_name, &tool_input);
 
     // Fire-and-forget audit log entry
-    let _ = db_tx.send(DbWrite::InsertAuditEntry {
-        session_id: session_id.to_string(),
-        task_id: task_id.to_string(),
-        tool_name: tool_name.clone(),
-        tool_input_summary: input_summary.clone(),
-        decision: result.decision.as_str().to_string(),
-        reason: result.reason.clone(),
-        created_at: crate::task::epoch_ms(),
-    }).await;
+    let _ = db_tx
+        .send(DbWrite::InsertAuditEntry {
+            session_id: session_id.to_string(),
+            task_id: task_id.to_string(),
+            tool_name: tool_name.clone(),
+            tool_input_summary: input_summary.clone(),
+            decision: result.decision.as_str().to_string(),
+            reason: result.reason.clone(),
+            created_at: crate::task::epoch_ms(),
+        })
+        .await;
 
     match result.decision {
         PolicyDecision::AutoAllow | PolicyDecision::AutoAllowLogged => {
@@ -1044,35 +1262,47 @@ async fn handle_control_request(
             }
 
             // Notify frontend (lightweight event for UI indicator)
-            let _ = app.emit("policy-auto-approved", PolicyAutoApprovedEvent {
-                session_id: session_id.to_string(),
-                tool_name,
-                tool_input_summary: input_summary,
-                decision: result.decision,
-                reason: result.reason,
-            });
+            let _ = app.emit(
+                "policy-auto-approved",
+                PolicyAutoApprovedEvent {
+                    session_id: session_id.to_string(),
+                    tool_name,
+                    tool_input_summary: input_summary,
+                    decision: result.decision,
+                    reason: result.reason,
+                },
+            );
 
-            Some(ControlRequestResult { handled: true, tool_start: Some(tool_start) })
+            Some(ControlRequestResult {
+                handled: true,
+                tool_start: Some(tool_start),
+            })
         }
         PolicyDecision::RequireApproval => {
             // Original behavior: emit to frontend, wait for user response
             let request_id = uuid::Uuid::new_v4().to_string();
 
-            let _ = app.emit("tool-approval-request", ToolApprovalEvent {
-                request_id: request_id.clone(),
-                session_id: session_id.to_string(),
-                tool_name: tool_name.clone(),
-                tool_input: tool_input.clone(),
-            });
+            let _ = app.emit(
+                "tool-approval-request",
+                ToolApprovalEvent {
+                    request_id: request_id.clone(),
+                    session_id: session_id.to_string(),
+                    tool_name: tool_name.clone(),
+                    tool_input: tool_input.clone(),
+                },
+            );
 
             let (tx, rx) = tokio::sync::oneshot::channel::<ApprovalResponse>();
             pending_approvals.insert(request_id.clone(), tx);
-            pending_meta.insert(request_id.clone(), PendingApprovalEntry {
-                request_id: request_id.clone(),
-                session_id: session_id.to_string(),
-                tool_name,
-                tool_input: tool_input.clone(),
-            });
+            pending_meta.insert(
+                request_id.clone(),
+                PendingApprovalEntry {
+                    request_id: request_id.clone(),
+                    session_id: session_id.to_string(),
+                    tool_name,
+                    tool_input: tool_input.clone(),
+                },
+            );
 
             let (behavior, updated_input) = match rx.await {
                 Ok(resp) => (resp.behavior, resp.updated_input),
@@ -1114,16 +1344,15 @@ async fn handle_control_request(
                 let _ = writer.flush().await;
             }
 
-            Some(ControlRequestResult { handled: true, tool_start: Some(tool_start) })
+            Some(ControlRequestResult {
+                handled: true,
+                tool_start: Some(tool_start),
+            })
         }
     }
 }
 
-fn emit_item(
-    app: &AppHandle,
-    session_id: &str,
-    item: OutputItem,
-) {
+fn emit_item(app: &AppHandle, session_id: &str, item: OutputItem) {
     let _ = app.emit(
         "session-output",
         SessionOutputEvent {
@@ -1133,11 +1362,7 @@ fn emit_item(
     );
 }
 
-fn flush_buffer(
-    app: &AppHandle,
-    session_id: &str,
-    buffer: &mut Vec<OutputItem>,
-) {
+fn flush_buffer(app: &AppHandle, session_id: &str, buffer: &mut Vec<OutputItem>) {
     if buffer.is_empty() {
         return;
     }
@@ -1152,12 +1377,7 @@ fn flush_buffer(
     );
 }
 
-fn persist_line(
-    db_tx: &DbWriteTx,
-    session_id: &str,
-    line: &str,
-    total_persisted: &mut usize,
-) {
+fn persist_line(db_tx: &DbWriteTx, session_id: &str, line: &str, total_persisted: &mut usize) {
     if *total_persisted >= MAX_PERSISTED_LINES {
         return;
     }
@@ -1257,7 +1477,10 @@ mod tests {
     fn parse_system_init_is_silent() {
         let line = r#"{"type":"system","subtype":"init","session_id":"abc","model":"claude-sonnet-4-6","tools":[]}"#;
         let items = parse_sdk_event(line);
-        assert!(items.is_empty(), "System messages should be silently consumed");
+        assert!(
+            items.is_empty(),
+            "System messages should be silently consumed"
+        );
     }
 
     #[test]
@@ -1266,7 +1489,14 @@ mod tests {
         let items = parse_sdk_event(line);
         assert_eq!(items.len(), 1);
         match &items[0] {
-            OutputItem::TurnEnd { status, cost, input_tokens, output_tokens, error, .. } => {
+            OutputItem::TurnEnd {
+                status,
+                cost,
+                input_tokens,
+                output_tokens,
+                error,
+                ..
+            } => {
                 assert_eq!(status, "completed");
                 assert_eq!(*cost, Some(0.042));
                 assert_eq!(*input_tokens, Some(100));
@@ -1283,7 +1513,12 @@ mod tests {
         let items = parse_sdk_event(line);
         assert_eq!(items.len(), 1);
         match &items[0] {
-            OutputItem::TurnEnd { cost, input_tokens, output_tokens, .. } => {
+            OutputItem::TurnEnd {
+                cost,
+                input_tokens,
+                output_tokens,
+                ..
+            } => {
                 assert_eq!(*cost, None);
                 assert_eq!(*input_tokens, None);
                 assert_eq!(*output_tokens, None);
@@ -1348,7 +1583,9 @@ mod tests {
 
     #[test]
     fn output_item_text_serializes() {
-        let item = OutputItem::Text { text: "hello".into() };
+        let item = OutputItem::Text {
+            text: "hello".into(),
+        };
         let json = serde_json::to_value(&item).unwrap();
         assert_eq!(json["kind"], "text");
         assert_eq!(json["text"], "hello");
@@ -1364,7 +1601,10 @@ mod tests {
 
     #[test]
     fn output_item_tool_start_serializes() {
-        let item = OutputItem::ToolStart { tool: "Bash".into(), input: "ls".into() };
+        let item = OutputItem::ToolStart {
+            tool: "Bash".into(),
+            input: "ls".into(),
+        };
         let json = serde_json::to_value(&item).unwrap();
         assert_eq!(json["kind"], "toolStart");
         assert_eq!(json["tool"], "Bash");

--- a/src-tauri/src/task.rs
+++ b/src-tauri/src/task.rs
@@ -17,16 +17,36 @@ use uuid::Uuid;
 // ---------------------------------------------------------------------------
 
 const ADJECTIVES: &[&str] = &[
-    "sleepy", "bouncy", "fuzzy", "sneaky", "grumpy", "silly", "wobbly", "zappy",
-    "cranky", "spooky", "fluffy", "dizzy", "rusty", "jazzy", "lucky", "witty",
-    "peppy", "quirky", "zippy", "snappy", "wacky", "goofy", "funky", "jumpy",
+    "sleepy", "bouncy", "fuzzy", "sneaky", "grumpy", "silly", "wobbly", "zappy", "cranky",
+    "spooky", "fluffy", "dizzy", "rusty", "jazzy", "lucky", "witty", "peppy", "quirky", "zippy",
+    "snappy", "wacky", "goofy", "funky", "jumpy",
 ];
 
 const ANIMALS: &[&str] = &[
-    "penguin", "capybara", "otter", "raccoon", "platypus", "axolotl", "quokka",
-    "narwhal", "armadillo", "chinchilla", "flamingo", "lemur", "pangolin", "wombat",
-    "gecko", "puffin", "sloth", "toucan", "hedgehog", "chameleon", "koala", "walrus",
-    "dingo", "ferret",
+    "penguin",
+    "capybara",
+    "otter",
+    "raccoon",
+    "platypus",
+    "axolotl",
+    "quokka",
+    "narwhal",
+    "armadillo",
+    "chinchilla",
+    "flamingo",
+    "lemur",
+    "pangolin",
+    "wombat",
+    "gecko",
+    "puffin",
+    "sloth",
+    "toucan",
+    "hedgehog",
+    "chameleon",
+    "koala",
+    "walrus",
+    "dingo",
+    "ferret",
 ];
 
 pub fn funny_branch_name() -> String {
@@ -208,7 +228,10 @@ pub fn spawn_hook_pty(
         let (status, error) = match exit_code {
             Some(0) => ("completed".to_string(), None),
             Some(code) => {
-                eprintln!("[verun] {} hook failed with exit code {code}", bg_hook_type.as_str());
+                eprintln!(
+                    "[verun] {} hook failed with exit code {code}",
+                    bg_hook_type.as_str()
+                );
                 ("failed".to_string(), Some(format!("Exit code: {code}")))
             }
             None => {
@@ -341,7 +364,15 @@ pub async fn create_task(
     setup_in_progress: &SetupInProgress,
     params: CreateTaskParams,
 ) -> Result<(Task, Session), String> {
-    let CreateTaskParams { project_id, repo_path, base_branch, setup_hook, port_offset, from_task_window, agent_type } = params;
+    let CreateTaskParams {
+        project_id,
+        repo_path,
+        base_branch,
+        setup_hook,
+        port_offset,
+        from_task_window,
+        agent_type,
+    } = params;
     let id = Uuid::new_v4().to_string();
     let branch = funny_branch_name();
     let now = epoch_ms();
@@ -351,9 +382,7 @@ pub async fn create_task(
         let rp = repo_path.clone();
         let br = branch.clone();
         let bb = base_branch;
-        tokio::task::spawn_blocking(move || {
-            worktree::create_worktree(&rp, &br, &bb)
-        })
+        tokio::task::spawn_blocking(move || worktree::create_worktree(&rp, &br, &bb))
             .await
             .map_err(|e| format!("Join error: {e}"))?
     }?;
@@ -398,7 +427,17 @@ pub async fn create_task(
     }
 
     // Phase 2: Run setup hook in background (if non-empty)
-    spawn_setup_hook(app, pty_map, hook_pty_map, setup_in_progress, &task.id, &worktree_path, &setup_hook, port_offset, &repo_path);
+    spawn_setup_hook(
+        app,
+        pty_map,
+        hook_pty_map,
+        setup_in_progress,
+        &task.id,
+        &worktree_path,
+        &setup_hook,
+        port_offset,
+        &repo_path,
+    );
 
     Ok((task, session))
 }
@@ -437,7 +476,11 @@ pub async fn delete_task(
 
     let rp = repo_path.to_string();
     let wtp = task.worktree_path.clone();
-    let hook = if skip_destroy_hook { String::new() } else { destroy_hook.to_string() };
+    let hook = if skip_destroy_hook {
+        String::new()
+    } else {
+        destroy_hook.to_string()
+    };
     let branch = task.branch.clone();
     let env_vars = worktree::verun_env_vars(task.port_offset, repo_path);
     let _ = tokio::task::spawn_blocking(move || -> Result<(), String> {
@@ -453,10 +496,13 @@ pub async fn delete_task(
             }
         }
         Ok(())
-    }).await;
+    })
+    .await;
 
     db_tx
-        .send(db::DbWrite::DeleteTask { id: task.id.clone() })
+        .send(db::DbWrite::DeleteTask {
+            id: task.id.clone(),
+        })
         .await
         .map_err(|e| format!("DB write failed: {e}"))?;
 
@@ -501,7 +547,11 @@ pub async fn archive_task(
     // Run destroy hook (unless skipped) and capture last commit message
     let rp = repo_path.to_string();
     let branch = task.branch.clone();
-    let hook = if skip_destroy_hook { String::new() } else { destroy_hook.to_string() };
+    let hook = if skip_destroy_hook {
+        String::new()
+    } else {
+        destroy_hook.to_string()
+    };
     let wtp = task.worktree_path.clone();
     let env_vars = worktree::verun_env_vars(task.port_offset, repo_path);
     let last_commit_message = tokio::task::spawn_blocking(move || {
@@ -542,7 +592,12 @@ pub async fn archive_task(
 // ---------------------------------------------------------------------------
 
 /// Create a new session record (no process spawned yet — that happens on send_message)
-pub async fn create_session(db_tx: &DbWriteTx, task_id: String, agent_type: String, model: Option<String>) -> Result<Session, String> {
+pub async fn create_session(
+    db_tx: &DbWriteTx,
+    task_id: String,
+    agent_type: String,
+    model: Option<String>,
+) -> Result<Session, String> {
     let session = Session {
         id: Uuid::new_v4().to_string(),
         task_id,
@@ -605,7 +660,24 @@ pub async fn send_message(
     pending_approval_meta: PendingApprovalMeta,
     params: SendMessageParams,
 ) -> Result<(), String> {
-    let SendMessageParams { session_id, task_id, project_id, worktree_path, repo_path, port_offset, trust_level, message, resume_session_id, attachments, model, plan_mode, thinking_mode, fast_mode, task_name, agent_type } = params;
+    let SendMessageParams {
+        session_id,
+        task_id,
+        project_id,
+        worktree_path,
+        repo_path,
+        port_offset,
+        trust_level,
+        message,
+        resume_session_id,
+        attachments,
+        model,
+        plan_mode,
+        thinking_mode,
+        fast_mode,
+        task_name,
+        agent_type,
+    } = params;
     let agent = AgentKind::parse(&agent_type).implementation();
     // Don't allow concurrent messages on the same session
     if active.contains_key(&session_id) {
@@ -671,7 +743,8 @@ pub async fn send_message(
         "plan_mode": plan_mode,
         "thinking_mode": thinking_mode,
         "fast_mode": fast_mode,
-    }).to_string();
+    })
+    .to_string();
     let _ = db_tx
         .send(db::DbWrite::InsertOutputLines {
             session_id: session_id.clone(),
@@ -690,9 +763,18 @@ pub async fn send_message(
     };
 
     let args_list = agent.build_session_args(&session_args);
-    eprintln!("[verun][{}] spawn: {} {}", agent.display_name(), agent.cli_binary(), args_list.join(" "));
+    eprintln!(
+        "[verun][{}] spawn: {} {}",
+        agent.display_name(),
+        agent.cli_binary(),
+        args_list.join(" ")
+    );
     eprintln!("[verun][{}] cwd: {}", agent.display_name(), worktree_path);
-    eprintln!("[verun][{}] input_mode: {:?}", agent.display_name(), agent.input_mode());
+    eprintln!(
+        "[verun][{}] input_mode: {:?}",
+        agent.display_name(),
+        agent.input_mode()
+    );
 
     let mut cmd = tokio::process::Command::new(agent.cli_binary());
     cmd.args(&args_list);
@@ -708,12 +790,18 @@ pub async fn send_message(
         .spawn()
         .map_err(|e| format!("Failed to spawn {}: {e}", agent.display_name()))?;
 
-    eprintln!("[verun][{}] spawned pid={:?}", agent.display_name(), child.id());
+    eprintln!(
+        "[verun][{}] spawned pid={:?}",
+        agent.display_name(),
+        child.id()
+    );
 
     let stdin = match agent.input_mode() {
         crate::agent::InputMode::StreamJsonStdin => {
             // Claude: send the message as a stream-json payload on stdin, keep open for control_response
-            let mut stdin_handle = child.stdin.take()
+            let mut stdin_handle = child
+                .stdin
+                .take()
                 .ok_or_else(|| "Failed to capture stdin".to_string())?;
 
             let mut content_blocks = Vec::new();
@@ -742,9 +830,13 @@ pub async fn send_message(
                 .map_err(|e| format!("Failed to serialize message: {e}"))?;
             payload.push('\n');
 
-            stdin_handle.write_all(payload.as_bytes()).await
+            stdin_handle
+                .write_all(payload.as_bytes())
+                .await
                 .map_err(|e| format!("Failed to write to stdin: {e}"))?;
-            stdin_handle.flush().await
+            stdin_handle
+                .flush()
+                .await
                 .map_err(|e| format!("Failed to flush stdin: {e}"))?;
 
             // Keep stdin open — needed for control_response messages
@@ -799,7 +891,13 @@ pub async fn send_message(
     );
 
     // Track the active process
-    active.insert(session_id.clone(), ActiveProcess { child, stdin: stdin.clone() });
+    active.insert(
+        session_id.clone(),
+        ActiveProcess {
+            child,
+            stdin: stdin.clone(),
+        },
+    );
 
     // Spawn monitor: stream output, detect exit, update DB
     let monitor_app = app.clone();
@@ -858,7 +956,8 @@ pub async fn send_message(
         let config_path = format!("{wt_for_hooks}/.verun.json");
         if let Some((setup, destroy, start)) = parse_verun_config_file(&config_path) {
             // Look up existing auto_start so auto-detect doesn't reset it
-            let auto_start = if let Some(pool) = monitor_app.try_state::<sqlx::sqlite::SqlitePool>() {
+            let auto_start = if let Some(pool) = monitor_app.try_state::<sqlx::sqlite::SqlitePool>()
+            {
                 db::get_project(pool.inner(), &monitor_pid)
                     .await
                     .ok()
@@ -877,12 +976,15 @@ pub async fn send_message(
                     auto_start,
                 })
                 .await;
-            let _ = monitor_app.emit("project-hooks-updated", serde_json::json!({
-                "projectId": monitor_pid,
-                "setupHook": setup,
-                "destroyHook": destroy,
-                "startCommand": start,
-            }));
+            let _ = monitor_app.emit(
+                "project-hooks-updated",
+                serde_json::json!({
+                    "projectId": monitor_pid,
+                    "setupHook": setup,
+                    "destroyHook": destroy,
+                    "startCommand": start,
+                }),
+            );
         }
 
         // Update session status
@@ -903,7 +1005,9 @@ pub async fn send_message(
         }
 
         let error_msg = if final_status == "error" {
-            stream_result.error.or_else(|| Some("Session exited unexpectedly".to_string()))
+            stream_result
+                .error
+                .or_else(|| Some("Session exited unexpectedly".to_string()))
         } else {
             None
         };
@@ -967,10 +1071,13 @@ async fn generate_session_title(first_message: &str, worktree_path: &str) -> Opt
     );
     let output = tokio::process::Command::new(AgentKind::Claude.implementation().cli_binary())
         .args([
-            "-p", &prompt,
-            "--output-format", "text",
+            "-p",
+            &prompt,
+            "--output-format",
+            "text",
             "--no-session-persistence",
-            "--model", "haiku",
+            "--model",
+            "haiku",
         ])
         .current_dir(worktree_path)
         .output()
@@ -1345,11 +1452,8 @@ pub async fn fork_session_to_new_task(
                     Ok(Some(temp_sha)) => {
                         let new_pb = std::path::PathBuf::from(&new_path);
                         let tree_ref = format!("{temp_sha}^{{tree}}");
-                        run_git_ignoring_env(
-                            &new_pb,
-                            &["read-tree", "--reset", "-u", &tree_ref],
-                        )
-                        .map_err(|e| format!("git read-tree on new worktree: {e}"))?;
+                        run_git_ignoring_env(&new_pb, &["read-tree", "--reset", "-u", &tree_ref])
+                            .map_err(|e| format!("git read-tree on new worktree: {e}"))?;
                     }
                     Ok(None) => {
                         // Parent worktree has no HEAD — nothing to overlay.
@@ -1498,8 +1602,15 @@ mod tests {
     fn funny_branch_name_format() {
         let name = funny_branch_name();
         let parts: Vec<&str> = name.split('-').collect();
-        assert_eq!(parts.len(), 3, "Expected adjective-animal-number, got: {name}");
-        assert!(parts[2].parse::<u64>().is_ok(), "Third part should be a number");
+        assert_eq!(
+            parts.len(),
+            3,
+            "Expected adjective-animal-number, got: {name}"
+        );
+        assert!(
+            parts[2].parse::<u64>().is_ok(),
+            "Third part should be a number"
+        );
     }
 
     #[test]
@@ -1528,5 +1639,4 @@ mod tests {
         assert!(ADJECTIVES.len() >= 20);
         assert!(ANIMALS.len() >= 20);
     }
-
 }

--- a/src-tauri/src/tsgo_check.rs
+++ b/src-tauri/src/tsgo_check.rs
@@ -154,11 +154,7 @@ fn walk(base: &Path, dir: &Path, out: &mut Vec<PathBuf>) {
 /// Spawn one `tsgo --noEmit --pretty false -p <tsconfig>` invocation and
 /// parse its stdout. Failures produce an empty vec — a single project's
 /// failure shouldn't tank the whole aggregated check.
-async fn run_single(
-    binary: &Path,
-    worktree: &Path,
-    tsconfig_rel: &Path,
-) -> Vec<TsgoProblem> {
+async fn run_single(binary: &Path, worktree: &Path, tsconfig_rel: &Path) -> Vec<TsgoProblem> {
     let mut child = match Command::new(binary)
         .arg("--noEmit")
         .arg("--pretty")
@@ -325,13 +321,19 @@ mod tests {
 
     #[test]
     fn parses_simple_error() {
-        let p = parse_tsc_line("src/foo.ts(10,5): error TS2322: Type 'string' is not assignable to type 'number'.").unwrap();
+        let p = parse_tsc_line(
+            "src/foo.ts(10,5): error TS2322: Type 'string' is not assignable to type 'number'.",
+        )
+        .unwrap();
         assert_eq!(p.file, "src/foo.ts");
         assert_eq!(p.line, 10);
         assert_eq!(p.column, 5);
         assert_eq!(p.severity, "error");
         assert_eq!(p.code, "TS2322");
-        assert_eq!(p.message, "Type 'string' is not assignable to type 'number'.");
+        assert_eq!(
+            p.message,
+            "Type 'string' is not assignable to type 'number'."
+        );
     }
 
     #[test]

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -5,7 +5,8 @@ use std::sync::Arc;
 use std::time::Duration;
 use tauri::{AppHandle, Emitter};
 
-pub type FileWatcherMap = Arc<DashMap<String, notify_debouncer_mini::Debouncer<notify::RecommendedWatcher>>>;
+pub type FileWatcherMap =
+    Arc<DashMap<String, notify_debouncer_mini::Debouncer<notify::RecommendedWatcher>>>;
 
 pub fn new_file_watcher_map() -> FileWatcherMap {
     Arc::new(DashMap::new())
@@ -32,30 +33,36 @@ pub fn start_watching(
     let tid = task_id.clone();
     let wt_path = worktree_path.clone();
 
-    let mut debouncer = new_debouncer(Duration::from_millis(500), move |events: Result<Vec<notify_debouncer_mini::DebouncedEvent>, notify::Error>| {
-        if let Ok(events) = events {
-            // Collect unique parent directories that changed
-            let mut dirs = std::collections::HashSet::new();
-            for event in &events {
-                if event.kind == DebouncedEventKind::Any {
-                    if let Some(parent) = event.path.parent() {
-                        let rel = parent
-                            .strip_prefix(&wt_path)
-                            .unwrap_or(parent)
-                            .to_string_lossy()
-                            .to_string();
-                        dirs.insert(rel);
+    let mut debouncer = new_debouncer(
+        Duration::from_millis(500),
+        move |events: Result<Vec<notify_debouncer_mini::DebouncedEvent>, notify::Error>| {
+            if let Ok(events) = events {
+                // Collect unique parent directories that changed
+                let mut dirs = std::collections::HashSet::new();
+                for event in &events {
+                    if event.kind == DebouncedEventKind::Any {
+                        if let Some(parent) = event.path.parent() {
+                            let rel = parent
+                                .strip_prefix(&wt_path)
+                                .unwrap_or(parent)
+                                .to_string_lossy()
+                                .to_string();
+                            dirs.insert(rel);
+                        }
                     }
                 }
+                for dir in dirs {
+                    let _ = app.emit(
+                        "file-tree-changed",
+                        FileTreeChangedEvent {
+                            task_id: tid.clone(),
+                            path: dir,
+                        },
+                    );
+                }
             }
-            for dir in dirs {
-                let _ = app.emit("file-tree-changed", FileTreeChangedEvent {
-                    task_id: tid.clone(),
-                    path: dir,
-                });
-            }
-        }
-    })
+        },
+    )
     .map_err(|e| format!("Failed to create file watcher: {e}"))?;
 
     let path = std::path::Path::new(&worktree_path);

--- a/src-tauri/src/worktree.rs
+++ b/src-tauri/src/worktree.rs
@@ -70,7 +70,10 @@ pub fn detect_base_branch(repo_path: &str) -> String {
     }
 
     // Fallback: current HEAD branch name
-    if let Ok(output) = git(repo_path).args(["rev-parse", "--abbrev-ref", "HEAD"]).output() {
+    if let Ok(output) = git(repo_path)
+        .args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .output()
+    {
         if output.status.success() {
             let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
             if !branch.is_empty() && branch != "HEAD" {
@@ -95,7 +98,9 @@ pub fn create_worktree(repo_path: &str, branch: &str, base_branch: &str) -> Resu
     let worktree_path = format!("{}/.verun/worktrees/{}", repo_path, branch);
 
     // Best-effort fetch from origin
-    let _ = git(repo_path).args(["fetch", "origin", base_branch]).output();
+    let _ = git(repo_path)
+        .args(["fetch", "origin", base_branch])
+        .output();
 
     // Create the branch from the base branch.
     // Try origin/{base_branch} first, then local {base_branch}, then fall back to HEAD.
@@ -160,7 +165,8 @@ pub fn run_hook(cwd: &str, command: &str, env_vars: &[(String, String)]) -> Resu
         cmd.env(k, v);
     }
 
-    let output = cmd.output()
+    let output = cmd
+        .output()
         .map_err(|e| format!("Failed to run hook: {e}"))?;
 
     if !output.status.success() {
@@ -256,7 +262,11 @@ pub fn get_diff(worktree_path: &str) -> Result<String, String> {
 }
 
 /// Merge a worktree branch into target, then clean up the worktree.
-pub fn merge_branch(repo_path: &str, source_branch: &str, target_branch: &str) -> Result<(), String> {
+pub fn merge_branch(
+    repo_path: &str,
+    source_branch: &str,
+    target_branch: &str,
+) -> Result<(), String> {
     let output = git(repo_path)
         .args(["checkout", target_branch])
         .output()
@@ -343,7 +353,12 @@ fn ref_exists(worktree_path: &str, refname: &str) -> bool {
 /// Returns (left_count, right_count) from `git rev-list --left-right --count left...right`
 fn rev_list_left_right(worktree_path: &str, left: &str, right: &str) -> (u32, u32) {
     let output = git(worktree_path)
-        .args(["rev-list", "--left-right", "--count", &format!("{left}...{right}")])
+        .args([
+            "rev-list",
+            "--left-right",
+            "--count",
+            &format!("{left}...{right}"),
+        ])
         .output();
 
     let output = match output {
@@ -357,10 +372,7 @@ fn rev_list_left_right(worktree_path: &str, left: &str, right: &str) -> (u32, u3
         return (0, 0);
     }
 
-    (
-        parts[0].parse().unwrap_or(0),
-        parts[1].parse().unwrap_or(0),
-    )
+    (parts[0].parse().unwrap_or(0), parts[1].parse().unwrap_or(0))
 }
 
 /// Find the base branch (main/master) to compare ahead count against.
@@ -385,13 +397,28 @@ mod tests {
         let repo_path = dir.path().join("repo");
         fs::create_dir(&repo_path).unwrap();
 
-        git(repo_path.to_str().unwrap()).args(["init"]).output().unwrap();
-        git(repo_path.to_str().unwrap()).args(["config", "user.email", "test@test.com"]).output().unwrap();
-        git(repo_path.to_str().unwrap()).args(["config", "user.name", "Test"]).output().unwrap();
+        git(repo_path.to_str().unwrap())
+            .args(["init"])
+            .output()
+            .unwrap();
+        git(repo_path.to_str().unwrap())
+            .args(["config", "user.email", "test@test.com"])
+            .output()
+            .unwrap();
+        git(repo_path.to_str().unwrap())
+            .args(["config", "user.name", "Test"])
+            .output()
+            .unwrap();
 
         fs::write(repo_path.join("README.md"), "# test").unwrap();
-        git(repo_path.to_str().unwrap()).args(["add", "."]).output().unwrap();
-        git(repo_path.to_str().unwrap()).args(["commit", "-m", "init"]).output().unwrap();
+        git(repo_path.to_str().unwrap())
+            .args(["add", "."])
+            .output()
+            .unwrap();
+        git(repo_path.to_str().unwrap())
+            .args(["commit", "-m", "init"])
+            .output()
+            .unwrap();
 
         let path_str = repo_path.to_str().unwrap().to_string();
         (dir, path_str)
@@ -443,7 +470,9 @@ mod tests {
 
         let worktrees = list_worktrees(&repo_path).unwrap();
         assert!(worktrees.len() >= 2);
-        assert!(worktrees.iter().any(|p| p.contains("test-branch") || p == &wt_path));
+        assert!(worktrees
+            .iter()
+            .any(|p| p.contains("test-branch") || p == &wt_path));
     }
 
     #[test]
@@ -515,13 +544,19 @@ mod tests {
     fn merge_branch_cleans_up_worktree() {
         let (_dir, repo_path) = init_test_repo();
 
-        let output = git(&repo_path).args(["branch", "--show-current"]).output().unwrap();
+        let output = git(&repo_path)
+            .args(["branch", "--show-current"])
+            .output()
+            .unwrap();
         let main_branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
 
         let wt_path = create_worktree(&repo_path, "merge-cleanup", "main").unwrap();
         fs::write(format!("{wt_path}/feature.txt"), "feature").unwrap();
         git(&wt_path).args(["add", "."]).output().unwrap();
-        git(&wt_path).args(["commit", "-m", "add feature"]).output().unwrap();
+        git(&wt_path)
+            .args(["commit", "-m", "add feature"])
+            .output()
+            .unwrap();
 
         let result = merge_branch(&repo_path, "merge-cleanup", &main_branch);
         assert!(result.is_ok(), "merge failed: {:?}", result.err());
@@ -552,7 +587,10 @@ mod tests {
 
         fs::write(format!("{wt_path}/new.txt"), "new").unwrap();
         git(&wt_path).args(["add", "."]).output().unwrap();
-        git(&wt_path).args(["commit", "-m", "ahead"]).output().unwrap();
+        git(&wt_path)
+            .args(["commit", "-m", "ahead"])
+            .output()
+            .unwrap();
 
         let (ahead, behind, _unpushed) = get_branch_status(&wt_path).unwrap();
         assert_eq!(ahead, 1);
@@ -568,7 +606,10 @@ mod tests {
         // Make a commit on main
         fs::write(format!("{repo_path}/main-change.txt"), "main").unwrap();
         git(&repo_path).args(["add", "."]).output().unwrap();
-        git(&repo_path).args(["commit", "-m", "main change"]).output().unwrap();
+        git(&repo_path)
+            .args(["commit", "-m", "main change"])
+            .output()
+            .unwrap();
 
         let (ahead, behind, _unpushed) = get_branch_status(&wt_path).unwrap();
         assert_eq!(behind, 1, "should be 1 behind main");
@@ -582,25 +623,41 @@ mod tests {
         // Create bare remote
         let bare_path = dir.path().join("remote.git");
         fs::create_dir(&bare_path).unwrap();
-        git(bare_path.to_str().unwrap()).args(["init", "--bare"]).output().unwrap();
+        git(bare_path.to_str().unwrap())
+            .args(["init", "--bare"])
+            .output()
+            .unwrap();
 
         // Clone it
         let clone_path = dir.path().join("clone");
         std::process::Command::new("git")
             .current_dir(dir.path())
-            .args(["clone", bare_path.to_str().unwrap(), clone_path.to_str().unwrap()])
+            .args([
+                "clone",
+                bare_path.to_str().unwrap(),
+                clone_path.to_str().unwrap(),
+            ])
             .output()
             .unwrap();
 
         let cp = clone_path.to_str().unwrap();
-        git(cp).args(["config", "user.email", "test@test.com"]).output().unwrap();
-        git(cp).args(["config", "user.name", "Test"]).output().unwrap();
+        git(cp)
+            .args(["config", "user.email", "test@test.com"])
+            .output()
+            .unwrap();
+        git(cp)
+            .args(["config", "user.name", "Test"])
+            .output()
+            .unwrap();
 
         // Initial commit + push
         fs::write(clone_path.join("README.md"), "# test").unwrap();
         git(cp).args(["add", "."]).output().unwrap();
         git(cp).args(["commit", "-m", "init"]).output().unwrap();
-        git(cp).args(["push", "-u", "origin", "main"]).output().unwrap();
+        git(cp)
+            .args(["push", "-u", "origin", "main"])
+            .output()
+            .unwrap();
 
         let bp = bare_path.to_str().unwrap().to_string();
         (dir, cp.to_string(), bp)
@@ -611,10 +668,16 @@ mod tests {
         let (_dir, clone_path, bare_path) = init_test_repo_with_remote();
 
         // Create a feature branch
-        git(&clone_path).args(["checkout", "-b", "feature"]).output().unwrap();
+        git(&clone_path)
+            .args(["checkout", "-b", "feature"])
+            .output()
+            .unwrap();
         fs::write(format!("{clone_path}/feature.txt"), "feat").unwrap();
         git(&clone_path).args(["add", "."]).output().unwrap();
-        git(&clone_path).args(["commit", "-m", "feature commit"]).output().unwrap();
+        git(&clone_path)
+            .args(["commit", "-m", "feature commit"])
+            .output()
+            .unwrap();
 
         // Simulate someone else pushing to origin/main
         let other_clone = _dir.path().join("other");
@@ -624,11 +687,20 @@ mod tests {
             .output()
             .unwrap();
         let oc = other_clone.to_str().unwrap();
-        git(oc).args(["config", "user.email", "other@test.com"]).output().unwrap();
-        git(oc).args(["config", "user.name", "Other"]).output().unwrap();
+        git(oc)
+            .args(["config", "user.email", "other@test.com"])
+            .output()
+            .unwrap();
+        git(oc)
+            .args(["config", "user.name", "Other"])
+            .output()
+            .unwrap();
         fs::write(format!("{oc}/other.txt"), "other").unwrap();
         git(oc).args(["add", "."]).output().unwrap();
-        git(oc).args(["commit", "-m", "main advance"]).output().unwrap();
+        git(oc)
+            .args(["commit", "-m", "main advance"])
+            .output()
+            .unwrap();
         git(oc).args(["push"]).output().unwrap();
 
         // Fetch in original clone so it sees the new origin/main
@@ -644,10 +716,16 @@ mod tests {
         let (_dir, clone_path, _bare_path) = init_test_repo_with_remote();
 
         // Create a branch — main hasn't changed so behind should be 0
-        git(&clone_path).args(["checkout", "-b", "up-to-date"]).output().unwrap();
+        git(&clone_path)
+            .args(["checkout", "-b", "up-to-date"])
+            .output()
+            .unwrap();
         fs::write(format!("{clone_path}/file.txt"), "content").unwrap();
         git(&clone_path).args(["add", "."]).output().unwrap();
-        git(&clone_path).args(["commit", "-m", "commit"]).output().unwrap();
+        git(&clone_path)
+            .args(["commit", "-m", "commit"])
+            .output()
+            .unwrap();
 
         let (ahead, behind, _unpushed) = get_branch_status(&clone_path).unwrap();
         assert_eq!(ahead, 1, "should be 1 ahead of origin/main");
@@ -693,7 +771,12 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let cwd = dir.path().to_str().unwrap();
         let vars = verun_env_vars(0, "/tmp/repo");
-        run_hook(cwd, "echo $VERUN_PORT_0 $VERUN_REPO_PATH > env-test.txt", &vars).unwrap();
+        run_hook(
+            cwd,
+            "echo $VERUN_PORT_0 $VERUN_REPO_PATH > env-test.txt",
+            &vars,
+        )
+        .unwrap();
         let content = fs::read_to_string(dir.path().join("env-test.txt")).unwrap();
         assert!(content.contains("10000"));
         assert!(content.contains("/tmp/repo"));

--- a/src/components/QuickOpen.tsx
+++ b/src/components/QuickOpen.tsx
@@ -1,4 +1,4 @@
-import { Component, Show, For, createSignal, createEffect, on } from 'solid-js'
+import { Component, Show, For, createSignal, createEffect, on, onCleanup } from 'solid-js'
 import { createVirtualizer } from '@tanstack/solid-virtual'
 import { Search, X } from 'lucide-solid'
 import { getFileIcon } from '../lib/fileIcons'
@@ -84,6 +84,12 @@ export const QuickOpen: Component = () => {
   let inputRef: HTMLInputElement | undefined
   let scrollRef: HTMLDivElement | undefined
 
+  const focusInput = () => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => inputRef?.focus())
+    })
+  }
+
   // Load files when overlay opens
   createEffect(on(showQuickOpen, (open) => {
     if (!open) return
@@ -91,15 +97,30 @@ export const QuickOpen: Component = () => {
     setSelectedIndex(0)
 
     // Focus input after DOM renders (double-rAF for Solid's Show)
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => inputRef?.focus())
-    })
+    focusInput()
 
     // Load file list async
     const taskId = selectedTaskId()
     if (!taskId) return
     ipc.listWorktreeFiles(taskId).then(setFiles).catch(() => setFiles([]))
   }))
+
+  createEffect(() => {
+    if (!showQuickOpen()) return
+
+    const refocusIfNeeded = () => {
+      if (!showQuickOpen()) return
+      if (document.visibilityState !== 'visible') return
+      focusInput()
+    }
+
+    window.addEventListener('focus', refocusIfNeeded)
+    document.addEventListener('visibilitychange', refocusIfNeeded)
+    onCleanup(() => {
+      window.removeEventListener('focus', refocusIfNeeded)
+      document.removeEventListener('visibilitychange', refocusIfNeeded)
+    })
+  })
 
   // Filtered results
   type QuickOpenResult = {

--- a/src/components/QuickOpen.tsx
+++ b/src/components/QuickOpen.tsx
@@ -1,10 +1,12 @@
 import { Component, Show, For, createSignal, createEffect, on } from 'solid-js'
 import { createVirtualizer } from '@tanstack/solid-virtual'
-import { Search } from 'lucide-solid'
+import { Search, X } from 'lucide-solid'
 import { getFileIcon } from '../lib/fileIcons'
 import { openFilePinned, revealFileInTree } from '../store/editorView'
 import { showQuickOpen, setShowQuickOpen } from '../store/ui'
 import { selectedTaskId } from '../store/ui'
+import { removeRecentFile, recentFilesForTask } from '../store/recentFiles'
+import { taskById } from '../store/tasks'
 import * as ipc from '../lib/ipc'
 
 // ── Fuzzy match scoring ────────────────────────────────────────────────
@@ -76,6 +78,7 @@ function fuzzyMatch(query: string, path: string): number | null {
 export const QuickOpen: Component = () => {
   const [query, setQuery] = createSignal('')
   const [files, setFiles] = createSignal<string[]>([])
+  const [recentVersion, setRecentVersion] = createSignal(0)
   const [selectedIndex, setSelectedIndex] = createSignal(0)
 
   let inputRef: HTMLInputElement | undefined
@@ -99,16 +102,52 @@ export const QuickOpen: Component = () => {
   }))
 
   // Filtered results
+  type QuickOpenResult = {
+    path: string
+    isRecent: boolean
+  }
+
   const filtered = () => {
     const q = query()
-    if (!q) return files().slice(0, 500) // Show all (capped) when no query
-    const scored: Array<{ path: string; score: number }> = []
-    for (const path of files()) {
+    recentVersion()
+
+    const recent = recentFilesForTask(selectedTaskId())
+    const recentSet = new Set(recent)
+
+    if (!q) {
+      const results: QuickOpenResult[] = recent.map(path => ({
+        path,
+        isRecent: true,
+      }))
+
+      for (const path of files()) {
+        if (recentSet.has(path)) continue
+        results.push({ path, isRecent: false })
+      }
+
+      return results.slice(0, 500)
+    }
+
+    const scored: Array<QuickOpenResult & { score: number }> = []
+    for (const path of recent) {
       const score = fuzzyMatch(q, path)
-      if (score !== null) scored.push({ path, score })
+      if (score !== null) {
+        scored.push({
+          path,
+          isRecent: true,
+          score: score + 1000 - scored.length,
+        })
+      }
+    }
+    for (const path of files()) {
+      if (recentSet.has(path)) continue
+      const score = fuzzyMatch(q, path)
+      if (score !== null) {
+        scored.push({ path, isRecent: false, score })
+      }
     }
     scored.sort((a, b) => b.score - a.score)
-    return scored.slice(0, 200).map(s => s.path)
+    return scored.slice(0, 200).map(({ score: _score, ...result }) => result)
   }
 
   // Reset selection when query changes
@@ -118,7 +157,7 @@ export const QuickOpen: Component = () => {
 
   const openSelected = () => {
     const results = filtered()
-    const path = results[selectedIndex()]
+    const path = results[selectedIndex()]?.path
     if (!path) return
     const name = path.split('/').pop() || path
     const taskId = selectedTaskId()
@@ -150,6 +189,16 @@ export const QuickOpen: Component = () => {
     if ((e.target as HTMLElement).classList.contains('quick-open-backdrop')) {
       close()
     }
+  }
+
+  const handleRemoveRecent = (path: string, e: MouseEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    const task = taskById(selectedTaskId() ?? '')
+    if (!task) return
+    removeRecentFile(task.projectId, path)
+    setRecentVersion(v => v + 1)
+    setSelectedIndex(i => Math.max(0, Math.min(i, filtered().length - 1)))
   }
 
   // Virtualizer for results
@@ -211,8 +260,9 @@ export const QuickOpen: Component = () => {
               >
                 <For each={virtualizer.getVirtualItems()}>
                   {(virtualRow) => {
-                    const path = () => filtered()[virtualRow.index]
-                    const name = () => path()?.split('/').pop() || ''
+                    const result = () => filtered()[virtualRow.index]
+                    const path = () => result()?.path || ''
+                    const name = () => path().split('/').pop() || ''
                     const dir = () => {
                       const p = path()
                       if (!p) return ''
@@ -231,26 +281,40 @@ export const QuickOpen: Component = () => {
                           transform: `translateY(${virtualRow.start}px)`,
                         }}
                       >
-                        <button
-                          class={`w-full flex items-center gap-2 px-3 py-1 text-left transition-colors ${
+                        <div
+                          class={`w-full flex items-center gap-2 px-3 py-1 transition-colors ${
                             isSelected()
                               ? 'bg-[#2c313a] text-[#abb2bf]'
                               : 'text-[#7f848e] hover:bg-[#2c313a]/50'
                           }`}
-                          onClick={() => {
-                            setSelectedIndex(virtualRow.index)
-                            openSelected()
-                          }}
                           onMouseEnter={() => setSelectedIndex(virtualRow.index)}
                         >
-                          {(() => { const I = getFileIcon(name()); return <I size={14} class="shrink-0" /> })()}
-                          <span class="text-[12px] truncate">
-                            <span class={isSelected() ? 'text-[#abb2bf]' : 'text-[#abb2bf]/80'}>{name()}</span>
-                            <Show when={dir()}>
-                              <span class="text-[#5c6370] ml-2">{dir()}</span>
-                            </Show>
-                          </span>
-                        </button>
+                          <button
+                            class="min-w-0 flex-1 flex items-center gap-2 text-left"
+                            onClick={() => {
+                              setSelectedIndex(virtualRow.index)
+                              openSelected()
+                            }}
+                          >
+                            {(() => { const I = getFileIcon(name()); return <I size={14} class="shrink-0" /> })()}
+                            <span class="text-[12px] truncate">
+                              <span class={isSelected() ? 'text-[#abb2bf]' : 'text-[#abb2bf]/80'}>{name()}</span>
+                              <Show when={dir()}>
+                                <span class="text-[#5c6370] ml-2">{dir()}</span>
+                              </Show>
+                            </span>
+                          </button>
+                          <Show when={result()?.isRecent}>
+                            <button
+                              class="shrink-0 p-1 rounded text-[#5c6370] hover:text-[#abb2bf] hover:bg-[#3a404b]"
+                              onClick={(e) => handleRemoveRecent(path(), e)}
+                              aria-label={`Remove ${path()} from recent files`}
+                              title="Remove from recent files"
+                            >
+                              <X size={12} />
+                            </button>
+                          </Show>
+                        </div>
                       </div>
                     )
                   }}

--- a/src/store/editorView.ts
+++ b/src/store/editorView.ts
@@ -21,6 +21,7 @@ import {
 import { clearTaskEditorState, loadTaskEditorState, persistTaskEditorState } from './taskContextStorage'
 import type { DiffSource, EditorTab, PendingGoToLineRequest } from './editorTypes'
 import { clearCachedContent, diffTabKey, getDirContents, isDiffKey, loadDirectory } from './files'
+import { recordRecentFileOpen } from './recentFiles'
 import { setRightPanelTab } from './ui'
 
 export type { DiffSource, EditorTab } from './editorTypes'
@@ -165,6 +166,7 @@ export function openFile(taskId: string, relativePath: string, name: string) {
     setActiveTabForTaskContext(taskId, relativePath)
     setMainView(taskId, relativePath)
     pushMru(taskId, relativePath)
+    recordRecentFileOpen(taskId, relativePath)
     persistTabState(taskId)
     return
   }
@@ -175,6 +177,7 @@ export function openFile(taskId: string, relativePath: string, name: string) {
   setActiveTabForTaskContext(taskId, relativePath)
   setMainView(taskId, relativePath)
   pushMru(taskId, relativePath)
+  recordRecentFileOpen(taskId, relativePath)
   persistTabState(taskId)
 }
 
@@ -192,6 +195,7 @@ export function openFilePinned(taskId: string, relativePath: string, name: strin
     }
     setMainView(taskId, relativePath)
     pushMru(taskId, relativePath)
+    recordRecentFileOpen(taskId, relativePath)
     persistTabState(taskId)
     return
   }
@@ -202,6 +206,7 @@ export function openFilePinned(taskId: string, relativePath: string, name: strin
   setActiveTabForTaskContext(taskId, relativePath)
   setMainView(taskId, relativePath)
   pushMru(taskId, relativePath)
+  recordRecentFileOpen(taskId, relativePath)
   persistTabState(taskId)
 }
 
@@ -313,6 +318,7 @@ export function setActiveTab(taskId: string, relativePath: string) {
   setActiveTabForTaskContext(taskId, relativePath)
   setMainView(taskId, relativePath)
   pushMru(taskId, relativePath)
+  recordRecentFileOpen(taskId, relativePath)
   persistTabState(taskId)
 }
 

--- a/src/store/projects.ts
+++ b/src/store/projects.ts
@@ -4,6 +4,7 @@ import type { Project } from '../types'
 import * as ipc from '../lib/ipc'
 import { selectedTaskId, selectedProjectId, setSelectedProjectId, setSelectedTaskId, setSelectedSessionId } from './ui'
 import { taskById } from './tasks'
+import { clearRecentFilesForProject } from './recentFiles'
 
 export const [projects, setProjects] = createStore<Project[]>([])
 
@@ -21,6 +22,7 @@ export async function addProject(repoPath: string): Promise<Project> {
 export async function deleteProject(id: string) {
   await ipc.deleteProject(id)
   setProjects(prev => prev.filter(p => p.id !== id))
+  clearRecentFilesForProject(id)
 
   // Clear selection if the selected task belongs to the deleted project
   const tid = selectedTaskId()

--- a/src/store/recentFiles.test.ts
+++ b/src/store/recentFiles.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, test } from 'vitest'
+import { setTasks } from './tasks'
+import { clearRecentFilesForProject, recentFilesForProject, recordRecentFileOpen, removeRecentFile } from './recentFiles'
+import type { Task } from '../types'
+
+const makeTask = (overrides: Partial<Task> = {}): Task => ({
+  id: 'task-1',
+  projectId: 'project-1',
+  name: null,
+  worktreePath: '/tmp/project-1',
+  branch: 'main',
+  createdAt: 1000,
+  mergeBaseSha: null,
+  portOffset: 0,
+  archived: false,
+  archivedAt: null,
+  lastCommitMessage: null,
+  parentTaskId: null,
+  agentType: 'claude',
+  ...overrides,
+})
+
+describe('recentFiles store', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    setTasks([])
+    clearRecentFilesForProject('project-1')
+    clearRecentFilesForProject('project-2')
+  })
+
+  test('records recent files by project using task context', () => {
+    setTasks([makeTask()])
+
+    recordRecentFileOpen('task-1', 'src/App.tsx')
+    recordRecentFileOpen('task-1', '.env')
+
+    expect(recentFilesForProject('project-1')).toEqual(['.env', 'src/App.tsx'])
+  })
+
+  test('moves an existing path to the front instead of duplicating it', () => {
+    setTasks([makeTask()])
+
+    recordRecentFileOpen('task-1', 'src/App.tsx')
+    recordRecentFileOpen('task-1', 'src/components/QuickOpen.tsx')
+    recordRecentFileOpen('task-1', 'src/App.tsx')
+
+    expect(recentFilesForProject('project-1')).toEqual(['src/App.tsx', 'src/components/QuickOpen.tsx'])
+  })
+
+  test('removes a recent file without affecting other project entries', () => {
+    setTasks([
+      makeTask(),
+      makeTask({ id: 'task-2', projectId: 'project-2', worktreePath: '/tmp/project-2' }),
+    ])
+
+    recordRecentFileOpen('task-1', '.env')
+    recordRecentFileOpen('task-2', 'src/main.ts')
+    removeRecentFile('project-1', '.env')
+
+    expect(recentFilesForProject('project-1')).toEqual([])
+    expect(recentFilesForProject('project-2')).toEqual(['src/main.ts'])
+  })
+})

--- a/src/store/recentFiles.ts
+++ b/src/store/recentFiles.ts
@@ -1,0 +1,75 @@
+import { taskById } from './tasks'
+
+const STORAGE_KEY = 'verun:recentFilesByProject'
+const MAX_RECENT_FILES = 100
+
+interface RecentFilesByProject {
+  [projectId: string]: string[]
+}
+
+function loadRecentFiles(): RecentFilesByProject {
+  if (typeof localStorage === 'undefined') return {}
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return {}
+    const parsed = JSON.parse(raw) as unknown
+    if (!parsed || typeof parsed !== 'object') return {}
+    const out: RecentFilesByProject = {}
+    for (const [projectId, paths] of Object.entries(parsed as Record<string, unknown>)) {
+      if (!Array.isArray(paths)) continue
+      out[projectId] = paths.filter((path): path is string => typeof path === 'string')
+    }
+    return out
+  } catch {
+    return {}
+  }
+}
+
+function persistRecentFiles(next: RecentFilesByProject) {
+  if (typeof localStorage === 'undefined') return
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(next))
+}
+
+let recentFilesByProject = loadRecentFiles()
+
+export function recentFilesForProject(projectId: string | null | undefined): string[] {
+  if (!projectId) return []
+  return recentFilesByProject[projectId] ?? []
+}
+
+export function recentFilesForTask(taskId: string | null | undefined): string[] {
+  if (!taskId) return []
+  const task = taskById(taskId)
+  return task ? recentFilesForProject(task.projectId) : []
+}
+
+export function recordRecentFileOpen(taskId: string, relativePath: string) {
+  if (!relativePath || relativePath.startsWith('__diff__:')) return
+  const task = taskById(taskId)
+  if (!task) return
+
+  const current = recentFilesByProject[task.projectId] ?? []
+  const next = [relativePath, ...current.filter(path => path !== relativePath)].slice(0, MAX_RECENT_FILES)
+  recentFilesByProject = { ...recentFilesByProject, [task.projectId]: next }
+  persistRecentFiles(recentFilesByProject)
+}
+
+export function removeRecentFile(projectId: string, relativePath: string) {
+  const current = recentFilesByProject[projectId] ?? []
+  const next = current.filter(path => path !== relativePath)
+
+  if (next.length === current.length) return
+
+  recentFilesByProject = next.length > 0
+    ? { ...recentFilesByProject, [projectId]: next }
+    : Object.fromEntries(Object.entries(recentFilesByProject).filter(([id]) => id !== projectId))
+  persistRecentFiles(recentFilesByProject)
+}
+
+export function clearRecentFilesForProject(projectId: string) {
+  if (!(projectId in recentFilesByProject)) return
+  recentFilesByProject = Object.fromEntries(
+    Object.entries(recentFilesByProject).filter(([id]) => id !== projectId),
+  )
+  persistRecentFiles(recentFilesByProject)
+}


### PR DESCRIPTION
## Summary

- **Multi-agent support**: Claude, Codex, Cursor, Gemini CLI, and OpenCode — each with capability flags (streaming, resume, plan mode, model selection, effort, attachments, fork) so the UI adapts per-agent
- **Per-session model selection**: model stored on the session, not the task; new session menu lets you pick agent + model before spawning
- **Policy engine rewrite**: AST-based shell parsing via `yash-syntax` replaces substring matching — handles compound commands, subshells, `env`/`sudo`/`bash -c` wrappers; `.verun` and worktree paths are hard-blocked regardless of trust level
- **Quick Open recent files**: top-of-list boost for project-scoped recently opened files (including gitignored ones like `.env`); X button to remove entries; persisted in localStorage per project
- **Pre-parsed output (`verun_items`)**: Rust persists parsed items so frontend reload skips agent-specific re-parsing
- **cargo fmt pre-commit hook**: formatter runs automatically on commit and restages changed Rust files

## Key changes

### Agents
- New `AgentKind` enum with trait-based abstraction (`build_session_args`, `extract_resume_id`, `uses_claude_jsonl`, capability flags)
- Gemini: `--output-format stream-json --yolo`, plan mode, model selection, resume, attachments
- OpenCode: `opencode run --format json`, plan mode, `--agent plan`, model selection, resume
- Codex: `codex --full-auto`, model selection, no resume
- Cursor: `--stream-partial-output` word-by-word streaming, tool calls, thinking deltas
- Agent type moved from tasks to sessions (migration 16 backfills from task)
- Dynamic model lists: Cursor uses `agent --list-models`, OpenCode uses `opencode models`

### Sessions
- `agent_type` and `model` columns on sessions (migrations 15–16)
- `send_message` prefers session-level agent over task-level
- New session "+" menu: pick agent then model from cascading submenus
- Provider errors shown inline with Retry / Retry in new session buttons
- Token/cache usage extraction for all providers

### Policy
- Hard-block `git worktree prune/remove` and `rm` on `.verun` paths unconditionally
- Normal mode blocks: branch delete, worktree remove/prune, stash drop/clear, tag delete, remote remove, reflog expire, `gc --prune`, `filter-branch`, force-push, `gh repo/release delete`
- Strips `git -C <path>` flags to detect cross-repo attacks

### Bug fixes (selected)
- DB init moved to async spawn to prevent startup crash on macOS
- Session startup delay reduced: parallel pre-spawn queries, deferred title generation, PATH capture on background thread
- Message role corruption on task switch
- Step edit state leaking across task switches
- `gh pr merge --delete-branch` failing due to main worktree checkout conflict
- Slow paste in session composer and shell terminals
- Chat search position jumping on new messages
- Gitignored files (`.env`) now visible in file browser

## Test plan
- [ ] Create tasks with each agent type (Claude, Codex, Cursor, Gemini, OpenCode) and verify sessions spawn correctly
- [ ] Per-session model selection: change model mid-task, verify it persists across navigation
- [ ] Policy: attempt blocked commands in normal mode and verify they are denied
- [ ] Quick Open: open files, reopen Quick Open, verify recents appear at top; X button removes them
- [ ] Fork a session, verify agent type and model are preserved
- [ ] Archive task with merged PR, verify panel closes