### PR TITLE
fix: align claude CLI integration with claude-agent-sdk-python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,19 +25,17 @@
 - Stream loop now parses each NDJSON line once instead of up to three times
 - New `interrupt_session` IPC: cancel the current turn over stdin without killing the process
 - New `get_session_context_usage` IPC: ask the running CLI for current context-window usage
-- Plan/Think/Fast toggles no longer disabled while the agent is running, so mode changes can take effect on queued steps and steers
-- Composer model selector no longer disabled while the agent is running; the new selection applies to subsequent sends (manual, armed auto-send, or queued step)
-- Next Steps: click a step to edit inline (textarea + per-step mode toggles + model selector); removed the separate pencil icon and the edit-via-composer round-trip
-- Next Steps: armed state shown as an accent left-border; fire/arm/delete actions revealed on row hover to reduce visual noise
-- Next Steps: arm toggle now uses action-button semantics — armed step shows Pause (click to pause), disarmed shows Play (click to play)
-- Next Steps: fire button sits as the leftmost icon of the right-hand hover cluster (no longer prefixing the message) and is revealed only on hover
-- Next Steps: armed indicator is now an inset box-shadow instead of a left border, so armed rows keep the same horizontal alignment as disarmed ones
-- Next Steps: row contents vertically centered in view mode; buttons in edit mode no longer blur-save the textarea (WebKit fix)
-- ModelSelector: added `fixedPosition` option so the popover escapes overflow-clipping containers (used by inline step editing)
-- Composer: when the agent is running, the Enter button now uses a `ListPlus` icon to match its actual behaviour (add next step) instead of the send arrow
-- Next Steps: first idle step hides the arm/play button (redundant with the send button) and keeps its icons visible without hover; arm button no longer uses accent colour in the armed state
-- Next Steps: remove button uses an `X` icon instead of a trash bin, reflecting "dismiss from queue" semantics rather than permanent delete
-- Next Steps: "Next Steps" header sticks to the top of the list when scrolling so it remains visible as additional steps scroll past
+- Claude sessions now reuse a single persistent CLI process across all turns in a session (matches claude-agent-sdk-python): eliminates the 2-3s CLI boot cost on every message and fixes the armed-step race where a queued send would collide with the dying CLI's final JSONL write
+- Fix loading indicator sticking on after turn end: persistent-agent stream loop now emits `session-status: idle` from `turn_end` (the monitor's post-exit idle emission never fires for processes that stay alive across turns)
+- Abort on Claude sessions is now a single `control_request interrupt` write to stdin - the process stays alive for the next message, so there's no graceful-shutdown delay and no "Stopping..." spinner
+- New `prewarm_session` IPC + `TaskPanel` hook: opening a Claude session spawns the CLI in the background so the first message is instant. No-op for non-persistent agents (Codex, Gemini, Cursor, OpenCode)
+- `close_session` / `clear_session` / app-quit now shut down any live persistent CLI before DB writes or exit, so switching tasks or quitting doesn't leak orphan processes
+- New `Agent` trait methods (`persists_across_turns`, `abort_strategy`, `encode_stream_user_message`, `encode_stream_interrupt`): call sites stay agent-agnostic, any future agent opts into persistent sessions by flipping one flag
+- Plan viewer "Request changes..." input now forwards the typed feedback as the tool-deny message so Claude sees it as the refusal reason and continues the same turn; the plan UI dismisses immediately instead of sticking around waiting for a second message
+- Fix persistent-session mode/model race: fast-path `set_permission_mode` / `set_model` now waits for the CLI's `control_response` ACK before writing the user message, so plan mode (and model switches) take effect before Claude reads the prompt - previously the CLI could process the message in the old mode
+- Composer stays visible alongside the persisted "Plan ready" banner, and is dismissed automatically when the user sends a fresh message via the main composer - previously a stale plan file from a prior session could hide the composer and block follow-ups
+- Fix API/auth errors on Claude sessions rendering as plain text: persistent-agent `turn_end` now propagates the provider error through `session-status`, restoring the red inline banner with Retry / Retry in new session
+- Provider errors (auth, overload, prompt-too-long) now render as a single persistent block inside the transcript instead of duplicating across an assistant bubble + system bubble + bottom banner. The block stays visible across follow-up turns, carries Retry / Retry in new session, and exposes the raw CLI JSON behind a "Show details" toggle (copyable)
 
 ## 0.7.3 — 2026-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@
 - Sidebar task tiles show unread/attention state as a pulsing left-edge strip (amber for attention, blue for unread) instead of a trailing dot
 - Cmd+1…9 now focuses the existing window when the target task is already open in a separate window (matching sidebar click behavior); sidebar tiles display the shortcut, which swaps to the archive button on hover (#142)
 - Fix newly created task occasionally disappearing from sidebar after setup - the `task-created` event now carries the source window label so the originating window skips its own reload, avoiding a race with the async DB write queue (#135)
+- Graceful shutdown for aborted claude sessions: close stdin, wait 5s, SIGTERM, wait 5s, then SIGKILL - prevents losing the last assistant message on `--resume` when the CLI is mid-write of its session JSONL
+- Strip `CLAUDECODE` from the spawned CLI's env and set `CLAUDE_CODE_ENTRYPOINT=verun` so nested-detection and telemetry are correct
+- Stream parser skips non-JSON stdout lines (e.g. `[SandboxDebug]`) instead of surfacing them as raw output
+- Stream loop now parses each NDJSON line once instead of up to three times
+- New `interrupt_session` IPC: cancel the current turn over stdin without killing the process
+- New `get_session_context_usage` IPC: ask the running CLI for current context-window usage
 
 ## 0.7.3 — 2026-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,19 @@
 - Stream loop now parses each NDJSON line once instead of up to three times
 - New `interrupt_session` IPC: cancel the current turn over stdin without killing the process
 - New `get_session_context_usage` IPC: ask the running CLI for current context-window usage
+- Plan/Think/Fast toggles no longer disabled while the agent is running, so mode changes can take effect on queued steps and steers
+- Composer model selector no longer disabled while the agent is running; the new selection applies to subsequent sends (manual, armed auto-send, or queued step)
+- Next Steps: click a step to edit inline (textarea + per-step mode toggles + model selector); removed the separate pencil icon and the edit-via-composer round-trip
+- Next Steps: armed state shown as an accent left-border; fire/arm/delete actions revealed on row hover to reduce visual noise
+- Next Steps: arm toggle now uses action-button semantics — armed step shows Pause (click to pause), disarmed shows Play (click to play)
+- Next Steps: fire button sits as the leftmost icon of the right-hand hover cluster (no longer prefixing the message) and is revealed only on hover
+- Next Steps: armed indicator is now an inset box-shadow instead of a left border, so armed rows keep the same horizontal alignment as disarmed ones
+- Next Steps: row contents vertically centered in view mode; buttons in edit mode no longer blur-save the textarea (WebKit fix)
+- ModelSelector: added `fixedPosition` option so the popover escapes overflow-clipping containers (used by inline step editing)
+- Composer: when the agent is running, the Enter button now uses a `ListPlus` icon to match its actual behaviour (add next step) instead of the send arrow
+- Next Steps: first idle step hides the arm/play button (redundant with the send button) and keeps its icons visible without hover; arm button no longer uses accent colour in the armed state
+- Next Steps: remove button uses an `X` icon instead of a trash bin, reflecting "dismiss from queue" semantics rather than permanent delete
+- Next Steps: "Next Steps" header sticks to the top of the list when scrolling so it remains visible as additional steps scroll past
 
 ## 0.7.3 — 2026-04-17
 

--- a/src-tauri/src/agent/claude.rs
+++ b/src-tauri/src/agent/claude.rs
@@ -1,4 +1,4 @@
-use super::{Agent, AgentKind, InputMode, SessionArgs};
+use super::{Agent, AgentKind, AbortStrategy, InputMode, SessionArgs};
 
 /// Claude Code - Anthropic's CLI coding agent.
 ///
@@ -62,8 +62,9 @@ impl Agent for Claude {
     }
 
     fn build_session_args(&self, args: &SessionArgs<'_>) -> Vec<String> {
+        // No `-p`: the CLI stays alive reading NDJSON on stdin across turns,
+        // matching claude-agent-sdk-python (subprocess_cli.py:207).
         let mut v = vec![
-            "-p".into(),
             "--output-format".into(),
             "stream-json".into(),
             "--input-format".into(),
@@ -120,5 +121,90 @@ impl Agent for Claude {
             "result" => v.get("session_id")?.as_str().map(str::to_string),
             _ => None,
         }
+    }
+
+    fn persists_across_turns(&self) -> bool {
+        true
+    }
+
+    fn abort_strategy(&self) -> AbortStrategy {
+        AbortStrategy::Interrupt
+    }
+
+    fn encode_stream_user_message(
+        &self,
+        message: &str,
+        attachments: &[crate::task::Attachment],
+    ) -> Result<Vec<u8>, String> {
+        let mut content_blocks: Vec<serde_json::Value> = Vec::new();
+        for attachment in attachments {
+            content_blocks.push(serde_json::json!({
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": attachment.mime_type,
+                    "data": attachment.data_base64,
+                }
+            }));
+        }
+        if !message.is_empty() {
+            content_blocks.push(serde_json::json!({ "type": "text", "text": message }));
+        }
+
+        let user_msg = serde_json::json!({
+            "type": "user",
+            "session_id": "",
+            "parent_tool_use_id": null,
+            "message": { "role": "user", "content": content_blocks },
+        });
+
+        let mut payload =
+            serde_json::to_vec(&user_msg).map_err(|e| format!("serialize user msg: {e}"))?;
+        payload.push(b'\n');
+        Ok(payload)
+    }
+
+    fn encode_stream_interrupt(&self, request_id: &str) -> Result<Vec<u8>, String> {
+        let envelope = serde_json::json!({
+            "type": "control_request",
+            "request_id": request_id,
+            "request": { "subtype": "interrupt" },
+        });
+        let mut payload =
+            serde_json::to_vec(&envelope).map_err(|e| format!("serialize interrupt: {e}"))?;
+        payload.push(b'\n');
+        Ok(payload)
+    }
+
+    fn encode_stream_set_permission_mode(
+        &self,
+        request_id: &str,
+        mode: &str,
+    ) -> Result<Vec<u8>, String> {
+        let envelope = serde_json::json!({
+            "type": "control_request",
+            "request_id": request_id,
+            "request": { "subtype": "set_permission_mode", "mode": mode },
+        });
+        let mut payload = serde_json::to_vec(&envelope)
+            .map_err(|e| format!("serialize set_permission_mode: {e}"))?;
+        payload.push(b'\n');
+        Ok(payload)
+    }
+
+    fn encode_stream_set_model(
+        &self,
+        request_id: &str,
+        model: Option<&str>,
+    ) -> Result<Vec<u8>, String> {
+        let envelope = serde_json::json!({
+            "type": "control_request",
+            "request_id": request_id,
+            "request": { "subtype": "set_model", "model": model },
+        });
+        let mut payload =
+            serde_json::to_vec(&envelope).map_err(|e| format!("serialize set_model: {e}"))?;
+        payload.push(b'\n');
+        Ok(payload)
     }
 }

--- a/src-tauri/src/agent/mod.rs
+++ b/src-tauri/src/agent/mod.rs
@@ -1,3 +1,95 @@
+//! # Agents
+//!
+//! Verun runs several coding CLIs (Claude, Codex, Cursor, Gemini, OpenCode)
+//! with a single orchestration pipeline. This module is the seam: every
+//! agent-specific detail lives behind the [`Agent`] trait so that
+//! `task.rs`, `stream.rs`, and `ipc.rs` stay agent-agnostic.
+//!
+//! ## Rule of thumb
+//!
+//! If you find yourself writing `if agent_kind == Claude` anywhere outside
+//! `agent/`, stop — add a capability method to [`Agent`] instead and override
+//! it on the relevant impls.
+//!
+//! ## Anatomy of an agent
+//!
+//! Each agent is a zero-sized struct (see [`Claude`], [`Codex`], [`Cursor`],
+//! [`Gemini`], [`OpenCode`]) implementing [`Agent`]. [`AgentKind`] is the
+//! serializable tag stored on `sessions.agent_type` in the DB; it maps 1:1
+//! to a concrete impl via [`AgentKind::implementation`].
+//!
+//! The trait groups methods into four concerns:
+//!
+//! 1. **Identity** — `kind`, `display_name`, `cli_binary`, `install_hint`,
+//!    `docs_url`. Purely descriptive.
+//! 2. **Command shape** — `input_mode`, `build_session_args`, `version_args`,
+//!    `available_models`, `model_list_args`, `parse_model_list`. Everything
+//!    needed to build the subprocess invocation.
+//! 3. **Capability flags** — `supports_plan_mode`, `supports_effort`,
+//!    `supports_skills`, `supports_attachments`, `supports_fork`,
+//!    `uses_claude_jsonl`, `supports_streaming`, `supports_resume`,
+//!    `supports_model_selection`. Drive UI affordances and orchestrator
+//!    branching. **Default to conservative (usually `false`)** and opt in
+//!    per-agent.
+//! 4. **Lifecycle + streaming protocol** — `extract_resume_id`,
+//!    `defers_resume_id_until_turn_end`, `persists_across_turns`,
+//!    `abort_strategy`, `encode_stream_user_message`, `encode_stream_interrupt`.
+//!    Govern how the process is spawned, reused, and cancelled.
+//!
+//! ## Turn model
+//!
+//! An agent's process is either:
+//!
+//! - **One-shot per turn** (`persists_across_turns = false`, the default):
+//!   `send_message` spawns a fresh CLI, writes the user message, reads
+//!   stdout until `turn_end`, closes stdin, and lets the process exit.
+//!   Follow-up messages respawn with `--resume`. This matches Codex, Cursor,
+//!   Gemini, OpenCode.
+//!
+//! - **Persistent across turns** (`persists_across_turns = true`): the CLI
+//!   is spawned once and kept alive. `send_message` on turn 2+ writes a new
+//!   user message to the existing process's stdin via
+//!   [`Agent::encode_stream_user_message`]. `abort_message` writes an
+//!   interrupt control message via [`Agent::encode_stream_interrupt`]
+//!   (if `abort_strategy = Interrupt`). `close_session`, `clear_session`,
+//!   and app-exit must explicitly kill the process. This matches Claude.
+//!
+//! To opt a new agent into the persistent model:
+//!
+//! ```ignore
+//! impl Agent for MyAgent {
+//!     fn persists_across_turns(&self) -> bool { true }
+//!     fn abort_strategy(&self) -> AbortStrategy { AbortStrategy::Interrupt }
+//!     fn encode_stream_user_message(&self, msg: &str, atts: &[Attachment])
+//!         -> Result<Vec<u8>, String> { /* newline-delimited stdin frame */ }
+//!     fn encode_stream_interrupt(&self, request_id: &str)
+//!         -> Result<Vec<u8>, String> { /* control frame */ }
+//!     // ...
+//! }
+//! ```
+//!
+//! The orchestrator handles fast-path vs. spawn, abort dispatch, pre-warming,
+//! and shutdown automatically. You only supply the wire format.
+//!
+//! ## Adding a brand-new agent
+//!
+//! 1. Create `agent/<name>.rs` with a unit struct and `impl Agent`.
+//! 2. Add a variant to [`AgentKind`] and wire it into `parse`, `as_str`,
+//!    `all`, and `implementation`.
+//! 3. Add a `pub use <name>::MyAgent;` re-export at the top of this file.
+//! 4. Add tests in the `tests` module at the bottom — the existing tests
+//!    are a good template: args for each mode, resume-id extraction,
+//!    capability flags.
+//!
+//! ## What NOT to do
+//!
+//! - Don't put orchestration logic (spawn, stream, abort, pre-warm) in
+//!   agent impls — those belong in `task.rs` / `stream.rs`.
+//! - Don't let agent-specific JSON shapes leak into the stream loop. Use
+//!   `extract_resume_id` and the encoders.
+//! - Don't add state to the agent struct. Impls are instantiated on demand
+//!   via [`AgentKind::implementation`] and are expected to be zero-sized.
+
 mod claude;
 mod codex;
 mod cursor;
@@ -119,6 +211,19 @@ pub enum InputMode {
 }
 
 // ---------------------------------------------------------------------------
+// How an in-flight turn is cancelled
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AbortStrategy {
+    /// EOF → SIGTERM → SIGKILL. Process dies; next send respawns.
+    Kill,
+    /// Write an interrupt control message on stdin. Process stays alive and
+    /// is ready for the next user message.
+    Interrupt,
+}
+
+// ---------------------------------------------------------------------------
 // Parameters for building a session command
 // ---------------------------------------------------------------------------
 
@@ -237,6 +342,63 @@ pub trait Agent: Send + Sync {
     fn defers_resume_id_until_turn_end(&self) -> bool {
         false
     }
+
+    /// Whether the CLI's process is reused across multiple turns in a
+    /// single session. When true:
+    ///   - stdin stays open after `turn_end`
+    ///   - `send_message` writes to the existing process instead of spawning
+    ///   - the process can be pre-warmed before the first user message
+    ///   - `close_session` / `clear_session` / app-exit must kill it explicitly
+    fn persists_across_turns(&self) -> bool {
+        false
+    }
+
+    /// How to cancel an in-flight turn. Meaningful only when
+    /// `persists_across_turns()` is true — otherwise we always kill.
+    fn abort_strategy(&self) -> AbortStrategy {
+        AbortStrategy::Kill
+    }
+
+    /// Serialize a user message (with attachments) to bytes for writing to
+    /// the CLI's stdin while it's already running. Called on every turn after
+    /// the first for persistent agents.
+    fn encode_stream_user_message(
+        &self,
+        _message: &str,
+        _attachments: &[crate::task::Attachment],
+    ) -> Result<Vec<u8>, String> {
+        Err("agent does not support streaming user input".into())
+    }
+
+    /// Serialize an interrupt control message to stdin bytes. The caller
+    /// supplies the request id so the same id can be correlated elsewhere.
+    fn encode_stream_interrupt(&self, _request_id: &str) -> Result<Vec<u8>, String> {
+        Err("agent does not support stream interrupt".into())
+    }
+
+    /// Serialize a `set_permission_mode` control request for persistent
+    /// sessions. `mode` is the target mode ("default", "plan",
+    /// "acceptEdits", "bypassPermissions"). Only needed when
+    /// `persists_across_turns()` is true, since respawning naturally picks
+    /// up the new mode from CLI args.
+    fn encode_stream_set_permission_mode(
+        &self,
+        _request_id: &str,
+        _mode: &str,
+    ) -> Result<Vec<u8>, String> {
+        Err("agent does not support set_permission_mode".into())
+    }
+
+    /// Serialize a `set_model` control request. `model = None` resets to
+    /// the CLI's default. Only needed when `persists_across_turns()` is
+    /// true.
+    fn encode_stream_set_model(
+        &self,
+        _request_id: &str,
+        _model: Option<&str>,
+    ) -> Result<Vec<u8>, String> {
+        Err("agent does not support set_model".into())
+    }
 }
 
 #[cfg(test)]
@@ -278,7 +440,9 @@ mod tests {
     fn claude_build_args_basic() {
         let agent = Claude;
         let args = agent.build_session_args(&default_args());
-        assert!(args.contains(&"-p".to_string()));
+        // `-p` (print-and-exit mode) must NOT be present — we want the CLI to
+        // stay alive reading stdin across turns, matching claude-agent-sdk-python.
+        assert!(!args.contains(&"-p".to_string()));
         assert!(args.contains(&"stream-json".to_string()));
     }
 
@@ -366,6 +530,158 @@ mod tests {
         assert!(agent.supports_attachments());
         assert!(agent.supports_fork());
         assert!(agent.uses_claude_jsonl());
+    }
+
+    // ── Persistence + abort strategy + stream encoders ──────────────────
+
+    #[test]
+    fn claude_persists_across_turns() {
+        assert!(Claude.persists_across_turns());
+    }
+
+    #[test]
+    fn other_agents_do_not_persist() {
+        assert!(!Codex.persists_across_turns());
+        assert!(!Cursor.persists_across_turns());
+        assert!(!Gemini.persists_across_turns());
+        assert!(!OpenCode.persists_across_turns());
+    }
+
+    #[test]
+    fn claude_abort_strategy_is_interrupt() {
+        assert_eq!(Claude.abort_strategy(), AbortStrategy::Interrupt);
+    }
+
+    #[test]
+    fn other_agents_abort_strategy_is_kill() {
+        assert_eq!(Codex.abort_strategy(), AbortStrategy::Kill);
+        assert_eq!(Cursor.abort_strategy(), AbortStrategy::Kill);
+        assert_eq!(Gemini.abort_strategy(), AbortStrategy::Kill);
+        assert_eq!(OpenCode.abort_strategy(), AbortStrategy::Kill);
+    }
+
+    #[test]
+    fn claude_encodes_stream_user_message_as_newline_delimited_json() {
+        let agent = Claude;
+        let bytes = agent
+            .encode_stream_user_message("hi there", &[])
+            .expect("claude should encode");
+        assert!(bytes.ends_with(b"\n"), "stream lines must be newline-delimited");
+        let text = std::str::from_utf8(&bytes).expect("utf8");
+        let v: serde_json::Value = serde_json::from_str(text.trim_end()).expect("valid json");
+        assert_eq!(v["type"], "user");
+        assert_eq!(v["session_id"], "");
+        assert!(v["parent_tool_use_id"].is_null());
+        assert_eq!(v["message"]["role"], "user");
+        let content = v["message"]["content"].as_array().expect("content array");
+        assert_eq!(content.len(), 1);
+        assert_eq!(content[0]["type"], "text");
+        assert_eq!(content[0]["text"], "hi there");
+    }
+
+    #[test]
+    fn claude_encodes_stream_user_message_with_attachments_before_text() {
+        let agent = Claude;
+        let att = crate::task::Attachment {
+            name: "logo.png".into(),
+            mime_type: "image/png".into(),
+            data_base64: "abc123".into(),
+        };
+        let bytes = agent
+            .encode_stream_user_message("look at this", std::slice::from_ref(&att))
+            .expect("encode");
+        let v: serde_json::Value = serde_json::from_slice(&bytes[..bytes.len() - 1]).unwrap();
+        let content = v["message"]["content"].as_array().unwrap();
+        assert_eq!(content.len(), 2);
+        assert_eq!(content[0]["type"], "image");
+        assert_eq!(content[0]["source"]["type"], "base64");
+        assert_eq!(content[0]["source"]["media_type"], "image/png");
+        assert_eq!(content[0]["source"]["data"], "abc123");
+        assert_eq!(content[1]["type"], "text");
+        assert_eq!(content[1]["text"], "look at this");
+    }
+
+    #[test]
+    fn claude_encodes_stream_interrupt_as_control_request() {
+        let agent = Claude;
+        let bytes = agent.encode_stream_interrupt("req_abc").expect("encode");
+        assert!(bytes.ends_with(b"\n"));
+        let v: serde_json::Value =
+            serde_json::from_slice(&bytes[..bytes.len() - 1]).expect("json");
+        assert_eq!(v["type"], "control_request");
+        assert_eq!(v["request_id"], "req_abc");
+        assert_eq!(v["request"]["subtype"], "interrupt");
+    }
+
+    #[test]
+    fn claude_encodes_set_permission_mode_plan() {
+        let agent = Claude;
+        let bytes = agent
+            .encode_stream_set_permission_mode("req_1", "plan")
+            .expect("encode");
+        assert!(bytes.ends_with(b"\n"));
+        let v: serde_json::Value =
+            serde_json::from_slice(&bytes[..bytes.len() - 1]).expect("json");
+        assert_eq!(v["type"], "control_request");
+        assert_eq!(v["request_id"], "req_1");
+        assert_eq!(v["request"]["subtype"], "set_permission_mode");
+        assert_eq!(v["request"]["mode"], "plan");
+    }
+
+    #[test]
+    fn claude_encodes_set_permission_mode_default() {
+        let agent = Claude;
+        let bytes = agent
+            .encode_stream_set_permission_mode("req_2", "default")
+            .expect("encode");
+        let v: serde_json::Value =
+            serde_json::from_slice(&bytes[..bytes.len() - 1]).expect("json");
+        assert_eq!(v["request"]["mode"], "default");
+    }
+
+    #[test]
+    fn claude_encodes_set_model() {
+        let agent = Claude;
+        let bytes = agent
+            .encode_stream_set_model("req_3", Some("claude-sonnet-4-6"))
+            .expect("encode");
+        assert!(bytes.ends_with(b"\n"));
+        let v: serde_json::Value =
+            serde_json::from_slice(&bytes[..bytes.len() - 1]).expect("json");
+        assert_eq!(v["type"], "control_request");
+        assert_eq!(v["request_id"], "req_3");
+        assert_eq!(v["request"]["subtype"], "set_model");
+        assert_eq!(v["request"]["model"], "claude-sonnet-4-6");
+    }
+
+    #[test]
+    fn claude_encodes_set_model_null_resets_to_default() {
+        let agent = Claude;
+        let bytes = agent
+            .encode_stream_set_model("req_4", None)
+            .expect("encode");
+        let v: serde_json::Value =
+            serde_json::from_slice(&bytes[..bytes.len() - 1]).expect("json");
+        assert!(v["request"]["model"].is_null());
+    }
+
+    #[test]
+    fn other_agents_reject_stream_encoders_by_default() {
+        for agent in [
+            Box::new(Codex) as Box<dyn Agent>,
+            Box::new(Cursor),
+            Box::new(Gemini),
+            Box::new(OpenCode),
+        ] {
+            assert!(agent.encode_stream_user_message("x", &[]).is_err());
+            assert!(agent.encode_stream_interrupt("req_x").is_err());
+            assert!(agent
+                .encode_stream_set_permission_mode("req_x", "plan")
+                .is_err());
+            assert!(agent
+                .encode_stream_set_model("req_x", Some("m"))
+                .is_err());
+        }
     }
 
     // ── Codex ───────────────────────────────────────────────────────────

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -5,7 +5,7 @@ use crate::lsp::LspMap;
 use crate::pty::{self, ActivePtyMap};
 use crate::task::{
     self, ActiveMap, ApprovalResponse, HookPtyMap, PendingApprovalEntry, PendingApprovalMeta,
-    PendingApprovals, SetupInProgress,
+    PendingApprovals, PendingControlResponses, SetupInProgress,
 };
 use crate::tsgo_check::TsgoCheckMap;
 use crate::watcher::FileWatcherMap;
@@ -620,6 +620,7 @@ pub async fn send_message(
     active: State<'_, ActiveMap>,
     pending: State<'_, PendingApprovals>,
     pending_meta: State<'_, PendingApprovalMeta>,
+    pending_ctrl: State<'_, PendingControlResponses>,
     session_id: String,
     message: String,
     attachments: Option<Vec<task::Attachment>>,
@@ -650,6 +651,7 @@ pub async fn send_message(
         active.inner().clone(),
         pending.inner().clone(),
         pending_meta.inner().clone(),
+        pending_ctrl.inner().clone(),
         task::SendMessageParams {
             session_id,
             task_id: session.task_id.clone(),
@@ -726,6 +728,28 @@ pub async fn abort_message(
     session_id: String,
 ) -> Result<(), String> {
     task::abort_message(&app, db_tx.inner(), active.inner(), &session_id).await
+}
+
+/// Send a `control_request` `interrupt` to a running claude CLI. Cancels the
+/// current turn without killing the process, so the session can keep going on
+/// the next message.
+#[tauri::command]
+pub async fn interrupt_session(
+    active: State<'_, ActiveMap>,
+    session_id: String,
+) -> Result<(), String> {
+    task::interrupt_session(active.inner(), &session_id).await
+}
+
+/// Ask the running claude CLI for its current context-window usage and wait
+/// for the matching `control_response`.
+#[tauri::command]
+pub async fn get_session_context_usage(
+    active: State<'_, ActiveMap>,
+    pending_ctrl: State<'_, PendingControlResponses>,
+    session_id: String,
+) -> Result<serde_json::Value, String> {
+    task::get_session_context_usage(active.inner(), pending_ctrl.inner(), &session_id).await
 }
 
 /// Return session IDs that currently have an active process

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -674,6 +674,75 @@ pub async fn send_message(
     .await
 }
 
+/// Pre-warm a persistent-agent session by spawning its CLI in the background
+/// so the first `send_message` doesn't pay the boot cost. Best-effort: no-op
+/// for non-persistent agents (Codex/Gemini/Cursor), already-warm sessions, or
+/// any failure — the normal spawn path will take over on the next send.
+#[allow(clippy::too_many_arguments)]
+#[tauri::command]
+pub async fn prewarm_session(
+    app: AppHandle,
+    pool: State<'_, SqlitePool>,
+    db_tx: State<'_, DbWriteTx>,
+    active: State<'_, ActiveMap>,
+    pending: State<'_, PendingApprovals>,
+    pending_meta: State<'_, PendingApprovalMeta>,
+    pending_ctrl: State<'_, PendingControlResponses>,
+    session_id: String,
+) -> Result<(), String> {
+    let session = match db::get_session(pool.inner(), &session_id).await? {
+        Some(s) => s,
+        None => return Ok(()), // session closed or gone
+    };
+
+    let agent = crate::agent::AgentKind::parse(&session.agent_type).implementation();
+    if !agent.persists_across_turns() {
+        return Ok(());
+    }
+    if active.contains_key(&session_id) {
+        return Ok(()); // already warm
+    }
+
+    let t = match db::get_task(pool.inner(), &session.task_id).await? {
+        Some(t) => t,
+        None => return Ok(()),
+    };
+    let (trust_result, repo_result) = tokio::join!(
+        db::get_trust_level(pool.inner(), &session.task_id),
+        db::get_repo_path_for_task(pool.inner(), &session.task_id),
+    );
+    let trust_level = crate::policy::TrustLevel::from_str(&trust_result?);
+    let repo_path = repo_result?;
+
+    task::spawn_session_process(
+        app,
+        db_tx.inner().clone(),
+        active.inner().clone(),
+        pending.inner().clone(),
+        pending_meta.inner().clone(),
+        pending_ctrl.inner().clone(),
+        task::SpawnSessionParams {
+            session_id,
+            task_id: session.task_id.clone(),
+            project_id: t.project_id,
+            worktree_path: t.worktree_path,
+            repo_path,
+            port_offset: t.port_offset,
+            trust_level,
+            resume_session_id: session.resume_session_id,
+            model: session.model,
+            plan_mode: false,
+            thinking_mode: false,
+            fast_mode: false,
+            agent_type: session.agent_type.clone(),
+            message: String::new(),
+            attachments: Vec::new(),
+            prewarm: true,
+        },
+    )
+    .await
+}
+
 #[tauri::command]
 pub async fn update_session_model(
     db_tx: State<'_, DbWriteTx>,
@@ -691,7 +760,16 @@ pub async fn update_session_model(
 
 /// Close a session (hides from UI, persists in DB as 'closed')
 #[tauri::command]
-pub async fn close_session(db_tx: State<'_, DbWriteTx>, session_id: String) -> Result<(), String> {
+pub async fn close_session(
+    active: State<'_, ActiveMap>,
+    db_tx: State<'_, DbWriteTx>,
+    session_id: String,
+) -> Result<(), String> {
+    // Persistent agents keep a live CLI across turns — kill it before DB close
+    // so we don't leak a pid after the tab disappears.
+    if let Some((_, mut proc)) = active.remove(&session_id) {
+        task::graceful_shutdown(&mut proc.child, &proc.stdin).await;
+    }
     db_tx
         .send(db::DbWrite::CloseSession { id: session_id })
         .await
@@ -700,7 +778,17 @@ pub async fn close_session(db_tx: State<'_, DbWriteTx>, session_id: String) -> R
 
 /// Clear a session's Claude context (reset session_id + delete output lines)
 #[tauri::command]
-pub async fn clear_session(db_tx: State<'_, DbWriteTx>, session_id: String) -> Result<(), String> {
+pub async fn clear_session(
+    active: State<'_, ActiveMap>,
+    db_tx: State<'_, DbWriteTx>,
+    session_id: String,
+) -> Result<(), String> {
+    // If a persistent CLI is running on the old session, shut it down so the
+    // next message starts fresh instead of resuming the old context.
+    if let Some((_, mut proc)) = active.remove(&session_id) {
+        task::graceful_shutdown(&mut proc.child, &proc.stdin).await;
+    }
+
     // Clear the resume_session_id so next message starts fresh
     db_tx
         .send(db::DbWrite::SetResumeSessionId {
@@ -766,11 +854,13 @@ pub async fn respond_to_approval(
     request_id: String,
     behavior: String,
     updated_input: Option<serde_json::Value>,
+    message: Option<String>,
 ) -> Result<(), String> {
     if let Some((_, tx)) = pending.remove(&request_id) {
         let _ = tx.send(ApprovalResponse {
             behavior,
             updated_input,
+            message,
         });
         Ok(())
     } else {
@@ -2221,7 +2311,15 @@ pub async fn tsgo_check_cancel(
 }
 
 #[tauri::command]
-pub fn quit_app() {
+pub async fn quit_app(active: State<'_, ActiveMap>) -> Result<(), String> {
+    // Persistent agents keep CLIs alive across turns; drain them all so we
+    // don't leak orphan processes after the app exits.
+    let session_ids: Vec<String> = active.iter().map(|e| e.key().clone()).collect();
+    for sid in session_ids {
+        if let Some((_, mut proc)) = active.remove(&sid) {
+            task::graceful_shutdown(&mut proc.child, &proc.stdin).await;
+        }
+    }
     std::process::exit(0);
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -252,6 +252,7 @@ pub fn run() {
             // Sessions
             ipc::create_session,
             ipc::send_message,
+            ipc::prewarm_session,
             ipc::update_session_model,
             ipc::close_session,
             ipc::clear_session,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -44,6 +44,7 @@ pub fn run() {
         .manage(task::new_active_map())
         .manage(task::new_pending_approvals())
         .manage(task::new_pending_approval_meta())
+        .manage(task::new_pending_control_responses())
         .manage(task::new_setup_in_progress())
         .manage(task::new_hook_pty_map())
         .manage(pty::new_active_pty_map())
@@ -255,6 +256,8 @@ pub fn run() {
             ipc::close_session,
             ipc::clear_session,
             ipc::abort_message,
+            ipc::interrupt_session,
+            ipc::get_session_context_usage,
             ipc::get_active_sessions,
             ipc::respond_to_approval,
             ipc::get_pending_approvals,

--- a/src-tauri/src/stream.rs
+++ b/src-tauri/src/stream.rs
@@ -8,6 +8,7 @@ use crate::task::{
 };
 use serde::Serialize;
 use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter};
@@ -53,6 +54,15 @@ pub enum OutputItem {
     /// System/status message
     #[serde(rename_all = "camelCase")]
     System { text: String },
+
+    /// Provider error (API failure, auth, overload, prompt-too-long, etc.).
+    /// Carries the human message plus the raw source JSON so the frontend
+    /// can show a persistent retry banner with an expandable details panel.
+    #[serde(rename_all = "camelCase")]
+    ErrorMessage {
+        message: String,
+        raw: Option<String>,
+    },
 
     /// Turn completed
     #[serde(rename_all = "camelCase")]
@@ -225,7 +235,13 @@ fn parse_sdk_event_value(v: &serde_json::Value) -> Vec<OutputItem> {
                         None
                     }
                 });
-            let status = if is_error || status_str != "success" {
+            // `error_during_execution` is how the Claude CLI signals that the
+            // user aborted the turn via `control_request interrupt`. Treat it
+            // as a distinct `interrupted` status so the renderer can suppress
+            // the bubble (the user already knows they hit stop).
+            let status = if status_str == "error_during_execution" {
+                "interrupted"
+            } else if is_error || status_str != "success" {
                 "error"
             } else {
                 "completed"
@@ -745,14 +761,21 @@ fn parse_stream_event(v: &serde_json::Value) -> Vec<OutputItem> {
 /// in real-time, so the snapshot is redundant for those. We skip it to avoid duplication.
 /// However, we DO extract tool_use blocks since content_block_start may not always arrive.
 fn parse_assistant_message(v: &serde_json::Value) -> Vec<OutputItem> {
-    let content = match v
-        .get("message")
-        .and_then(|m| m.get("content"))
-        .and_then(|c| c.as_array())
-    {
+    let message = match v.get("message") {
+        Some(m) => m,
+        None => return vec![],
+    };
+    let content = match message.get("content").and_then(|c| c.as_array()) {
         Some(c) => c,
         None => return vec![],
     };
+
+    // Synthetic assistant snapshots (e.g. "Prompt is too long", API errors)
+    // arrive with `model: "<synthetic>"` and carry the error text as a text
+    // block — they never have stream_event deltas, so skipping text here
+    // would drop the message entirely. For regular assistant snapshots text
+    // is already delivered via deltas, so we skip it to avoid duplication.
+    let is_synthetic = message.get("model").and_then(|m| m.as_str()) == Some("<synthetic>");
 
     let mut items = Vec::new();
     for block in content {
@@ -775,6 +798,17 @@ fn parse_assistant_message(v: &serde_json::Value) -> Vec<OutputItem> {
                     tool: name.to_string(),
                     input: input_str,
                 });
+            }
+            "text" if is_synthetic => {
+                if let Some(text) = block.get("text").and_then(|t| t.as_str()) {
+                    if !text.is_empty() {
+                        let raw = serde_json::to_string(v).ok();
+                        items.push(OutputItem::ErrorMessage {
+                            message: text.to_string(),
+                            raw,
+                        });
+                    }
+                }
             }
             _ => {}
         }
@@ -1047,6 +1081,7 @@ pub async fn stream_and_capture(
     task_id: String,
     stdout: ChildStdout,
     stdin: Arc<TokioMutex<Option<ChildStdin>>>,
+    busy: Arc<AtomicBool>,
     pending_approvals: PendingApprovals,
     pending_approval_meta: PendingApprovalMeta,
     pending_control_responses: PendingControlResponses,
@@ -1077,8 +1112,7 @@ pub async fn stream_and_capture(
             line = reader.next_line() => {
                 match line {
                     Ok(Some(line)) => {
-                        let preview = if line.len() > 200 { &line[..200] } else { &line };
-                        eprintln!("[verun][stream][{session_id}] {preview}");
+                        eprintln!("[verun][stream][{session_id}] {line}");
 
                         // Cleanly skip non-JSON garbage (e.g. `[SandboxDebug]` lines the CLI
                         // can interleave under permission/sandbox modes). Matches the
@@ -1086,8 +1120,7 @@ pub async fn stream_and_capture(
                         let trimmed = line.trim_start();
                         if !trimmed.starts_with('{') {
                             if !trimmed.is_empty() {
-                                eprintln!("[verun][stream][{session_id}] skipping non-JSON: {}",
-                                    trimmed.chars().take(200).collect::<String>());
+                                eprintln!("[verun][stream][{session_id}] skipping non-JSON: {trimmed}");
                             }
                             continue;
                         }
@@ -1224,11 +1257,36 @@ pub async fn stream_and_capture(
                             }
                         }
 
-                        // Close stdin after turn completes so the CLI process can exit
+                        // For one-shot-per-turn agents (e.g. Codex), close stdin so
+                        // the CLI exits and we respawn on next send. For persistent
+                        // agents (Claude), keep stdin open — `busy=false` signals the
+                        // process is ready for the next turn. Since the process never
+                        // exits, the monitor's post-stream status emission never fires,
+                        // so we emit it here: idle on success, error (with the provider
+                        // message) on an API/auth failure so the retry banner renders.
                         if is_turn_end {
-                            // Take the ChildStdin out and drop it to close the fd (sends EOF)
-                            let mut guard = stdin.lock().await;
-                            drop(guard.take());
+                            if !agent.persists_across_turns() {
+                                let mut guard = stdin.lock().await;
+                                drop(guard.take());
+                            } else {
+                                let (status, error) = turn_end_session_status(&last_error);
+                                let _ = db_tx.send(DbWrite::UpdateSessionStatus {
+                                    id: session_id.clone(),
+                                    status: status.to_string(),
+                                }).await;
+                                let _ = app.emit(
+                                    "session-status",
+                                    SessionStatusEvent {
+                                        session_id: session_id.clone(),
+                                        status: status.to_string(),
+                                        error,
+                                    },
+                                );
+                                // Clear so the next turn starts clean — the error is
+                                // associated with the turn that just ended, not future ones.
+                                last_error = None;
+                            }
+                            busy.store(false, Ordering::SeqCst);
                         }
 
                         // Flush buffer. On turn end we ALWAYS flush so the TurnEnd
@@ -1442,9 +1500,9 @@ async fn handle_control_request(
                 },
             );
 
-            let (behavior, updated_input) = match rx.await {
-                Ok(resp) => (resp.behavior, resp.updated_input),
-                Err(_) => ("deny".to_string(), None),
+            let (behavior, updated_input, deny_message) = match rx.await {
+                Ok(resp) => (resp.behavior, resp.updated_input, resp.message),
+                Err(_) => ("deny".to_string(), None, None),
             };
 
             pending_approvals.remove(&request_id);
@@ -1457,9 +1515,10 @@ async fn handle_control_request(
                     "updatedInput": input
                 })
             } else {
+                let msg = deny_message.unwrap_or_else(|| "User denied this action".to_string());
                 serde_json::json!({
                     "behavior": "deny",
-                    "message": "User denied this action",
+                    "message": msg,
                     "interrupt": false
                 })
             };
@@ -1550,6 +1609,17 @@ pub fn map_exit_status(code: Option<i32>) -> &'static str {
         Some(0) => "done",
         Some(_) => "error",
         None => "error",
+    }
+}
+
+/// Decide the `session-status` event payload to emit at turn_end for a
+/// persistent agent. The process stays alive, so we can't wait for exit —
+/// a turn-level error (e.g. API 401, overload) must propagate as the
+/// session status so the frontend can render the retry banner.
+pub fn turn_end_session_status(err: &Option<String>) -> (&'static str, Option<String>) {
+    match err {
+        Some(msg) => ("error", Some(msg.clone())),
+        None => ("idle", None),
     }
 }
 
@@ -1702,6 +1772,69 @@ mod tests {
             OutputItem::Raw { text } => assert_eq!(text, "not json at all"),
             _ => panic!("Expected Raw item"),
         }
+    }
+
+    #[test]
+    fn turn_end_session_status_idle_when_no_error() {
+        let (status, err) = turn_end_session_status(&None);
+        assert_eq!(status, "idle");
+        assert!(err.is_none());
+    }
+
+    #[test]
+    fn turn_end_session_status_error_when_present() {
+        // Regression: auth/API errors on persistent Claude sessions were
+        // dropped because the persistent-agent turn_end branch always
+        // emitted idle. The red retry banner depends on status=error +
+        // the provider message propagating through session-status.
+        let msg = "API Error: 401 authentication_error".to_string();
+        let (status, err) = turn_end_session_status(&Some(msg.clone()));
+        assert_eq!(status, "error");
+        assert_eq!(err.as_deref(), Some(msg.as_str()));
+    }
+
+    #[test]
+    fn parse_result_error_during_execution_maps_to_interrupted() {
+        // Claude CLI emits this subtype when the user sends a
+        // `control_request interrupt` mid-turn. It is NOT an error worth
+        // surfacing as a red bubble in chat — the user already knows they
+        // hit stop. We map it to a distinct `interrupted` status so the
+        // renderer can suppress the bubble entirely.
+        let line = r#"{"type":"result","subtype":"error_during_execution","is_error":true,"duration_ms":1000,"session_id":"abc"}"#;
+        let items = parse_sdk_event(line);
+        assert_eq!(items.len(), 1);
+        match &items[0] {
+            OutputItem::TurnEnd { status, error, .. } => {
+                assert_eq!(status, "interrupted");
+                assert!(error.is_none(), "interrupt should not carry an error");
+            }
+            _ => panic!("Expected TurnEnd item"),
+        }
+    }
+
+    #[test]
+    fn parse_assistant_synthetic_error_emits_error_message_with_raw() {
+        // When the Claude API returns an error mid-turn (e.g. "Prompt is
+        // too long"), the CLI emits a synthetic assistant message with
+        // `model: "<synthetic>"` and a text block carrying the error
+        // message. We surface it as an `ErrorMessage` item so the UI can
+        // render a single persistent retry banner (no duplicate text / sys
+        // bubbles) with the raw JSON available for "Show details".
+        let line = r#"{"type":"assistant","message":{"id":"x","model":"<synthetic>","role":"assistant","type":"message","content":[{"type":"text","text":"Prompt is too long"}]},"session_id":"abc","uuid":"u","error":"invalid_request"}"#;
+        let items = parse_sdk_event(line);
+        let err = items.iter().find_map(|i| match i {
+            OutputItem::ErrorMessage { message, raw } => Some((message.clone(), raw.clone())),
+            _ => None,
+        });
+        let (message, raw) = err.expect("expected ErrorMessage item");
+        assert_eq!(message, "Prompt is too long");
+        let raw = raw.expect("expected raw JSON payload");
+        assert!(raw.contains("\"<synthetic>\""), "raw should carry source JSON: {raw}");
+        // Should NOT emit a duplicate plain Text item for the same synthetic error.
+        assert!(
+            !items.iter().any(|i| matches!(i, OutputItem::Text { .. })),
+            "synthetic error must not also emit a plain Text item: {items:?}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/stream.rs
+++ b/src-tauri/src/stream.rs
@@ -2,7 +2,10 @@ use crate::claude_jsonl;
 use crate::db::{DbWrite, DbWriteTx};
 use crate::policy::{self, PolicyDecision, TrustLevel};
 use crate::snapshots;
-use crate::task::{ApprovalResponse, PendingApprovalEntry, PendingApprovalMeta, PendingApprovals};
+use crate::task::{
+    ApprovalResponse, PendingApprovalEntry, PendingApprovalMeta, PendingApprovals,
+    PendingControlResponses,
+};
 use serde::Serialize;
 use std::path::Path;
 use std::sync::Arc;
@@ -152,21 +155,26 @@ pub struct PolicyAutoApprovedEvent {
 // ---------------------------------------------------------------------------
 
 /// Parse a single NDJSON line from Claude's stream-json output into OutputItems.
+///
+/// Kept for tests and rare call sites that only have the raw line. The stream
+/// loop itself parses once upfront and calls `parse_sdk_event_value` directly to
+/// avoid re-parsing the same line two or three times per tick.
+#[cfg_attr(not(test), allow(dead_code))]
 fn parse_sdk_event(line: &str) -> Vec<OutputItem> {
-    let v: serde_json::Value = match serde_json::from_str(line) {
-        Ok(v) => v,
-        Err(_) => {
-            return vec![OutputItem::Raw {
-                text: line.to_string(),
-            }]
-        }
-    };
+    match serde_json::from_str::<serde_json::Value>(line) {
+        Ok(v) => parse_sdk_event_value(&v),
+        Err(_) => vec![OutputItem::Raw {
+            text: line.to_string(),
+        }],
+    }
+}
 
+fn parse_sdk_event_value(v: &serde_json::Value) -> Vec<OutputItem> {
     let msg_type = v.get("type").and_then(|t| t.as_str()).unwrap_or("");
 
     match msg_type {
         // -- Streaming token deltas (real-time) --
-        "stream_event" => parse_stream_event(&v),
+        "stream_event" => parse_stream_event(v),
 
         // -- Assistant message --
         // Cursor with --stream-partial-output sends per-token `assistant` events
@@ -174,24 +182,20 @@ fn parse_sdk_event(line: &str) -> Vec<OutputItem> {
         "assistant" => {
             if v.get("timestamp_ms").is_some() {
                 // Streaming delta: extract just the text content
-                parse_assistant_text_only(&v)
+                parse_assistant_text_only(v)
             } else {
                 // Final snapshot or non-streaming: extract text + tool_use blocks
-                parse_assistant_message(&v)
+                parse_assistant_message(v)
             }
         }
 
         // -- User message (tool results) --
-        "user" => parse_user_message(&v),
+        "user" => parse_user_message(v),
 
         // -- System messages --
-        "system" => {
-            if v.get("subtype").and_then(|s| s.as_str()) == Some("init") {
-                vec![]
-            } else {
-                vec![]
-            }
-        }
+        // `system.init` gives us the resume id (extracted in stream_and_capture);
+        // other system subtypes are silently ignored.
+        "system" => vec![],
 
         // -- Result (turn completed) --
         // Text is already delivered via stream_event deltas; skip result.result to avoid duplication.
@@ -1045,6 +1049,7 @@ pub async fn stream_and_capture(
     stdin: Arc<TokioMutex<Option<ChildStdin>>>,
     pending_approvals: PendingApprovals,
     pending_approval_meta: PendingApprovalMeta,
+    pending_control_responses: PendingControlResponses,
     db_tx: DbWriteTx,
     worktree_path: String,
     repo_path: String,
@@ -1074,15 +1079,66 @@ pub async fn stream_and_capture(
                     Ok(Some(line)) => {
                         let preview = if line.len() > 200 { &line[..200] } else { &line };
                         eprintln!("[verun][stream][{session_id}] {preview}");
+
+                        // Cleanly skip non-JSON garbage (e.g. `[SandboxDebug]` lines the CLI
+                        // can interleave under permission/sandbox modes). Matches the
+                        // claude-agent-sdk-python fix for issue #347.
+                        let trimmed = line.trim_start();
+                        if !trimmed.starts_with('{') {
+                            if !trimmed.is_empty() {
+                                eprintln!("[verun][stream][{session_id}] skipping non-JSON: {}",
+                                    trimmed.chars().take(200).collect::<String>());
+                            }
+                            continue;
+                        }
+
+                        // Parse each line exactly once. Every downstream check (control_request,
+                        // control_response, resume_id extraction, rate_limit, event parse) now
+                        // works off this one `Value`.
+                        let v: serde_json::Value = match serde_json::from_str(&line) {
+                            Ok(v) => v,
+                            Err(e) => {
+                                eprintln!("[verun][stream][{session_id}] JSON parse error: {e}");
+                                // Keep the raw line visible in the UI rather than silently dropping it
+                                let items = vec![OutputItem::Raw { text: line.clone() }];
+                                for item in &items { buffer.push(item.clone()); }
+                                persist_items(&db_tx, &session_id, &items, &mut total_persisted);
+                                continue;
+                            }
+                        };
+                        let msg_type = v.get("type").and_then(|t| t.as_str()).unwrap_or("");
+
+                        // Incoming `control_response` — resolve the matching pending oneshot so
+                        // IPC callers like `interrupt_session` / `get_session_context_usage`
+                        // can unblock. No UI emission for these.
+                        if msg_type == "control_response" {
+                            if let Some(response) = v.get("response") {
+                                if let Some(req_id) = response.get("request_id").and_then(|r| r.as_str()) {
+                                    if let Some((_, tx)) = pending_control_responses.remove(req_id) {
+                                        let subtype = response.get("subtype").and_then(|s| s.as_str()).unwrap_or("");
+                                        let result = if subtype == "error" {
+                                            Err(response.get("error")
+                                                .and_then(|e| e.as_str())
+                                                .unwrap_or("CLI returned error")
+                                                .to_string())
+                                        } else {
+                                            Ok(response.get("response").cloned().unwrap_or(serde_json::Value::Null))
+                                        };
+                                        let _ = tx.send(result);
+                                    }
+                                }
+                            }
+                            continue;
+                        }
+
                         // Intercept control_request for tool approval
                         if let Some(cr) = handle_control_request(
-                            &app, &session_id, &task_id, &line, &stdin,
+                            &app, &session_id, &task_id, &v, &stdin,
                             &pending_approvals, &pending_approval_meta,
                             &worktree_path, &repo_path,
                             trust_level, &db_tx,
                         ).await {
                             if cr.handled {
-                                // Emit ToolStart so the frontend knows which tool is running
                                 if let Some(tool_start) = cr.tool_start {
                                     buffer.push(tool_start.clone());
                                     persist_items(&db_tx, &session_id, &[tool_start], &mut total_persisted);
@@ -1093,41 +1149,37 @@ pub async fn stream_and_capture(
 
                         // Extract the resume session id via the agent's own logic
                         if resume_id_for_snapshot.is_none() {
-                            if let Ok(v) = serde_json::from_str::<serde_json::Value>(&line) {
-                                if let Some(sid) = agent.extract_resume_id(&v) {
-                                    resume_id_for_snapshot = Some(sid.clone());
-                                    if defers_resume {
-                                        pending_resume_id = Some(sid);
-                                    } else {
-                                        let _ = db_tx.send(crate::db::DbWrite::SetResumeSessionId {
-                                            id: session_id.clone(),
-                                            resume_session_id: sid,
-                                        }).await;
-                                    }
+                            if let Some(sid) = agent.extract_resume_id(&v) {
+                                resume_id_for_snapshot = Some(sid.clone());
+                                if defers_resume {
+                                    pending_resume_id = Some(sid);
+                                } else {
+                                    let _ = db_tx.send(crate::db::DbWrite::SetResumeSessionId {
+                                        id: session_id.clone(),
+                                        resume_session_id: sid,
+                                    }).await;
                                 }
                             }
                         }
 
                         // Intercept rate_limit_event — emit as separate Tauri event
-                        if let Ok(v) = serde_json::from_str::<serde_json::Value>(&line) {
-                            if v.get("type").and_then(|t| t.as_str()) == Some("rate_limit_event") {
-                                if let Some(info) = v.get("rate_limit_info") {
-                                    let _ = app.emit("rate-limit-info", RateLimitInfoEvent {
-                                        session_id: session_id.clone(),
-                                        resets_at: info.get("resetsAt").and_then(|r| r.as_i64()).unwrap_or(0),
-                                        overage_resets_at: info.get("overageResetsAt").and_then(|r| r.as_i64()).unwrap_or(0),
-                                        rate_limit_type: info.get("rateLimitType").and_then(|r| r.as_str()).unwrap_or("").to_string(),
-                                        overage_status: info.get("overageStatus").and_then(|r| r.as_str()).unwrap_or("").to_string(),
-                                        is_using_overage: info.get("isUsingOverage").and_then(|r| r.as_bool()).unwrap_or(false),
-                                    });
-                                }
-                                persist_line(&db_tx, &session_id, &line, &mut total_persisted);
-                                continue;
+                        if msg_type == "rate_limit_event" {
+                            if let Some(info) = v.get("rate_limit_info") {
+                                let _ = app.emit("rate-limit-info", RateLimitInfoEvent {
+                                    session_id: session_id.clone(),
+                                    resets_at: info.get("resetsAt").and_then(|r| r.as_i64()).unwrap_or(0),
+                                    overage_resets_at: info.get("overageResetsAt").and_then(|r| r.as_i64()).unwrap_or(0),
+                                    rate_limit_type: info.get("rateLimitType").and_then(|r| r.as_str()).unwrap_or("").to_string(),
+                                    overage_status: info.get("overageStatus").and_then(|r| r.as_str()).unwrap_or("").to_string(),
+                                    is_using_overage: info.get("isUsingOverage").and_then(|r| r.as_bool()).unwrap_or(false),
+                                });
                             }
+                            persist_line(&db_tx, &session_id, &line, &mut total_persisted);
+                            continue;
                         }
 
-                        // Parse NDJSON into structured items
-                        let items = parse_sdk_event(&line);
+                        // Parse NDJSON into structured items (already have Value — no re-parse)
+                        let items = parse_sdk_event_value(&v);
 
                         // Emit text/thinking deltas immediately for real-time streaming
                         let mut has_immediate = false;
@@ -1248,7 +1300,7 @@ async fn handle_control_request(
     app: &AppHandle,
     session_id: &str,
     task_id: &str,
-    line: &str,
+    v: &serde_json::Value,
     stdin: &Arc<TokioMutex<Option<ChildStdin>>>,
     pending_approvals: &PendingApprovals,
     pending_meta: &PendingApprovalMeta,
@@ -1257,8 +1309,6 @@ async fn handle_control_request(
     trust_level: TrustLevel,
     db_tx: &DbWriteTx,
 ) -> Option<ControlRequestResult> {
-    let v: serde_json::Value = serde_json::from_str(line).ok()?;
-
     if v.get("type").and_then(|t| t.as_str()) != Some("control_request") {
         return Some(ControlRequestResult {
             handled: false,

--- a/src-tauri/src/task.rs
+++ b/src-tauri/src/task.rs
@@ -6,6 +6,7 @@ use crate::worktree;
 use dashmap::DashMap;
 use serde::Deserialize;
 use std::sync::Arc;
+use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 use tokio::process::{Child, ChildStdin};
@@ -342,6 +343,55 @@ pub fn new_pending_approval_meta() -> PendingApprovalMeta {
     Arc::new(DashMap::new())
 }
 
+/// request_id → oneshot channel awaiting a matching `control_response` from the CLI.
+/// Used by IPC callers that issue `control_request`s (interrupt, get_context_usage, ...)
+/// and need to correlate the async reply.
+pub type PendingControlResponses =
+    Arc<DashMap<String, oneshot::Sender<Result<serde_json::Value, String>>>>;
+
+pub fn new_pending_control_responses() -> PendingControlResponses {
+    Arc::new(DashMap::new())
+}
+
+/// Best-effort graceful shutdown of a claude CLI subprocess. Matches the cadence
+/// the official claude-agent-sdk-python uses: EOF on stdin, then a 5s grace,
+/// then SIGTERM + 5s, then SIGKILL.
+///
+/// Why: hard SIGKILL interrupts the CLI mid-write of its session JSONL file,
+/// causing the last assistant message to be lost on `--resume` (python-sdk #625/#729).
+pub async fn graceful_shutdown(child: &mut Child, stdin: &Arc<TokioMutex<Option<ChildStdin>>>) {
+    // 1. Drop stdin to send EOF — lets the CLI flush its transcript and exit cleanly.
+    {
+        let mut guard = stdin.lock().await;
+        drop(guard.take());
+    }
+
+    // 2. Wait up to 5s for natural exit.
+    if tokio::time::timeout(Duration::from_secs(5), child.wait())
+        .await
+        .is_ok()
+    {
+        return;
+    }
+
+    // 3. SIGTERM. tokio::process::Child only exposes SIGKILL directly; send SIGTERM via libc.
+    if let Some(pid) = child.id() {
+        unsafe {
+            libc::kill(pid as i32, libc::SIGTERM);
+        }
+    }
+    if tokio::time::timeout(Duration::from_secs(5), child.wait())
+        .await
+        .is_ok()
+    {
+        return;
+    }
+
+    // 4. SIGKILL as last resort.
+    let _ = child.start_kill();
+    let _ = child.wait().await;
+}
+
 // ---------------------------------------------------------------------------
 // Task lifecycle
 // ---------------------------------------------------------------------------
@@ -662,12 +712,14 @@ pub struct SendMessageParams {
 /// Send a message to Claude in this session's worktree.
 /// Always uses `--input-format stream-json` and pipes content via stdin, keeping stdin
 /// open so we can write `control_response` messages for tool approval.
+#[allow(clippy::too_many_arguments)]
 pub async fn send_message(
     app: AppHandle,
     db_tx: &DbWriteTx,
     active: ActiveMap,
     pending_approvals: PendingApprovals,
     pending_approval_meta: PendingApprovalMeta,
+    pending_control_responses: PendingControlResponses,
     params: SendMessageParams,
 ) -> Result<(), String> {
     let SendMessageParams {
@@ -794,6 +846,10 @@ pub async fn send_message(
     for (k, v) in worktree::verun_env_vars(port_offset, &repo_path) {
         cmd.env(&k, &v);
     }
+    // Match claude-agent-sdk-python: strip `CLAUDECODE` (issue #573) so the spawned
+    // CLI doesn't detect itself as nested, and tag the entrypoint for Anthropic telemetry.
+    cmd.env_remove("CLAUDECODE");
+    cmd.env("CLAUDE_CODE_ENTRYPOINT", "verun");
     cmd.stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
@@ -921,6 +977,7 @@ pub async fn send_message(
     let monitor_active = active.clone();
     let monitor_pending = pending_approvals.clone();
     let monitor_pending_meta = pending_approval_meta.clone();
+    let monitor_pending_ctrl = pending_control_responses.clone();
     let monitor_wt = worktree_path.clone();
     let monitor_repo = repo_path;
     let monitor_trust = trust_level;
@@ -936,6 +993,7 @@ pub async fn send_message(
             stdin,
             monitor_pending,
             monitor_pending_meta,
+            monitor_pending_ctrl,
             monitor_db_tx.clone(),
             monitor_wt,
             monitor_repo,
@@ -1053,7 +1111,11 @@ pub async fn abort_message(
     session_id: &str,
 ) -> Result<(), String> {
     if let Some((_, mut proc)) = active.remove(session_id) {
-        let _ = proc.child.kill().await;
+        // Do the EOF → SIGTERM → SIGKILL dance in the background so the UI
+        // doesn't block on the grace period.
+        tokio::spawn(async move {
+            graceful_shutdown(&mut proc.child, &proc.stdin).await;
+        });
 
         // Update session status so the UI reflects the abort
         let _ = db_tx
@@ -1075,6 +1137,122 @@ pub async fn abort_message(
     Ok(())
 }
 
+// ---------------------------------------------------------------------------
+// Control protocol helpers — send `control_request` to a running CLI over stdin
+// and correlate the `control_response` reply.
+// ---------------------------------------------------------------------------
+
+/// Generate a unique request id matching the claude-agent-sdk format.
+fn new_control_request_id() -> String {
+    let mut bytes = [0u8; 4];
+    getrandom_bytes(&mut bytes);
+    let hex: String = bytes.iter().map(|b| format!("{b:02x}")).collect();
+    format!("req_{}_{hex}", uuid::Uuid::new_v4().simple())
+}
+
+/// Tiny wrapper around /dev/urandom — avoids pulling in a new crate just for 4 bytes.
+fn getrandom_bytes(buf: &mut [u8]) {
+    use std::io::Read;
+    if let Ok(mut f) = std::fs::File::open("/dev/urandom") {
+        let _ = f.read_exact(buf);
+    }
+}
+
+/// Write a `control_request` JSON line to the given stdin and optionally register
+/// a oneshot to await the matching `control_response`. Returns the request id.
+async fn send_control_request(
+    stdin: &Arc<TokioMutex<Option<ChildStdin>>>,
+    pending: Option<&PendingControlResponses>,
+    request: serde_json::Value,
+) -> Result<
+    (
+        String,
+        Option<oneshot::Receiver<Result<serde_json::Value, String>>>,
+    ),
+    String,
+> {
+    let request_id = new_control_request_id();
+    let envelope = serde_json::json!({
+        "type": "control_request",
+        "request_id": request_id,
+        "request": request,
+    });
+
+    let mut payload = serde_json::to_string(&envelope).map_err(|e| e.to_string())?;
+    payload.push('\n');
+
+    let rx = if let Some(pending) = pending {
+        let (tx, rx) = oneshot::channel();
+        pending.insert(request_id.clone(), tx);
+        Some(rx)
+    } else {
+        None
+    };
+
+    let mut guard = stdin.lock().await;
+    let writer = guard
+        .as_mut()
+        .ok_or_else(|| "Session stdin is closed".to_string())?;
+    writer
+        .write_all(payload.as_bytes())
+        .await
+        .map_err(|e| e.to_string())?;
+    writer.flush().await.map_err(|e| e.to_string())?;
+
+    Ok((request_id, rx))
+}
+
+/// Send `{subtype: "interrupt"}` to cancel the current turn without killing the process.
+/// Fire-and-forget — the CLI ACKs via a control_response we don't need to inspect.
+pub async fn interrupt_session(active: &ActiveMap, session_id: &str) -> Result<(), String> {
+    let stdin = active
+        .get(session_id)
+        .map(|proc| proc.stdin.clone())
+        .ok_or_else(|| "No active session".to_string())?;
+
+    let (_req_id, _rx) = send_control_request(
+        &stdin,
+        None,
+        serde_json::json!({ "subtype": "interrupt" }),
+    )
+    .await?;
+    Ok(())
+}
+
+/// Ask the CLI for the current context-window usage, awaiting the response.
+pub async fn get_session_context_usage(
+    active: &ActiveMap,
+    pending: &PendingControlResponses,
+    session_id: &str,
+) -> Result<serde_json::Value, String> {
+    let stdin = active
+        .get(session_id)
+        .map(|proc| proc.stdin.clone())
+        .ok_or_else(|| "No active session".to_string())?;
+
+    let (request_id, rx) = send_control_request(
+        &stdin,
+        Some(pending),
+        serde_json::json!({ "subtype": "get_context_usage" }),
+    )
+    .await?;
+    let rx = rx.expect("pending map provided");
+
+    let result = tokio::time::timeout(Duration::from_secs(10), rx).await;
+
+    // Always clean up the pending entry on timeout so we don't leak.
+    if result.is_err() {
+        pending.remove(&request_id);
+    }
+
+    match result {
+        Ok(Ok(Ok(v))) => Ok(v),
+        Ok(Ok(Err(e))) => Err(e),
+        Ok(Err(_)) => Err("Session closed before responding".to_string()),
+        Err(_) => Err("Timed out waiting for CLI response".to_string()),
+    }
+}
+
 /// Generate a short title using a standalone Haiku call (fast, doesn't affect session).
 /// Uses the Claude CLI regardless of agent type since title generation is a Verun feature.
 async fn generate_session_title(first_message: &str, worktree_path: &str) -> Option<String> {
@@ -1092,6 +1270,8 @@ async fn generate_session_title(first_message: &str, worktree_path: &str) -> Opt
             "--model",
             "haiku",
         ])
+        .env_remove("CLAUDECODE")
+        .env("CLAUDE_CODE_ENTRYPOINT", "verun")
         .current_dir(worktree_path)
         .output()
         .await
@@ -1652,5 +1832,14 @@ mod tests {
     fn adjectives_and_animals_have_enough_variety() {
         assert!(ADJECTIVES.len() >= 20);
         assert!(ANIMALS.len() >= 20);
+    }
+
+    #[test]
+    fn control_request_id_is_unique_and_prefixed() {
+        let a = new_control_request_id();
+        let b = new_control_request_id();
+        assert!(a.starts_with("req_"));
+        assert!(b.starts_with("req_"));
+        assert_ne!(a, b);
     }
 }

--- a/src-tauri/src/task.rs
+++ b/src-tauri/src/task.rs
@@ -5,6 +5,7 @@ use crate::stream;
 use crate::worktree;
 use dashmap::DashMap;
 use serde::Deserialize;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager};
@@ -77,9 +78,29 @@ pub fn funny_branch_name() -> String {
 pub struct ActiveProcess {
     pub child: Child,
     /// Kept alive so `stream_and_capture` can write control_response messages via the Arc clone.
-    /// Inner Option is `take()`n on turn end to close the fd and let the process exit.
-    #[allow(dead_code)]
+    /// For persistent agents this stays Some across turns; for one-shot agents it's
+    /// `take()`n on `turn_end` to close the fd and let the process exit.
     pub stdin: Arc<TokioMutex<Option<ChildStdin>>>,
+    /// True while a turn is in flight. For persistent agents the stream loop
+    /// flips this to false on `turn_end` so the next `send_message` can take
+    /// the fast path instead of erroring as "already processing".
+    pub busy: Arc<AtomicBool>,
+    /// Which agent owns this process. Lets `abort_message` /
+    /// `close_session` / app-exit dispatch on the trait without a DB read.
+    pub kind: AgentKind,
+    /// Last-applied permission mode ("default" or "plan"). Persistent-session
+    /// sends compare against this to decide whether to emit a
+    /// `set_permission_mode` control_request before the user message.
+    pub current_permission_mode: String,
+    /// Last-applied model (`None` = CLI default). Persistent-session sends
+    /// compare against this to decide whether to emit a `set_model`
+    /// control_request before the user message.
+    pub current_model: Option<String>,
+    /// Last-applied effort flag (`thinking_mode`/`fast_mode`). The Claude CLI
+    /// only accepts `--effort` at spawn — there is no mid-session control
+    /// request — so any change forces a respawn.
+    pub current_thinking_mode: bool,
+    pub current_fast_mode: bool,
 }
 
 /// session_id → currently running claude process (only while processing a message)
@@ -315,9 +336,13 @@ pub fn get_active_session_ids(active: &ActiveMap) -> Vec<String> {
 /// Response from the frontend for a tool approval request.
 /// For normal tools: behavior is "allow" or "deny".
 /// For AskUserQuestion: behavior is "allow" and updated_input contains the answers.
+/// For deny: `message` carries the user's reason (e.g. plan-viewer feedback)
+/// so Claude can continue the turn with that context instead of seeing a
+/// generic "user denied" placeholder.
 pub struct ApprovalResponse {
     pub behavior: String,
     pub updated_input: Option<serde_json::Value>,
+    pub message: Option<String>,
 }
 
 /// Stored metadata for a pending approval so it can be re-emitted on frontend reload
@@ -709,9 +734,14 @@ pub struct SendMessageParams {
     pub agent_type: String,
 }
 
-/// Send a message to Claude in this session's worktree.
-/// Always uses `--input-format stream-json` and pipes content via stdin, keeping stdin
-/// open so we can write `control_response` messages for tool approval.
+/// Send a message to the agent's CLI in this session's worktree.
+///
+/// Two paths, both trait-driven:
+/// * **Fast path** (persistent agent, process already alive): encode the
+///   user message via `agent.encode_stream_user_message` and write it to
+///   the existing stdin. No spawn, no cold start.
+/// * **Spawn path** (no live process, or non-persistent agent): build the
+///   command, spawn the child, and hand off to `spawn_session_process`.
 #[allow(clippy::too_many_arguments)]
 pub async fn send_message(
     app: AppHandle,
@@ -741,62 +771,218 @@ pub async fn send_message(
         agent_type,
     } = params;
     let agent = AgentKind::parse(&agent_type).implementation();
-    // Don't allow concurrent messages on the same session
+    let is_first_turn = resume_session_id.as_ref().is_none_or(|s| s.is_empty());
+
+    // ── Fast path: persistent agent with a live, idle process in `active` ──
+    //
+    // Three sub-decisions, evaluated against the `ActiveProcess` entry:
+    //   1. Dead / missing   → fall through to spawn path.
+    //   2. Busy             → error ("already processing").
+    //   3. Effort changed   → kill and respawn (Claude CLI only accepts
+    //                         `--effort` at spawn, no mid-session control).
+    //   4. Mode/model diff  → write `set_permission_mode` / `set_model`
+    //                         control_request frames before the user message.
+    let want_permission_mode = if plan_mode { "plan" } else { "default" };
+    if agent.persists_across_turns() {
+        enum FastPath {
+            Go {
+                stdin: Arc<TokioMutex<Option<ChildStdin>>>,
+                busy: Arc<AtomicBool>,
+                send_set_permission_mode: bool,
+                send_set_model: bool,
+            },
+            Respawn,
+            Spawn,
+        }
+
+        let decision = {
+            if let Some(mut entry) = active.get_mut(&session_id) {
+                let alive = matches!(entry.child.try_wait(), Ok(None));
+                let busy_now = entry.busy.load(Ordering::SeqCst);
+                if !alive {
+                    drop(entry);
+                    active.remove(&session_id);
+                    FastPath::Spawn
+                } else if busy_now {
+                    return Err("Session is already processing a message".to_string());
+                } else if entry.current_thinking_mode != thinking_mode
+                    || entry.current_fast_mode != fast_mode
+                {
+                    drop(entry);
+                    FastPath::Respawn
+                } else {
+                    let send_set_permission_mode =
+                        entry.current_permission_mode != want_permission_mode;
+                    let send_set_model = entry.current_model != model;
+                    if send_set_permission_mode {
+                        entry.current_permission_mode = want_permission_mode.to_string();
+                    }
+                    if send_set_model {
+                        entry.current_model.clone_from(&model);
+                    }
+                    FastPath::Go {
+                        stdin: entry.stdin.clone(),
+                        busy: entry.busy.clone(),
+                        send_set_permission_mode,
+                        send_set_model,
+                    }
+                }
+            } else {
+                FastPath::Spawn
+            }
+        };
+
+        match decision {
+            FastPath::Go {
+                stdin,
+                busy,
+                send_set_permission_mode,
+                send_set_model,
+            } => {
+                let user_bytes = agent.encode_stream_user_message(&message, &attachments)?;
+                persist_verun_user_message(
+                    db_tx,
+                    &session_id,
+                    &message,
+                    &attachments,
+                    plan_mode,
+                    thinking_mode,
+                    fast_mode,
+                )
+                .await;
+                spawn_session_title_generation(
+                    app.clone(),
+                    db_tx.clone(),
+                    session_id.clone(),
+                    task_id.clone(),
+                    message.clone(),
+                    worktree_path.clone(),
+                    is_first_turn,
+                    task_name.is_none(),
+                );
+                // Control requests must complete before the user message: the
+                // CLI applies mode/model changes only after ACKing. Writing the
+                // user message first (or before the ACK arrives) can race the
+                // switch, leaving Claude running the previous mode/model.
+                if send_set_permission_mode {
+                    let req_id = new_control_request_id();
+                    let bytes =
+                        agent.encode_stream_set_permission_mode(&req_id, want_permission_mode)?;
+                    await_control_ack(
+                        &stdin,
+                        &pending_control_responses,
+                        &req_id,
+                        &bytes,
+                        "set_permission_mode",
+                    )
+                    .await?;
+                }
+                if send_set_model {
+                    let req_id = new_control_request_id();
+                    let bytes = agent.encode_stream_set_model(&req_id, model.as_deref())?;
+                    await_control_ack(
+                        &stdin,
+                        &pending_control_responses,
+                        &req_id,
+                        &bytes,
+                        "set_model",
+                    )
+                    .await?;
+                }
+                write_to_stdin(&stdin, &user_bytes).await?;
+                busy.store(true, Ordering::SeqCst);
+                let _ = db_tx
+                    .send(db::DbWrite::UpdateSessionStatus {
+                        id: session_id.clone(),
+                        status: "running".to_string(),
+                    })
+                    .await;
+                let _ = app.emit(
+                    "session-status",
+                    stream::SessionStatusEvent {
+                        session_id,
+                        status: "running".to_string(),
+                        error: None,
+                    },
+                );
+                return Ok(());
+            }
+            FastPath::Respawn => {
+                if let Some((_, mut proc)) = active.remove(&session_id) {
+                    graceful_shutdown(&mut proc.child, &proc.stdin).await;
+                }
+            }
+            FastPath::Spawn => {}
+        }
+    }
+
+    // ── Spawn path ──
     if active.contains_key(&session_id) {
         return Err("Session is already processing a message".to_string());
     }
 
-    let is_first_turn = resume_session_id.as_ref().is_none_or(|s| s.is_empty());
+    spawn_session_title_generation(
+        app.clone(),
+        db_tx.clone(),
+        session_id.clone(),
+        task_id.clone(),
+        message.clone(),
+        worktree_path.clone(),
+        is_first_turn,
+        task_name.is_none(),
+    );
 
-    // Generate AI title in background (non-blocking, tab shows "New session" until it arrives)
-    let needs_session_name = is_first_turn && !message.is_empty();
-    let needs_task_name = task_name.is_none() && !message.is_empty();
-    if needs_session_name || needs_task_name {
-        let title_app = app.clone();
-        let title_db = db_tx.clone();
-        let title_sid = session_id.clone();
-        let title_tid = task_id.clone();
-        let title_msg = message.clone();
-        let title_wt = worktree_path.clone();
-        tokio::spawn(async move {
-            // Let the main session claim CPU/network before spawning a second claude process
-            tokio::time::sleep(std::time::Duration::from_secs(3)).await;
-            if let Some(title) = generate_session_title(&title_msg, &title_wt).await {
-                if needs_session_name {
-                    let _ = title_db
-                        .send(db::DbWrite::UpdateSessionName {
-                            id: title_sid.clone(),
-                            name: title.clone(),
-                        })
-                        .await;
-                    let _ = title_app.emit(
-                        "session-name",
-                        stream::SessionNameEvent {
-                            session_id: title_sid,
-                            name: title.clone(),
-                        },
-                    );
-                }
-                if needs_task_name {
-                    let _ = title_db
-                        .send(db::DbWrite::UpdateTaskName {
-                            id: title_tid.clone(),
-                            name: title.clone(),
-                        })
-                        .await;
-                    let _ = title_app.emit(
-                        "task-name",
-                        stream::TaskNameEvent {
-                            task_id: title_tid,
-                            name: title,
-                        },
-                    );
-                }
-            }
-        });
-    }
+    persist_verun_user_message(
+        db_tx,
+        &session_id,
+        &message,
+        &attachments,
+        plan_mode,
+        thinking_mode,
+        fast_mode,
+    )
+    .await;
 
-    // Persist user message so it shows up on reload
+    spawn_session_process(
+        app,
+        db_tx.clone(),
+        active,
+        pending_approvals,
+        pending_approval_meta,
+        pending_control_responses,
+        SpawnSessionParams {
+            session_id,
+            task_id,
+            project_id,
+            worktree_path,
+            repo_path,
+            port_offset,
+            trust_level,
+            resume_session_id,
+            model,
+            plan_mode,
+            thinking_mode,
+            fast_mode,
+            agent_type,
+            message,
+            attachments,
+            prewarm: false,
+        },
+    )
+    .await
+}
+
+/// Persist the user's message to `output_lines` so it shows up after reload.
+/// Fire-and-forget semantics (send on the write queue; errors are logged upstream).
+async fn persist_verun_user_message(
+    db_tx: &DbWriteTx,
+    session_id: &str,
+    message: &str,
+    attachments: &[Attachment],
+    plan_mode: bool,
+    thinking_mode: bool,
+    fast_mode: bool,
+) {
     let attachment_names: Vec<&str> = attachments.iter().map(|a| a.name.as_str()).collect();
     let user_line = serde_json::json!({
         "type": "verun_user_message",
@@ -809,11 +995,172 @@ pub async fn send_message(
     .to_string();
     let _ = db_tx
         .send(db::DbWrite::InsertOutputLines {
-            session_id: session_id.clone(),
+            session_id: session_id.to_string(),
             lines: vec![(user_line, epoch_ms())],
         })
         .await;
+}
 
+/// Kick off the background Haiku call that names the session and task.
+/// No-op unless there's something to name.
+#[allow(clippy::too_many_arguments)]
+fn spawn_session_title_generation(
+    app: AppHandle,
+    db_tx: DbWriteTx,
+    session_id: String,
+    task_id: String,
+    message: String,
+    worktree_path: String,
+    is_first_turn: bool,
+    task_needs_name: bool,
+) {
+    let needs_session_name = is_first_turn && !message.is_empty();
+    let needs_task_name = task_needs_name && !message.is_empty();
+    if !needs_session_name && !needs_task_name {
+        return;
+    }
+    tokio::spawn(async move {
+        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+        if let Some(title) = generate_session_title(&message, &worktree_path).await {
+            if needs_session_name {
+                let _ = db_tx
+                    .send(db::DbWrite::UpdateSessionName {
+                        id: session_id.clone(),
+                        name: title.clone(),
+                    })
+                    .await;
+                let _ = app.emit(
+                    "session-name",
+                    stream::SessionNameEvent {
+                        session_id,
+                        name: title.clone(),
+                    },
+                );
+            }
+            if needs_task_name {
+                let _ = db_tx
+                    .send(db::DbWrite::UpdateTaskName {
+                        id: task_id.clone(),
+                        name: title.clone(),
+                    })
+                    .await;
+                let _ = app.emit(
+                    "task-name",
+                    stream::TaskNameEvent {
+                        task_id,
+                        name: title,
+                    },
+                );
+            }
+        }
+    });
+}
+
+/// Send a `control_request` frame and block until the CLI's matching
+/// `control_response` arrives. Use this when the next stdin write depends on
+/// the CLI having fully applied the request (e.g. a `set_permission_mode`
+/// before the user message, so Claude runs in the new mode).
+async fn await_control_ack(
+    stdin: &Arc<TokioMutex<Option<ChildStdin>>>,
+    pending: &PendingControlResponses,
+    request_id: &str,
+    bytes: &[u8],
+    label: &str,
+) -> Result<(), String> {
+    let (tx, rx) = oneshot::channel();
+    pending.insert(request_id.to_string(), tx);
+    if let Err(e) = write_to_stdin(stdin, bytes).await {
+        pending.remove(request_id);
+        return Err(e);
+    }
+    match tokio::time::timeout(Duration::from_secs(5), rx).await {
+        Ok(Ok(Ok(_))) => Ok(()),
+        Ok(Ok(Err(e))) => Err(format!("{label} failed: {e}")),
+        Ok(Err(_)) => Err(format!("{label}: response channel dropped")),
+        Err(_) => {
+            pending.remove(request_id);
+            Err(format!("{label}: CLI did not ACK within 5s"))
+        }
+    }
+}
+
+/// Write a payload to the session's stdin, keeping the fd open afterwards.
+/// Used both by the send-message fast path (user message) and abort (interrupt frame).
+async fn write_to_stdin(
+    stdin: &Arc<TokioMutex<Option<ChildStdin>>>,
+    bytes: &[u8],
+) -> Result<(), String> {
+    let mut guard = stdin.lock().await;
+    let writer = guard
+        .as_mut()
+        .ok_or_else(|| "Session stdin is closed".to_string())?;
+    writer
+        .write_all(bytes)
+        .await
+        .map_err(|e| format!("write stdin: {e}"))?;
+    writer
+        .flush()
+        .await
+        .map_err(|e| format!("flush stdin: {e}"))?;
+    Ok(())
+}
+
+/// Params for [`spawn_session_process`]. `prewarm=true` skips writing any
+/// initial user message; the CLI just boots and waits for the first send.
+pub struct SpawnSessionParams {
+    pub session_id: String,
+    pub task_id: String,
+    pub project_id: String,
+    pub worktree_path: String,
+    pub repo_path: String,
+    pub port_offset: i64,
+    pub trust_level: TrustLevel,
+    pub resume_session_id: Option<String>,
+    pub model: Option<String>,
+    pub plan_mode: bool,
+    pub thinking_mode: bool,
+    pub fast_mode: bool,
+    pub agent_type: String,
+    pub message: String,
+    pub attachments: Vec<Attachment>,
+    pub prewarm: bool,
+}
+
+/// Spawn a new CLI process for this session and start the stream monitor.
+///
+/// Registers the child in `active` with `busy = !prewarm` (pre-warm leaves
+/// the process idle). The caller is responsible for persisting the user
+/// message and kicking off title generation.
+#[allow(clippy::too_many_arguments)]
+pub async fn spawn_session_process(
+    app: AppHandle,
+    db_tx: DbWriteTx,
+    active: ActiveMap,
+    pending_approvals: PendingApprovals,
+    pending_approval_meta: PendingApprovalMeta,
+    pending_control_responses: PendingControlResponses,
+    params: SpawnSessionParams,
+) -> Result<(), String> {
+    let SpawnSessionParams {
+        session_id,
+        task_id,
+        project_id,
+        worktree_path,
+        repo_path,
+        port_offset,
+        trust_level,
+        resume_session_id,
+        model,
+        plan_mode,
+        thinking_mode,
+        fast_mode,
+        agent_type,
+        message,
+        attachments,
+        prewarm,
+    } = params;
+
+    let agent = AgentKind::parse(&agent_type).implementation();
     let resume_id = resume_session_id.as_deref().filter(|s| !s.is_empty());
     let session_args = crate::agent::SessionArgs {
         resume_session_id: resume_id,
@@ -829,8 +1176,9 @@ pub async fn send_message(
 
     let args_list = agent.build_session_args(&session_args);
     eprintln!(
-        "[verun][{}] spawn: {} {}",
+        "[verun][{}] spawn{}: {} {}",
         agent.display_name(),
+        if prewarm { " (prewarm)" } else { "" },
         agent.cli_binary(),
         args_list.join(" ")
     );
@@ -867,53 +1215,30 @@ pub async fn send_message(
 
     let stdin = match agent.input_mode() {
         crate::agent::InputMode::StreamJsonStdin => {
-            // Claude: send the message as a stream-json payload on stdin, keep open for control_response
             let mut stdin_handle = child
                 .stdin
                 .take()
                 .ok_or_else(|| "Failed to capture stdin".to_string())?;
 
-            let mut content_blocks = Vec::new();
-            for attachment in &attachments {
-                content_blocks.push(serde_json::json!({
-                    "type": "image",
-                    "source": {
-                        "type": "base64",
-                        "media_type": attachment.mime_type,
-                        "data": attachment.data_base64,
-                    }
-                }));
-            }
-            if !message.is_empty() {
-                content_blocks.push(serde_json::json!({ "type": "text", "text": message }));
+            if !prewarm {
+                let bytes = agent.encode_stream_user_message(&message, &attachments)?;
+                stdin_handle
+                    .write_all(&bytes)
+                    .await
+                    .map_err(|e| format!("Failed to write to stdin: {e}"))?;
+                stdin_handle
+                    .flush()
+                    .await
+                    .map_err(|e| format!("Failed to flush stdin: {e}"))?;
             }
 
-            let user_msg = serde_json::json!({
-                "type": "user",
-                "session_id": "",
-                "parent_tool_use_id": null,
-                "message": { "role": "user", "content": content_blocks },
-            });
-
-            let mut payload = serde_json::to_string(&user_msg)
-                .map_err(|e| format!("Failed to serialize message: {e}"))?;
-            payload.push('\n');
-
-            stdin_handle
-                .write_all(payload.as_bytes())
-                .await
-                .map_err(|e| format!("Failed to write to stdin: {e}"))?;
-            stdin_handle
-                .flush()
-                .await
-                .map_err(|e| format!("Failed to flush stdin: {e}"))?;
-
-            // Keep stdin open — needed for control_response messages
+            // Keep stdin open — persistent agents reuse it for subsequent
+            // user messages + control_request/response frames.
             Arc::new(TokioMutex::new(Some(stdin_handle)))
         }
         crate::agent::InputMode::PositionalOrStdin => {
-            // Non-Claude agents receive the prompt as a positional arg (already in args_list).
-            // Close stdin immediately so the process doesn't wait for input.
+            // Non-stream agents take the prompt as a positional arg (already in args_list).
+            // Close stdin so the process doesn't wait for input.
             let stdin_handle = child.stdin.take();
             drop(stdin_handle);
             Arc::new(TokioMutex::new(None::<tokio::process::ChildStdin>))
@@ -942,29 +1267,42 @@ pub async fn send_message(
         });
     }
 
-    // Mark session as running
-    let _ = db_tx
-        .send(db::DbWrite::UpdateSessionStatus {
-            id: session_id.clone(),
-            status: "running".to_string(),
-        })
-        .await;
+    // Busy flag: prewarm = idle, real send = in-flight. Stream loop will flip
+    // it to false on turn_end (only meaningful for persistent agents).
+    let busy = Arc::new(AtomicBool::new(!prewarm));
 
-    let _ = app.emit(
-        "session-status",
-        stream::SessionStatusEvent {
-            session_id: session_id.clone(),
-            status: "running".to_string(),
-            error: None,
-        },
-    );
+    // Mark session as running (skip for prewarm — the session is idle).
+    if !prewarm {
+        let _ = db_tx
+            .send(db::DbWrite::UpdateSessionStatus {
+                id: session_id.clone(),
+                status: "running".to_string(),
+            })
+            .await;
+
+        let _ = app.emit(
+            "session-status",
+            stream::SessionStatusEvent {
+                session_id: session_id.clone(),
+                status: "running".to_string(),
+                error: None,
+            },
+        );
+    }
 
     // Track the active process
+    let kind = AgentKind::parse(&agent_type);
     active.insert(
         session_id.clone(),
         ActiveProcess {
             child,
             stdin: stdin.clone(),
+            busy: busy.clone(),
+            kind,
+            current_permission_mode: if plan_mode { "plan" } else { "default" }.to_string(),
+            current_model: model.clone(),
+            current_thinking_mode: thinking_mode,
+            current_fast_mode: fast_mode,
         },
     );
 
@@ -982,6 +1320,7 @@ pub async fn send_message(
     let monitor_repo = repo_path;
     let monitor_trust = trust_level;
     let monitor_agent = AgentKind::parse(&agent_type).implementation();
+    let monitor_busy = busy.clone();
     tokio::spawn(async move {
         // Stream stdout lines to frontend + DB
         let wt_for_hooks = monitor_wt.clone();
@@ -991,6 +1330,7 @@ pub async fn send_message(
             monitor_tid.clone(),
             stdout,
             stdin,
+            monitor_busy,
             monitor_pending,
             monitor_pending_meta,
             monitor_pending_ctrl,
@@ -1103,36 +1443,92 @@ pub async fn send_message(
     Ok(())
 }
 
-/// Abort a currently running message
+/// Abort the in-flight turn.
+///
+/// Dispatches on [`crate::agent::AbortStrategy`]:
+/// * `Interrupt` (persistent agents): write a control_request interrupt frame
+///   to stdin and leave the process alive. Emits `session-status: idle` and
+///   `session-aborted` immediately — both near-instant.
+/// * `Kill` (one-shot agents): remove from `active` and run
+///   `graceful_shutdown` (EOF → SIGTERM → SIGKILL) in the background.
+///   The process exits; a subsequent `send_message` respawns with `--resume`.
 pub async fn abort_message(
     app: &AppHandle,
     db_tx: &DbWriteTx,
     active: &ActiveMap,
     session_id: &str,
 ) -> Result<(), String> {
-    if let Some((_, mut proc)) = active.remove(session_id) {
-        // Do the EOF → SIGTERM → SIGKILL dance in the background so the UI
-        // doesn't block on the grace period.
-        tokio::spawn(async move {
-            graceful_shutdown(&mut proc.child, &proc.stdin).await;
-        });
+    let kind = match active.get(session_id) {
+        Some(entry) => entry.kind,
+        None => return Ok(()), // Nothing to abort
+    };
+    let agent = kind.implementation();
 
-        // Update session status so the UI reflects the abort
-        let _ = db_tx
-            .send(db::DbWrite::UpdateSessionStatus {
-                id: session_id.to_string(),
-                status: "idle".to_string(),
-            })
-            .await;
+    match agent.abort_strategy() {
+        crate::agent::AbortStrategy::Interrupt => {
+            let stdin = match active.get(session_id) {
+                Some(entry) => entry.stdin.clone(),
+                None => return Ok(()),
+            };
+            let bytes = agent.encode_stream_interrupt(&new_control_request_id())?;
+            // Best-effort: if stdin is already closed we fall through (session will
+            // hit the regular exit path).
+            let _ = write_to_stdin(&stdin, &bytes).await;
 
-        let _ = app.emit(
-            "session-status",
-            stream::SessionStatusEvent {
-                session_id: session_id.to_string(),
-                status: "idle".to_string(),
-                error: None,
-            },
-        );
+            let _ = db_tx
+                .send(db::DbWrite::UpdateSessionStatus {
+                    id: session_id.to_string(),
+                    status: "idle".to_string(),
+                })
+                .await;
+            let _ = app.emit(
+                "session-status",
+                stream::SessionStatusEvent {
+                    session_id: session_id.to_string(),
+                    status: "idle".to_string(),
+                    error: None,
+                },
+            );
+            // Interrupt completes on a single stdin write; no background wait.
+            // Emit session-aborted right away so the frontend drains armed steps.
+            let _ = app.emit("session-aborted", session_id.to_string());
+        }
+        crate::agent::AbortStrategy::Kill => {
+            let Some((_, mut proc)) = active.remove(session_id) else {
+                return Ok(());
+            };
+            // Send interrupt first so the CLI cancels token generation immediately,
+            // instead of finishing the in-flight turn before seeing EOF on stdin.
+            // Non-persistent agents: best-effort, most won't support it.
+            if let Ok(bytes) = agent.encode_stream_interrupt(&new_control_request_id()) {
+                let _ = write_to_stdin(&proc.stdin, &bytes).await;
+            }
+
+            // Do the EOF → SIGTERM → SIGKILL dance in the background so the UI
+            // doesn't block on the grace period. Emit `session-aborted` when truly
+            // stopped so the frontend can drain its armed-step queue.
+            let app_clone = app.clone();
+            let sid_clone = session_id.to_string();
+            tokio::spawn(async move {
+                graceful_shutdown(&mut proc.child, &proc.stdin).await;
+                let _ = app_clone.emit("session-aborted", sid_clone);
+            });
+
+            let _ = db_tx
+                .send(db::DbWrite::UpdateSessionStatus {
+                    id: session_id.to_string(),
+                    status: "idle".to_string(),
+                })
+                .await;
+            let _ = app.emit(
+                "session-status",
+                stream::SessionStatusEvent {
+                    session_id: session_id.to_string(),
+                    status: "idle".to_string(),
+                    error: None,
+                },
+            );
+        }
     }
     Ok(())
 }

--- a/src/components/ChatView.rebuildBlocks.test.ts
+++ b/src/components/ChatView.rebuildBlocks.test.ts
@@ -1,0 +1,65 @@
+import { describe, test, expect } from 'vitest'
+import { rebuildBlocks } from './ChatView'
+import type { OutputItem } from '../types'
+
+describe('rebuildBlocks turnEnd rendering', () => {
+  test('error turnEnd (no prior errorMessage) renders a single error block with the message', () => {
+    const items: OutputItem[] = [
+      { kind: 'userMessage', text: 'hello', timestamp: 1 } as OutputItem,
+      { kind: 'turnEnd', status: 'error', error: 'Prompt is too long' } as OutputItem,
+    ]
+    const blocks = rebuildBlocks(items)
+    const errors = blocks.filter(b => b.type === 'error')
+    expect(errors.length).toBe(1)
+    expect((errors[0] as { message: string }).message).toContain('Prompt is too long')
+    // No duplicate system bubble for the same error.
+    expect(blocks.some(b => b.type === 'system' && 'text' in b && b.text.includes('Prompt is too long'))).toBe(false)
+  })
+
+  test('synthetic errorMessage + matching turnEnd de-dupe to one error block', () => {
+    // Regression: the CLI emits BOTH a synthetic assistant (→ errorMessage)
+    // AND a result with status=error. Without de-dupe the user sees the
+    // same error twice (assistant bubble + system bubble + banner).
+    const items: OutputItem[] = [
+      { kind: 'userMessage', text: 'hello', timestamp: 1 } as OutputItem,
+      { kind: 'errorMessage', message: 'Prompt is too long', raw: '{"foo":1}' } as OutputItem,
+      { kind: 'turnEnd', status: 'error', error: 'Prompt is too long' } as OutputItem,
+    ]
+    const blocks = rebuildBlocks(items)
+    const errors = blocks.filter(b => b.type === 'error')
+    expect(errors.length).toBe(1)
+    expect((errors[0] as { raw?: string }).raw).toBe('{"foo":1}')
+    expect(blocks.some(b => b.type === 'assistant')).toBe(false)
+  })
+
+  test('error block carries turnIndex so retry can pick the right user message', () => {
+    const items: OutputItem[] = [
+      { kind: 'userMessage', text: 'first', timestamp: 1 } as OutputItem,
+      { kind: 'turnEnd', status: 'completed' } as OutputItem,
+      { kind: 'userMessage', text: 'second', timestamp: 2 } as OutputItem,
+      { kind: 'errorMessage', message: 'API Error: 401', raw: undefined } as OutputItem,
+      { kind: 'turnEnd', status: 'error', error: 'API Error: 401' } as OutputItem,
+    ]
+    const blocks = rebuildBlocks(items)
+    const err = blocks.find(b => b.type === 'error') as { turnIndex: number } | undefined
+    expect(err?.turnIndex).toBe(2)
+  })
+
+  test('interrupted turnEnd renders no bubble (user already hit stop)', () => {
+    const items: OutputItem[] = [
+      { kind: 'turnEnd', status: 'interrupted' } as OutputItem,
+    ]
+    const blocks = rebuildBlocks(items)
+    expect(blocks.find(b => b.type === 'system')).toBeUndefined()
+    expect(blocks.find(b => b.type === 'error')).toBeUndefined()
+  })
+
+  test('completed turnEnd renders no bubble', () => {
+    const items: OutputItem[] = [
+      { kind: 'turnEnd', status: 'completed' } as OutputItem,
+    ]
+    const blocks = rebuildBlocks(items)
+    expect(blocks.find(b => b.type === 'system')).toBeUndefined()
+    expect(blocks.find(b => b.type === 'error')).toBeUndefined()
+  })
+})

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -3,7 +3,7 @@ import { createStore, produce, reconcile } from 'solid-js/store'
 import { clsx } from 'clsx'
 import { renderMarkdown, handleMarkdownLinkClick, getWorktreePath } from '../lib/markdown'
 import type { OutputItem, SessionStatus } from '../types'
-import { ChevronDown, ChevronRight, AlertTriangle, Copy, Check, ArrowUp, ArrowDown, X, GitBranch, RotateCw, Plus } from 'lucide-solid'
+import { ChevronDown, ChevronRight, AlertTriangle, Copy, Check, ArrowUp, ArrowDown, X, GitBranch, RotateCw, Plus, ChevronUp } from 'lucide-solid'
 import { FileMentionBadge } from './FileMentionBadge'
 import { ImageViewer } from './ImageViewer'
 import { BlobImage } from './BlobImage'
@@ -54,7 +54,6 @@ function renderMarkdownForTask(text: string, taskId?: string): string {
 interface Props {
   output: OutputItem[]
   sessionStatus?: SessionStatus
-  sessionError?: string
   sessionId?: string | null
   taskId?: string
   agentType?: string
@@ -97,9 +96,16 @@ interface SystemBlock {
   type: 'system'
   text: string
 }
-type DisplayBlock = UserBlock | AssistantBlock | ThinkingBlock | ToolBlock | SystemBlock
+interface ErrorBlock {
+  type: 'error'
+  message: string
+  raw?: string
+  /** Turn marker so retry picks the right user message. */
+  turnIndex: number
+}
+type DisplayBlock = UserBlock | AssistantBlock | ThinkingBlock | ToolBlock | SystemBlock | ErrorBlock
 
-function rebuildBlocks(items: OutputItem[]): DisplayBlock[] {
+export function rebuildBlocks(items: OutputItem[]): DisplayBlock[] {
   const blocks: DisplayBlock[] = []
   let currentText = ''
   let currentThinking = ''
@@ -129,6 +135,11 @@ function rebuildBlocks(items: OutputItem[]): DisplayBlock[] {
   let toolCounter = 0
   let thinkingCounter = 0
   let turnStartTs: number | undefined
+  let turnIndex = 0
+  // Track whether this turn has already produced an error block so we can
+  // drop the duplicate turnEnd-derived bubble (synthetic assistant + result
+  // both carry the same provider error).
+  let turnHasError = false
 
   for (const item of items) {
     switch (item.kind) {
@@ -143,7 +154,14 @@ function rebuildBlocks(items: OutputItem[]): DisplayBlock[] {
       case 'userMessage':
         flushText(); flushThinking()
         turnStartTs = item.timestamp
+        turnIndex += 1
+        turnHasError = false
         blocks.push({ type: 'user', text: item.text, images: item.images })
+        break
+      case 'errorMessage':
+        flushText(); flushThinking()
+        blocks.push({ type: 'error', message: item.message, raw: item.raw, turnIndex })
+        turnHasError = true
         break
       case 'toolStart': {
         // Hide ExitPlanMode from the chat — it's shown as a dedicated plan overlay
@@ -194,7 +212,18 @@ function rebuildBlocks(items: OutputItem[]): DisplayBlock[] {
           }
           if (blocks[i].type === 'user') break
         }
-        if (item.status !== 'completed' && !item.error) {
+        // Render rules:
+        //   - completed         → no bubble (happy path)
+        //   - interrupted       → no bubble (user already hit stop)
+        //   - error + message   → one error block per turn (de-duped — the
+        //                         synthetic assistant already produced one)
+        //   - other non-success → show the status as a system bubble
+        if (item.error) {
+          if (!turnHasError) {
+            blocks.push({ type: 'error', message: item.error, raw: undefined, turnIndex })
+            turnHasError = true
+          }
+        } else if (item.status !== 'completed' && item.status !== 'interrupted') {
           blocks.push({ type: 'system', text: `Turn ended: ${item.status}` })
         }
         turnStartTs = undefined
@@ -601,15 +630,31 @@ const savedScrollPositions = new Map<string, { scrollTop: number; autoScroll: bo
 // Error banner with retry actions
 // ---------------------------------------------------------------------------
 
-function getLastUserMessage(output: OutputItem[]): string | undefined {
-  for (let i = output.length - 1; i >= 0; i--) {
-    if (output[i].kind === 'userMessage') return (output[i] as { kind: 'userMessage'; text: string }).text
+/** Walk `output` and return the text of the user message that started the
+ *  given 1-based turn. Retry always resends the correct message even for
+ *  historical error blocks further up the transcript. */
+function userMessageForTurn(output: OutputItem[], turnIndex: number): string | undefined {
+  let seen = 0
+  for (const item of output) {
+    if (item.kind === 'userMessage') {
+      seen += 1
+      if (seen === turnIndex) return item.text
+    }
   }
   return undefined
 }
 
-const ErrorBanner: Component<{
-  error?: string
+/** Pretty-print a JSON blob if parseable, else return as-is. Keeps the raw
+ *  details panel readable regardless of what the CLI sent. */
+function prettyJson(raw?: string): string {
+  if (!raw) return ''
+  try { return JSON.stringify(JSON.parse(raw), null, 2) } catch { return raw }
+}
+
+const ErrorBlockView: Component<{
+  message: string
+  raw?: string
+  turnIndex: number
   output: OutputItem[]
   sessionId?: string | null
   taskId?: string
@@ -617,7 +662,9 @@ const ErrorBanner: Component<{
   model?: string | null
 }> = (props) => {
   const [retrying, setRetrying] = createSignal(false)
-  const lastMessage = () => getLastUserMessage(props.output)
+  const [showDetails, setShowDetails] = createSignal(false)
+  const [copiedRaw, setCopiedRaw] = createSignal(false)
+  const retryMessage = () => userMessageForTurn(props.output, props.turnIndex)
 
   const modeArgs = (): [string | undefined, boolean | undefined, boolean | undefined, boolean | undefined] => {
     const tid = props.taskId
@@ -630,7 +677,7 @@ const ErrorBanner: Component<{
   }
 
   const retry = async () => {
-    const msg = lastMessage()
+    const msg = retryMessage()
     if (!msg || !props.sessionId) return
     setRetrying(true)
     try {
@@ -641,7 +688,7 @@ const ErrorBanner: Component<{
   }
 
   const retryNewSession = async () => {
-    const msg = lastMessage()
+    const msg = retryMessage()
     if (!msg || !props.taskId) return
     setRetrying(true)
     try {
@@ -654,16 +701,21 @@ const ErrorBanner: Component<{
     setRetrying(false)
   }
 
+  const copyRaw = async () => {
+    if (!props.raw) return
+    await navigator.clipboard.writeText(prettyJson(props.raw))
+    setCopiedRaw(true)
+    setTimeout(() => setCopiedRaw(false), 2000)
+  }
+
   return (
     <div class="mx-5 mt-1 flex flex-col gap-2 px-3 py-2.5 rounded-lg bg-status-error/8 ring-1 ring-status-error/15">
       <div class="flex items-start gap-2">
         <AlertTriangle size={14} class="text-status-error shrink-0 mt-0.5" />
-        <span class="text-xs text-status-error">
-          {props.error || 'Session encountered an error'}
-        </span>
+        <span class="text-xs text-status-error whitespace-pre-wrap break-words">{props.message}</span>
       </div>
-      <Show when={lastMessage()}>
-        <div class="flex items-center gap-2 ml-5.5">
+      <div class="flex items-center gap-2 ml-5.5 flex-wrap">
+        <Show when={retryMessage()}>
           <button
             class="flex items-center gap-1.5 px-2.5 py-1 rounded-md text-[11px] font-medium bg-status-error/12 text-status-error hover:bg-status-error/20 transition-colors disabled:opacity-50"
             onClick={retry}
@@ -680,6 +732,31 @@ const ErrorBanner: Component<{
             <Plus size={11} />
             Retry in new session
           </button>
+        </Show>
+        <Show when={props.raw}>
+          <button
+            class="flex items-center gap-1.5 px-2.5 py-1 rounded-md text-[11px] font-medium bg-surface-2 text-text-secondary hover:bg-surface-3 transition-colors"
+            onClick={() => setShowDetails(v => !v)}
+          >
+            <Show when={showDetails()} fallback={<ChevronDown size={11} />}>
+              <ChevronUp size={11} />
+            </Show>
+            {showDetails() ? 'Hide details' : 'Show details'}
+          </button>
+        </Show>
+      </div>
+      <Show when={showDetails() && props.raw}>
+        <div class="ml-5.5 mt-1 relative">
+          <button
+            class="absolute top-1.5 right-1.5 p-1 rounded-md text-text-dim hover:text-text-muted hover:bg-surface-2 transition-colors"
+            onClick={copyRaw}
+            title="Copy"
+          >
+            <Show when={copiedRaw()} fallback={<Copy size={11} />}>
+              <Check size={11} class="text-status-running" />
+            </Show>
+          </button>
+          <pre class="my-0 max-h-64 overflow-auto text-[11px] text-text-secondary bg-surface-1 rounded-md p-2 pr-7 ring-1 ring-white/5 whitespace-pre-wrap break-words">{prettyJson(props.raw)}</pre>
         </div>
       </Show>
     </div>
@@ -1069,20 +1146,26 @@ export const ChatView: Component<Props> = (props) => {
                   <span class="text-[11px] text-text-dim whitespace-pre-wrap">{(block as SystemBlock).text}</span>
                 </div>
               </Match>
+              <Match when={block.type === 'error'}>
+                {(() => {
+                  const b = block as ErrorBlock
+                  return (
+                    <ErrorBlockView
+                      message={b.message}
+                      raw={b.raw}
+                      turnIndex={b.turnIndex}
+                      output={props.output}
+                      sessionId={props.sessionId}
+                      taskId={props.taskId}
+                      agentType={props.agentType}
+                      model={props.model}
+                    />
+                  )
+                })()}
+              </Match>
             </Switch>
           )}
         </For>
-
-        <Show when={props.sessionStatus === 'error'}>
-          <ErrorBanner
-            error={props.sessionError}
-            output={props.output}
-            sessionId={props.sessionId}
-            taskId={props.taskId}
-            agentType={props.agentType}
-            model={props.model}
-          />
-        </Show>
 
         <Show when={props.sessionStatus === 'running'}>
           <div class="px-5 py-2">
@@ -1092,7 +1175,7 @@ export const ChatView: Component<Props> = (props) => {
           </div>
         </Show>
 
-        <Show when={blocks.length === 0 && props.sessionStatus !== 'error'}>
+        <Show when={blocks.length === 0}>
           <div class="flex-1 flex items-center justify-center pt-20">
             <div class="text-center max-w-sm">
               <p class="text-sm text-text-secondary mb-1">New session</p>

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -573,11 +573,18 @@ export const MessageInput: Component<Props> = (props) => {
     if (feedback) {
       // Request changes
       setPlanChanges('')
+      const tid = selectedTaskId()
       try {
         if (approval && isExitPlanMode()) {
-          await denyToolUse(approval.requestId, approval.sessionId)
+          // Forward the feedback as the tool-deny message so Claude sees it as
+          // the reason and continues the same turn. No separate sendMessage.
+          if (tid) setTaskPlanFilePath(tid, null)
+          await denyToolUse(approval.requestId, approval.sessionId, feedback)
+        } else {
+          // Persisted plan viewer — no live approval, send as a new message.
+          if (tid) setTaskPlanFilePath(tid, null)
+          await sendMessage(sid, feedback, undefined, currentModel(), true)
         }
-        await sendMessage(sid, feedback, undefined, currentModel(), true)
       } catch (error) {
         setPlanActionPending(false)
         throw error
@@ -862,6 +869,8 @@ export const MessageInput: Component<Props> = (props) => {
     setMessage('')
     setAttachments([])
     setShowPalette(false)
+    // Dismiss any persisted plan panel — the user has moved on from that plan.
+    if (tid && taskPlanFilePath[tid]) setTaskPlanFilePath(tid, null)
     try {
       await sendMessage(sid, msg, atts.length > 0 ? atts : undefined, currentModel(), planMode(), thinkingMode(), fastMode())
     } catch (e) {
@@ -2042,7 +2051,7 @@ export const MessageInput: Component<Props> = (props) => {
 
       <div class={clsx(
         'relative bg-surface-1 rounded-xl transition-all outline-none',
-        currentApproval() || showPlanResponse() || (showPlanViewer() && planContent()) ? 'hidden' : '',
+        currentApproval() || (showPlanViewer() && planContent()) ? 'hidden' : '',
         (editingMessageIdx() !== null || editingStepId() !== null)
           ? 'border border-amber-500/40 shadow-[0_0_0_2px_rgba(245,158,11,0.12)]'
           : planMode()

--- a/src/components/TaskPanel.tsx
+++ b/src/components/TaskPanel.tsx
@@ -178,6 +178,13 @@ export const TaskPanel: Component = () => {
       clearSessionUnread(sessionId)
       await loadOutputLines(sessionId)
       await loadSteps(sessionId)
+      // Best-effort pre-warm so the first message on a Claude session doesn't
+      // pay the CLI boot cost. No-op for non-persistent agents (Codex, etc).
+      // Skip if the session is already running — it has a live process.
+      const s = sessionById(sessionId)
+      if (s && s.status !== 'running') {
+        ipc.prewarmSession(sessionId).catch(() => {})
+      }
     }
   }))
 
@@ -623,7 +630,6 @@ export const TaskPanel: Component = () => {
                             <ChatView
                               output={currentOutput()}
                               sessionStatus={currentSession()?.status}
-                              sessionError={currentSession()?.error}
                               sessionId={selectedSessionId()}
                               taskId={t().id}
                               agentType={currentSession()?.agentType}

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -50,6 +50,9 @@ function formatItem(item: OutputItem): string {
       if (item.status === 'completed') {
         return `\r\n${GREEN}${DIM} Turn completed${RESET}\r\n`
       }
+      if (item.status === 'interrupted') {
+        return ''
+      }
       return `\r\n${RED}${DIM} ${item.error || `Turn ended: ${item.status}`}${RESET}\r\n`
 
     case 'raw':

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -91,6 +91,12 @@ export const clearSession = (sessionId: string) =>
 export const abortMessage = (sessionId: string) =>
   invoke<void>('abort_message', { sessionId })
 
+export const interruptSession = (sessionId: string) =>
+  invoke<void>('interrupt_session', { sessionId })
+
+export const getSessionContextUsage = (sessionId: string) =>
+  invoke<unknown>('get_session_context_usage', { sessionId })
+
 export const getActiveSessions = (): Promise<string[]> =>
   DEMO ? Promise.resolve([]) : invoke<string[]>('get_active_sessions')
 

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -82,6 +82,12 @@ export const sendMessage = (sessionId: string, message: string, attachments?: At
 export const updateSessionModel = (sessionId: string, model: string | null) =>
   invoke<void>('update_session_model', { sessionId, model })
 
+// Best-effort pre-warm: for persistent agents (Claude) this spawns the CLI in
+// the background so the first user message doesn't pay the boot cost. No-op
+// for non-persistent agents. Fire-and-forget — callers should swallow errors.
+export const prewarmSession = (sessionId: string) =>
+  invoke<void>('prewarm_session', { sessionId })
+
 export const closeSession = (sessionId: string) =>
   invoke<void>('close_session', { sessionId })
 
@@ -100,8 +106,8 @@ export const getSessionContextUsage = (sessionId: string) =>
 export const getActiveSessions = (): Promise<string[]> =>
   DEMO ? Promise.resolve([]) : invoke<string[]>('get_active_sessions')
 
-export const respondToApproval = (requestId: string, behavior: 'allow' | 'deny', updatedInput?: Record<string, unknown>) =>
-  invoke<void>('respond_to_approval', { requestId, behavior, updatedInput })
+export const respondToApproval = (requestId: string, behavior: 'allow' | 'deny', updatedInput?: Record<string, unknown>, message?: string) =>
+  invoke<void>('respond_to_approval', { requestId, behavior, updatedInput, message })
 
 export const getPendingApprovals = (): Promise<ToolApprovalRequest[]> =>
   DEMO ? Promise.resolve([]) : invoke<ToolApprovalRequest[]>('get_pending_approvals')

--- a/src/store/sessions.abort.test.ts
+++ b/src/store/sessions.abort.test.ts
@@ -1,0 +1,165 @@
+import { describe, test, expect, beforeAll, beforeEach, vi } from 'vitest'
+import { produce } from 'solid-js/store'
+
+type Listener = (event: { payload: unknown }) => void
+const listeners = new Map<string, Listener[]>()
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn((name: string, cb: Listener) => {
+    const arr = listeners.get(name) || []
+    arr.push(cb)
+    listeners.set(name, arr)
+    return Promise.resolve(() => {})
+  }),
+  emit: vi.fn(() => Promise.resolve()),
+}))
+
+vi.mock('../lib/ipc', () => ({
+  listSteps: vi.fn().mockResolvedValue([]),
+  addStep: vi.fn().mockResolvedValue(undefined),
+  updateStep: vi.fn().mockResolvedValue(undefined),
+  deleteStep: vi.fn().mockResolvedValue(undefined),
+  reorderSteps: vi.fn().mockResolvedValue(undefined),
+  disarmAllSteps: vi.fn().mockResolvedValue(undefined),
+  abortMessage: vi.fn().mockResolvedValue(undefined),
+  sendMessage: vi.fn().mockResolvedValue(undefined),
+  getPendingApprovals: vi.fn().mockResolvedValue([]),
+}))
+
+vi.mock('../lib/notifications', () => ({ notify: vi.fn() }))
+vi.mock('../lib/binary', () => ({
+  deserializeAttachments: vi.fn(() => undefined),
+  serializeAttachments: vi.fn(() => null),
+}))
+vi.mock('./tasks', () => ({
+  setTasks: vi.fn(),
+  taskById: vi.fn(() => ({ name: 'test-task' })),
+}))
+vi.mock('./ui', () => ({
+  markTaskUnread: vi.fn(),
+  markTaskAttention: vi.fn(),
+  clearTaskAttention: vi.fn(),
+  markSessionUnread: vi.fn(),
+}))
+
+import {
+  sessions, setSessions,
+  outputItems, setOutputItems,
+  abortingSessions, setAbortingSessions,
+  abortMessage,
+  initSessionListeners,
+} from './sessions'
+import { addStep, clearSteps, getSteps } from './steps'
+import * as ipc from '../lib/ipc'
+import type { Session, OutputItem } from '../types'
+
+const SID = 's-abort-001'
+
+const makeSession = (overrides: Partial<Session> = {}): Session => ({
+  id: SID,
+  taskId: 't-001',
+  name: null,
+  resumeSessionId: null,
+  status: 'running',
+  startedAt: 1000,
+  endedAt: null,
+  totalCost: 0,
+  parentSessionId: null,
+  forkedAtMessageUuid: null,
+  agentType: 'claude' as const,
+  model: null,
+  ...overrides,
+})
+
+function fire(name: string, payload: unknown) {
+  const arr = listeners.get(name) || []
+  for (const cb of arr) cb({ payload })
+}
+
+describe('abort flow with armed steps', () => {
+  beforeAll(async () => {
+    await initSessionListeners()
+  })
+
+  beforeEach(() => {
+    setSessions([])
+    setOutputItems(produce(store => { delete store[SID] }))
+    setAbortingSessions(produce(store => { delete store[SID] }))
+    clearSteps(SID)
+    vi.clearAllMocks()
+  })
+
+  test('abortMessage sets abortingSessions flag and flips status to idle', async () => {
+    setSessions([makeSession({ status: 'running' })])
+    await abortMessage(SID)
+    expect(abortingSessions[SID]).toBe(true)
+    expect(sessions[0].status).toBe('idle')
+    expect(ipc.abortMessage).toHaveBeenCalledWith(SID)
+  })
+
+  test('session-status:idle while aborting does NOT drain the armed step', async () => {
+    setSessions([makeSession({ status: 'running' })])
+    addStep({ sessionId: SID, message: 'queued work', armed: true })
+    await abortMessage(SID)
+
+    // Backend emits idle before graceful shutdown completes.
+    // Drain must be skipped or the new --resume spawn races the old JSONL.
+    fire('session-status', { sessionId: SID, status: 'idle' })
+
+    expect(getSteps(SID).length).toBe(1)
+    expect(getSteps(SID)[0].armed).toBe(true)
+    expect(ipc.sendMessage).not.toHaveBeenCalled()
+  })
+
+  test('session-aborted clears flag, dequeues armed step, and pushes userMessage bubble', async () => {
+    setSessions([makeSession({ status: 'running' })])
+    addStep({ sessionId: SID, message: 'armed message', armed: true })
+    await abortMessage(SID)
+    fire('session-status', { sessionId: SID, status: 'idle' })
+
+    // Graceful shutdown completes — now drain should happen.
+    fire('session-aborted', SID)
+
+    expect(abortingSessions[SID]).toBeUndefined()
+    expect(getSteps(SID).length).toBe(0)
+    expect(ipc.sendMessage).toHaveBeenCalledTimes(1)
+
+    // The user message bubble must appear in outputItems synchronously so the UI
+    // renders the armed message immediately — this is the regression the user hit.
+    const items: OutputItem[] = outputItems[SID] || []
+    const userMsg = items.find(i => i.kind === 'userMessage')
+    expect(userMsg).toBeDefined()
+    expect(userMsg && userMsg.kind === 'userMessage' ? userMsg.text : undefined).toBe('armed message')
+  })
+
+  test('session-aborted on an already-running session does not drain (guard against stale idle check)', async () => {
+    setSessions([makeSession({ status: 'running' })])
+    addStep({ sessionId: SID, message: 'should wait', armed: true })
+    // No abort flow — just a stray session-aborted event while still running.
+    fire('session-aborted', SID)
+    expect(getSteps(SID).length).toBe(1)
+    expect(ipc.sendMessage).not.toHaveBeenCalled()
+  })
+
+  test('normal idle (no abort) drains armed step via session-status listener', async () => {
+    setSessions([makeSession({ status: 'running' })])
+    addStep({ sessionId: SID, message: 'normal queue', armed: true })
+
+    fire('session-status', { sessionId: SID, status: 'idle' })
+
+    expect(getSteps(SID).length).toBe(0)
+    expect(ipc.sendMessage).toHaveBeenCalledTimes(1)
+    const items: OutputItem[] = outputItems[SID] || []
+    expect(items.some(i => i.kind === 'userMessage')).toBe(true)
+  })
+
+  test('abortMessage rollback: ipc failure restores running status and clears flag', async () => {
+    setSessions([makeSession({ status: 'running' })])
+    vi.mocked(ipc.abortMessage).mockRejectedValueOnce(new Error('boom'))
+
+    await expect(abortMessage(SID)).rejects.toThrow('boom')
+
+    expect(abortingSessions[SID]).toBeUndefined()
+    expect(sessions[0].status).toBe('running')
+  })
+})

--- a/src/store/sessions.deny.test.ts
+++ b/src/store/sessions.deny.test.ts
@@ -1,0 +1,58 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(() => Promise.resolve(() => {})),
+  emit: vi.fn(() => Promise.resolve()),
+}))
+
+vi.mock('../lib/ipc', () => ({
+  listSteps: vi.fn().mockResolvedValue([]),
+  respondToApproval: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('../lib/notifications', () => ({ notify: vi.fn() }))
+vi.mock('../lib/binary', () => ({
+  deserializeAttachments: vi.fn(() => undefined),
+  serializeAttachments: vi.fn(() => null),
+}))
+vi.mock('./tasks', () => ({
+  setTasks: vi.fn(),
+  taskById: vi.fn(() => ({ name: 'test-task' })),
+}))
+vi.mock('./ui', () => ({
+  markTaskUnread: vi.fn(),
+  markTaskAttention: vi.fn(),
+  clearTaskAttention: vi.fn(),
+  markSessionUnread: vi.fn(),
+}))
+
+import { denyToolUse } from './sessions'
+import * as ipc from '../lib/ipc'
+
+describe('denyToolUse with feedback message', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('denyToolUse without feedback omits the message', async () => {
+    await denyToolUse('req_1', 's_1')
+    expect(ipc.respondToApproval).toHaveBeenCalledWith('req_1', 'deny', undefined, undefined)
+  })
+
+  test('denyToolUse with feedback forwards the message to the CLI', async () => {
+    // Regression: the plan viewer's "Request changes..." input used to fire
+    // denyToolUse without the typed text, then send a separate sendMessage.
+    // Claude never saw the feedback, and the plan UI stayed open because of
+    // the race between the two calls. denyToolUse must accept a third
+    // `message` argument and pass it through to respond_to_approval — the
+    // Rust side then emits it as the `message` field in the deny response,
+    // which Claude reads as the reason and continues the turn.
+    await denyToolUse('req_2', 's_1', 'add error handling to step 3')
+    expect(ipc.respondToApproval).toHaveBeenCalledWith(
+      'req_2',
+      'deny',
+      undefined,
+      'add error handling to step 3',
+    )
+  })
+})

--- a/src/store/sessions.ts
+++ b/src/store/sessions.ts
@@ -17,6 +17,9 @@ export const [pendingApprovals, setPendingApprovals] = createStore<Record<string
 export const [autoApprovedCounts, setAutoApprovedCounts] = createStore<Record<string, number>>({})
 export const [sessionCosts, setSessionCosts] = createStore<Record<string, number>>({})
 export const [sessionTokens, setSessionTokens] = createStore<Record<string, { input: number; output: number; cacheRead: number; cacheWrite: number }>>({})
+/// Tracks sessions whose CLI is in the middle of a graceful shutdown after abort.
+/// Set on abort click, cleared when the backend emits `session-aborted`.
+export const [abortingSessions, setAbortingSessions] = createStore<Record<string, boolean>>({})
 export const [rateLimitInfo, setRateLimitInfo] = createSignal<RateLimitInfo | null>(null)
 const [_taskPlanMode, _setTaskPlanMode] = createStore<Record<string, boolean>>({})
 const [_taskThinkingMode, _setTaskThinkingMode] = createStore<Record<string, boolean>>({})
@@ -108,10 +111,12 @@ export async function sendMessage(sessionId: string, message: string, attachment
 }
 
 export async function abortMessage(sessionId: string) {
+  setAbortingSessions(sessionId, true)
   setSessions(s => s.id === sessionId, 'status', 'idle')
   try {
     await ipc.abortMessage(sessionId)
   } catch (e) {
+    setAbortingSessions(produce(store => { delete store[sessionId] }))
     setSessions(s => s.id === sessionId, 'status', 'running')
     throw e
   }
@@ -122,8 +127,8 @@ export async function approveToolUse(requestId: string, sessionId: string) {
   removeApproval(requestId, sessionId)
 }
 
-export async function denyToolUse(requestId: string, sessionId: string) {
-  await ipc.respondToApproval(requestId, 'deny')
+export async function denyToolUse(requestId: string, sessionId: string, message?: string) {
+  await ipc.respondToApproval(requestId, 'deny', undefined, message)
   removeApproval(requestId, sessionId)
 }
 
@@ -162,6 +167,7 @@ export async function closeSession(sessionId: string) {
   setOutputItems(produce(store => { delete store[sessionId] }))
   setSessionCosts(produce(store => { delete store[sessionId] }))
   setSessionTokens(produce(store => { delete store[sessionId] }))
+  setAbortingSessions(produce(store => { delete store[sessionId] }))
   // Persist closure to DB (status = 'closed', filtered from future loads)
   await ipc.closeSession(sessionId)
 }
@@ -337,8 +343,12 @@ export async function initSessionListeners() {
     if (status !== 'running') {
       setPendingApprovals(produce(store => { delete store[sessionId] }))
     }
-    // Drain armed steps on idle
-    if (status === 'idle') {
+    // Drain armed steps on idle — but only if this idle didn't come from an
+    // abort that's still graceful-shutting-down. Spawning a new `--resume`
+    // process while the old one is still writing its JSONL races the transcript
+    // and the queued message gets eaten. Deferred drain happens in the
+    // `session-aborted` listener below.
+    if (status === 'idle' && !abortingSessions[sessionId]) {
       const next = dequeueArmedStep(sessionId)
       if (next) {
         const attachments = next.attachmentsJson ? JSON.parse(next.attachmentsJson) : undefined
@@ -393,6 +403,21 @@ export async function initSessionListeners() {
   await listen<{ sessionId: string; name: string }>('session-name', (event) => {
     const { sessionId, name } = event.payload
     setSessions(s => s.id === sessionId, 'name', name)
+  })
+
+  await listen<string>('session-aborted', (event) => {
+    const sid = event.payload
+    setAbortingSessions(produce(store => { delete store[sid] }))
+    // Now that graceful shutdown is done, drain any armed step that the
+    // session-status:idle listener skipped to avoid racing the transcript.
+    const session = sessions.find(s => s.id === sid)
+    if (session?.status === 'idle') {
+      const next = dequeueArmedStep(sid)
+      if (next) {
+        const attachments = next.attachmentsJson ? deserializeAttachments(next.attachmentsJson) : undefined
+        sendMessage(next.sessionId, next.message, attachments, next.model ?? undefined, next.planMode ?? undefined, next.thinkingMode ?? undefined, next.fastMode ?? undefined)
+      }
+    }
   })
 
   await listen<{ taskId: string; name: string }>('task-name', (event) => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -134,6 +134,7 @@ export type OutputItem =
   | { kind: 'toolStart'; tool: string; input: string }
   | { kind: 'toolResult'; text: string; isError: boolean }
   | { kind: 'system'; text: string }
+  | { kind: 'errorMessage'; message: string; raw?: string }
   | { kind: 'turnEnd'; status: string; timestamp?: number; cost?: number; inputTokens?: number; outputTokens?: number; cacheReadTokens?: number; cacheWriteTokens?: number; error?: string }
   | { kind: 'turnSnapshot'; messageUuid: string }
   | { kind: 'userMessage'; text: string; images?: Array<{ mimeType: string; data: Uint8Array }>; timestamp?: number }


### PR DESCRIPTION
## Summary

Five changes informed by diffing our subprocess transport against the official [claude-agent-sdk-python](https://github.com/anthropics/claude-agent-sdk-python) — all reliability/speed fixes, no behavior changes for users on the happy path.

## Changes

**1. Graceful shutdown on abort** (`task.rs`)
Aborting a session used to `child.kill().await` (SIGKILL) immediately, which can interrupt the CLI mid-write of its session JSONL. The SDK closes stdin, waits 5s, sends SIGTERM, waits 5s, then SIGKILL (see python-sdk#625 / #729). We match that cadence. The grace period runs in a spawned task so the IPC still returns fast.

**Impact:** fixes intermittent "last assistant message missing on --resume" that's otherwise silent.

**2. Strip `CLAUDECODE`, set `CLAUDE_CODE_ENTRYPOINT=verun`** (`task.rs`)
Verun-launched terminals inherit `CLAUDECODE=1` when Verun was itself started from a Claude Code session, subtly changing CLI behavior (python-sdk#573). We strip it. Also set the entrypoint env var so Anthropic telemetry can distinguish Verun-driven sessions.

**3. Non-JSON line skip** (`stream.rs`)
`--permission-prompt-tool` and sandbox modes sometimes interleave lines like `[SandboxDebug]` into stdout. Previously these became `OutputItem::Raw` noise in the UI. Now they're logged and skipped (python-sdk#347).

**4. Single JSON parse per line** (`stream.rs`)
Each stdout line used to be `serde_json::from_str`'d up to three times (control_request check, resume-id extraction, rate_limit check, then `parse_sdk_event`). The loop now parses once into `serde_json::Value` and passes `&Value` everywhere. New `parse_sdk_event_value(&Value)` for the hot path; the `&str` variant stays for tests.

**5. Stdin control protocol: interrupt + context_usage IPC**
New `interrupt_session` IPC sends `{subtype: "interrupt"}` over stdin, cancelling the current turn without killing the process. New `get_session_context_usage` IPC writes `{subtype: "get_context_usage"}` and awaits the matching `control_response` via a new `PendingControlResponses` correlation map. The stream loop routes incoming `control_response` entries back to the pending oneshot so IPC callers can await them, with a 10s timeout.

## Test plan

- [x] `make check` passes (clippy zero warnings, 268 rust tests + 62 vitest)
- [x] New test `control_request_id_is_unique_and_prefixed` in `task::tests`
- [ ] Manual: abort a session mid-turn in `pnpm tauri dev`, reopen and verify the last assistant message is still present on resume
- [ ] Manual: kick off a turn, call `interrupt_session` from devtools, verify it cancels without ending the session
- [ ] Manual: call `get_session_context_usage` on an active session and verify the returned payload
- [ ] Manual: confirm no behavior regressions on sessions that don't use any of the new paths

## Follow-ups (not in this PR)

- Expose `set_model`, `set_permission_mode`, `rewind_files` etc. via the same control-request pipe
- Make `--include-partial-messages` opt-in per task (background tasks could skip ~10x stream volume)
- Bounded channel between stream reader and UI emit for backpressure under massive tool outputs