### PR TITLE
fix: map Codex trust level to proper approval policy and sandbox flags

### DIFF
--- a/src-tauri/src/agent/codex.rs
+++ b/src-tauri/src/agent/codex.rs
@@ -1,4 +1,28 @@
 use super::{Agent, AgentKind, InputMode, SessionArgs};
+use crate::policy::TrustLevel;
+
+fn resolve_codex_extra_writable_dirs(args: &SessionArgs<'_>) -> Vec<String> {
+    let mut dirs = Vec::new();
+
+    let repo_git_dir = std::path::Path::new(args.repo_path).join(".git");
+    if repo_git_dir.exists() {
+        dirs.push(repo_git_dir.to_string_lossy().to_string());
+    }
+
+    let git_pointer_path = std::path::Path::new(args.worktree_path).join(".git");
+    if let Ok(contents) = std::fs::read_to_string(&git_pointer_path) {
+        if let Some(raw) = contents.trim().strip_prefix("gitdir:") {
+            let gitdir = raw.trim();
+            if !gitdir.is_empty() {
+                dirs.push(gitdir.to_string());
+            }
+        }
+    }
+
+    dirs.sort();
+    dirs.dedup();
+    dirs
+}
 
 /// OpenAI Codex CLI - open-source coding agent.
 ///
@@ -66,14 +90,29 @@ impl Agent for Codex {
     }
 
     fn build_session_args(&self, args: &SessionArgs<'_>) -> Vec<String> {
-        let mut v: Vec<String> = vec!["exec".into(), "--json".into()];
+        let (approval_policy, sandbox) = match args.trust_level {
+            TrustLevel::FullAuto => ("never", "danger-full-access"),
+            TrustLevel::Normal | TrustLevel::Supervised => ("on-request", "workspace-write"),
+        };
+
+        let mut v: Vec<String> = vec![
+            "-a".into(),
+            approval_policy.into(),
+            "exec".into(),
+            "--json".into(),
+            "-s".into(),
+            sandbox.into(),
+        ];
+
+        if args.trust_level != TrustLevel::FullAuto {
+            for dir in resolve_codex_extra_writable_dirs(args) {
+                v.extend(["--add-dir".into(), dir]);
+            }
+        }
 
         if let Some(m) = args.model {
             v.extend(["-m".into(), m.to_string()]);
         }
-
-        // Default to full-auto so Verun can drive it non-interactively.
-        v.push("--full-auto".into());
 
         // Resume is a subcommand: `codex exec resume <session_id>`
         if let Some(rid) = args.resume_session_id {

--- a/src-tauri/src/agent/mod.rs
+++ b/src-tauri/src/agent/mod.rs
@@ -128,6 +128,9 @@ pub struct SessionArgs<'a> {
     pub plan_mode: bool,
     pub thinking_mode: bool,
     pub fast_mode: bool,
+    pub trust_level: crate::policy::TrustLevel,
+    pub worktree_path: &'a str,
+    pub repo_path: &'a str,
     /// For `PositionalOrStdin` agents: the user message appended as the final positional arg.
     pub message: &'a str,
 }
@@ -240,6 +243,9 @@ mod tests {
             plan_mode: false,
             thinking_mode: false,
             fast_mode: false,
+            trust_level: crate::policy::TrustLevel::Normal,
+            worktree_path: "",
+            repo_path: "",
             message: "",
         }
     }
@@ -365,8 +371,24 @@ mod tests {
         });
         assert!(args.contains(&"exec".to_string()));
         assert!(args.contains(&"--json".to_string()));
-        assert!(args.contains(&"--full-auto".to_string()));
+        assert!(args.contains(&"-a".to_string()));
+        assert!(args.contains(&"on-request".to_string()));
+        assert!(args.contains(&"-s".to_string()));
+        assert!(args.contains(&"workspace-write".to_string()));
         assert!(args.contains(&"fix the bug".to_string()));
+    }
+
+    #[test]
+    fn codex_build_args_full_auto_uses_danger_mode() {
+        let agent = Codex;
+        let args = agent.build_session_args(&SessionArgs {
+            trust_level: crate::policy::TrustLevel::FullAuto,
+            ..default_args()
+        });
+        assert!(args.contains(&"-a".to_string()));
+        assert!(args.contains(&"never".to_string()));
+        assert!(args.contains(&"-s".to_string()));
+        assert!(args.contains(&"danger-full-access".to_string()));
     }
 
     #[test]

--- a/src-tauri/src/task.rs
+++ b/src-tauri/src/task.rs
@@ -760,6 +760,9 @@ pub async fn send_message(
         plan_mode,
         thinking_mode,
         fast_mode,
+        trust_level,
+        worktree_path: &worktree_path,
+        repo_path: &repo_path,
         message: &message,
     };
 


### PR DESCRIPTION
## Summary
- Replaces hardcoded `--full-auto` with `-a` (approval policy) and `-s` (sandbox) flags driven by the session's `TrustLevel`
- `FullAuto` → `-a never -s danger-full-access`
- `Normal`/`Supervised` → `-a on-request -s workspace-write` with `--add-dir` for the worktree's git directories (so Codex can write lock files etc.)
- Adds `trust_level`, `worktree_path`, and `repo_path` fields to `SessionArgs` to support this

## Test plan
- [ ] Start a Codex session in Normal trust mode - confirm `-a on-request -s workspace-write` is passed
- [ ] Start a Codex session in FullAuto mode - confirm `-a never -s danger-full-access` is passed
- [ ] `cargo test` passes (new `codex_build_args_full_auto_uses_danger_mode` test)