### PR TITLE
fix: focus newly created session when file tab is open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Creating a new session now focuses it even when a file tab is open
+
 ## 0.7.2 — 2026-04-17
 
 ### Changes

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -13,6 +13,7 @@ import * as ipc from '../lib/ipc'
 import { addToast, setSelectedTaskId, setSelectedSessionId } from '../store/ui'
 import { setSessions, loadOutputLines, sendMessage, createSession, taskPlanMode, taskThinkingMode, taskFastMode } from '../store/sessions'
 import { setTasks } from '../store/tasks'
+import { setMainView } from '../store/editorView'
 
 function formatDuration(ms: number): string {
   const totalSec = Math.round(ms / 1000)
@@ -646,6 +647,7 @@ const ErrorBanner: Component<{
     try {
       const session = await createSession(props.taskId, props.agentType ?? 'claude', props.model ?? undefined)
       setSelectedSessionId(session.id)
+      setMainView(props.taskId, 'session')
       const [model, plan, thinking, fast] = modeArgs()
       await sendMessage(session.id, msg, undefined, model, plan, thinking, fast)
     } catch { /* status will update via event */ }

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -7,7 +7,7 @@ import { addStep, getSteps, updateStep, extractStep } from '../store/steps'
 import { ModelSelector } from './ModelSelector'
 import { CommandPalette } from './CommandPalette'
 import { FileMention } from './FileMention'
-import { openFile } from '../store/editorView'
+import { openFile, setMainView } from '../store/editorView'
 import { renderMarkdown, handleMarkdownLinkClick, getWorktreePath } from '../lib/markdown'
 import type { Command } from '../store/commands'
 import { ArrowUp, Square, X, Plus, ShieldAlert, HelpCircle, Shield, ShieldCheck, ListChecks, Zap, Brain, Minimize2, Maximize2, Loader2, Activity, ListPlus, Check } from 'lucide-solid'
@@ -924,6 +924,7 @@ export const MessageInput: Component<Props> = (props) => {
           const currentAgent = sessionById(props.sessionId ?? '')?.agentType ?? 'claude' as AgentType
           const session = await createSession(tid, currentAgent)
           setSelectedSessionId(session.id)
+          setMainView(tid, 'session')
         }
         break
       }

--- a/src/components/TaskPanel.tsx
+++ b/src/components/TaskPanel.tsx
@@ -217,6 +217,7 @@ export const TaskPanel: Component = () => {
     if (!tid) return
     const session = await createSession(tid, agentType, model)
     setSelectedSessionId(session.id)
+    setMainView(tid, 'session')
   }
 
   const currentSession = () => {


### PR DESCRIPTION
## Summary

- Creating a new session (via the new session button, `/new-session` command, or retry-with-new-session) now correctly switches focus to the new session even when a file tab is open
- Root cause: `setMainView(taskId, 'session')` was missing at all three `createSession` call sites in `TaskPanel`, `MessageInput`, and `ChatView` — `mainView` stayed pointed at the open file tab
- Matches the existing pattern already used when clicking a session in the session list (`TaskPanel.tsx:515`)

## Test plan

- [ ] Open a task and open a file in the editor (so a file tab is active)
- [ ] Click the new session button — verify the view switches to the new session
- [ ] With a file tab open, type `/new-session` in the message input — verify focus switches
- [ ] Trigger a session error and click retry — verify the new session is focused