### PR TITLE
fix: Codex cancel-before-reply causes "no rollout found" on follow-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Creating a new session now focuses it even when a file tab is open
+- Codex: don't persist `thread_id` until the first turn completes, so cancelling a fresh session before it replies doesn't break the next message with "no rollout found"
 
 ## 0.7.2 — 2026-04-17
 

--- a/src-tauri/src/agent/codex.rs
+++ b/src-tauri/src/agent/codex.rs
@@ -99,4 +99,8 @@ impl Agent for Codex {
             None
         }
     }
+
+    fn defers_resume_id_until_turn_end(&self) -> bool {
+        true
+    }
 }

--- a/src-tauri/src/agent/mod.rs
+++ b/src-tauri/src/agent/mod.rs
@@ -226,6 +226,14 @@ pub trait Agent: Send + Sync {
     fn extract_resume_id(&self, _v: &serde_json::Value) -> Option<String> {
         None
     }
+
+    /// If true, the captured resume id is only safe to persist after at least
+    /// one turn completes. Codex emits `thread.started` with a thread_id at
+    /// startup, but the rollout file is only written to disk once a turn
+    /// completes — resuming before that fails with "no rollout found".
+    fn defers_resume_id_until_turn_end(&self) -> bool {
+        false
+    }
 }
 
 #[cfg(test)]
@@ -403,6 +411,15 @@ mod tests {
         assert!(agent.supports_attachments());
         assert!(!agent.supports_fork());
         assert!(!agent.uses_claude_jsonl());
+        assert!(agent.defers_resume_id_until_turn_end());
+    }
+
+    #[test]
+    fn other_agents_do_not_defer_resume_id() {
+        assert!(!Claude.defers_resume_id_until_turn_end());
+        assert!(!Cursor.defers_resume_id_until_turn_end());
+        assert!(!Gemini.defers_resume_id_until_turn_end());
+        assert!(!OpenCode.defers_resume_id_until_turn_end());
     }
 
     // ── Cursor ──────────────────────────────────────────────────────────

--- a/src-tauri/src/stream.rs
+++ b/src-tauri/src/stream.rs
@@ -989,6 +989,10 @@ pub async fn stream_and_capture(
     let mut last_error: Option<String> = None;
     // Captured from `system.init` events for the per-turn snapshot hook.
     let mut resume_id_for_snapshot: Option<String> = None;
+    // For agents that defer (Codex): hold the captured id until the first
+    // turn completes, because the rollout file isn't persisted until then.
+    let mut pending_resume_id: Option<String> = None;
+    let defers_resume = agent.defers_resume_id_until_turn_end();
 
     loop {
         let deadline = tokio::time::sleep(FLUSH_INTERVAL);
@@ -1022,10 +1026,14 @@ pub async fn stream_and_capture(
                             if let Ok(v) = serde_json::from_str::<serde_json::Value>(&line) {
                                 if let Some(sid) = agent.extract_resume_id(&v) {
                                     resume_id_for_snapshot = Some(sid.clone());
-                                    let _ = db_tx.send(crate::db::DbWrite::SetResumeSessionId {
-                                        id: session_id.clone(),
-                                        resume_session_id: sid,
-                                    }).await;
+                                    if defers_resume {
+                                        pending_resume_id = Some(sid);
+                                    } else {
+                                        let _ = db_tx.send(crate::db::DbWrite::SetResumeSessionId {
+                                            id: session_id.clone(),
+                                            resume_session_id: sid,
+                                        }).await;
+                                    }
                                 }
                             }
                         }
@@ -1081,6 +1089,18 @@ pub async fn stream_and_capture(
 
                         // Persist pre-parsed items (agent-format-agnostic)
                         persist_items(&db_tx, &session_id, &items, &mut total_persisted);
+
+                        // Commit the deferred resume id once a turn has completed —
+                        // by this point the agent (e.g. Codex) has written its
+                        // rollout file, so the id is safe to use for future resumes.
+                        if is_turn_end {
+                            if let Some(sid) = pending_resume_id.take() {
+                                let _ = db_tx.send(crate::db::DbWrite::SetResumeSessionId {
+                                    id: session_id.clone(),
+                                    resume_session_id: sid,
+                                }).await;
+                            }
+                        }
 
                         // Close stdin after turn completes so the CLI process can exit
                         if is_turn_end {


### PR DESCRIPTION
## Summary

- Codex emits `thread.started` with a `thread_id` at session start, but only persists its rollout file after a turn completes
- We were writing the `thread_id` to the DB immediately, so cancelling a fresh session before it replied saved an id with no rollout behind it
- The next message would then call `codex exec resume <id>` and fail with `thread/resume failed: no rollout found for thread id ...`

## Fix

Added a `defers_resume_id_until_turn_end()` trait method on `Agent` (default false). Codex overrides it to true. In the stream loop, deferred agents hold the captured id in `pending_resume_id` and only write it to the DB on the first `TurnEnd`. If the process is aborted before that, the id is silently dropped and the next message starts a fresh session.

## Test plan

- [ ] Send a message to a fresh Codex session, cancel before it replies, then send another message - should start fresh without error
- [ ] Normal Codex flow (send, wait for reply, send follow-up) still resumes correctly
- [ ] All other agents unaffected (Claude, Cursor, Gemini, OpenCode all have `defers_resume_id_until_turn_end = false`)