### PR TITLE
fix: suppress session init system message from output

### DIFF
--- a/src-tauri/src/stream.rs
+++ b/src-tauri/src/stream.rs
@@ -187,9 +187,7 @@ fn parse_sdk_event(line: &str) -> Vec<OutputItem> {
         // -- System messages --
         "system" => {
             if v.get("subtype").and_then(|s| s.as_str()) == Some("init") {
-                vec![OutputItem::System {
-                    text: "Initializing session...".into(),
-                }]
+                vec![]
             } else {
                 vec![]
             }


### PR DESCRIPTION
## Summary

- Removes the "Initializing session..." system message that was emitted on `init` subtype events - the output is now silently dropped, keeping the terminal clean at session start.

## Test plan

- [ ] Start a new session and confirm no "Initializing session..." message appears in the terminal output