### PR TITLE
fix: prevent double-submit on plan approve and surface SDK errors

### DIFF
--- a/src-tauri/src/stream.rs
+++ b/src-tauri/src/stream.rs
@@ -202,9 +202,29 @@ fn parse_sdk_event(line: &str) -> Vec<OutputItem> {
                 .and_then(|s| s.as_str())
                 .or_else(|| v.get("status").and_then(|s| s.as_str()))
                 .unwrap_or("unknown");
-            let status = match status_str {
-                "success" => "completed",
-                _ => "error",
+            let is_error = v
+                .get("is_error")
+                .and_then(|e| e.as_bool())
+                .unwrap_or(false);
+            let error = v
+                .get("error")
+                .and_then(|e| e.as_str())
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string())
+                .or_else(|| {
+                    if is_error {
+                        v.get("result")
+                            .and_then(|r| r.as_str())
+                            .filter(|s| !s.is_empty())
+                            .map(|s| s.to_string())
+                    } else {
+                        None
+                    }
+                });
+            let status = if is_error || status_str != "success" {
+                "error"
+            } else {
+                "completed"
             };
             let cost = v.get("total_cost_usd").and_then(|c| c.as_f64());
             // Claude/Cursor: `usage`, Gemini: `stats`
@@ -229,13 +249,6 @@ fn parse_sdk_event(line: &str) -> Vec<OutputItem> {
                         .or_else(|| u.get("cacheWriteTokens"))
                 })
                 .and_then(|t| t.as_u64());
-            let error = if status == "error" {
-                v.get("error")
-                    .and_then(|e| e.as_str())
-                    .map(|s| s.to_string())
-            } else {
-                None
-            };
             vec![OutputItem::TurnEnd {
                 status: status.to_string(),
                 cost,
@@ -1534,6 +1547,20 @@ mod tests {
             OutputItem::TurnEnd { status, error, .. } => {
                 assert_eq!(status, "error");
                 assert_eq!(error.as_deref(), Some("API Error: 529 overloaded"));
+            }
+            _ => panic!("Expected TurnEnd item"),
+        }
+    }
+
+    #[test]
+    fn parse_result_success_with_is_error_uses_result_text() {
+        let line = r#"{"type":"result","subtype":"success","is_error":true,"result":"Prompt is too long","api_error_status":400,"session_id":"abc"}"#;
+        let items = parse_sdk_event(line);
+        assert_eq!(items.len(), 1);
+        match &items[0] {
+            OutputItem::TurnEnd { status, error, .. } => {
+                assert_eq!(status, "error");
+                assert_eq!(error.as_deref(), Some("Prompt is too long"));
             }
             _ => panic!("Expected TurnEnd item"),
         }

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -193,7 +193,7 @@ function rebuildBlocks(items: OutputItem[]): DisplayBlock[] {
           }
           if (blocks[i].type === 'user') break
         }
-        if (item.status !== 'completed') {
+        if (item.status !== 'completed' && !item.error) {
           blocks.push({ type: 'system', text: `Turn ended: ${item.status}` })
         }
         turnStartTs = undefined
@@ -653,7 +653,7 @@ const ErrorBanner: Component<{
   }
 
   return (
-    <div class="mx-5 flex flex-col gap-2 px-3 py-2.5 rounded-lg bg-status-error/8 ring-1 ring-status-error/15">
+    <div class="mx-5 mt-1 flex flex-col gap-2 px-3 py-2.5 rounded-lg bg-status-error/8 ring-1 ring-status-error/15">
       <div class="flex items-start gap-2">
         <AlertTriangle size={14} class="text-status-error shrink-0 mt-0.5" />
         <span class="text-xs text-status-error">

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -565,37 +565,60 @@ export const MessageInput: Component<Props> = (props) => {
     return !!taskPlanFilePath[tid]
   }
 
-  const handleApprovePlan = () => {
+  const [planActionPending, setPlanActionPending] = createSignal(false)
+
+  const handleApprovePlan = async () => {
+    if (planActionPending()) return
     const sid = props.sessionId
     if (!sid) return
+    setPlanActionPending(true)
     const tid = selectedTaskId()
     if (tid) setTaskPlanFilePath(tid, null)
     setPlanMode(false)
-    sendMessage(sid, 'The plan is approved. Please implement it now.', undefined, currentModel(), false)
+    try {
+      await sendMessage(sid, 'The plan is approved. Please implement it now.', undefined, currentModel(), false)
+    } catch (error) {
+      setPlanActionPending(false)
+      throw error
+    }
   }
 
   // Handles both live ExitPlanMode approval and persisted plan viewer
-  const handlePlanViewerAction = (feedback: string) => {
+  const handlePlanViewerAction = async (feedback: string) => {
+    if (planActionPending()) return
     const sid = props.sessionId
     if (!sid) return
+    setPlanActionPending(true)
     const approval = currentApproval()
     if (feedback) {
       // Request changes
       setPlanChanges('')
-      if (approval && isExitPlanMode()) {
-        denyToolUse(approval.requestId, approval.sessionId)
+      try {
+        if (approval && isExitPlanMode()) {
+          await denyToolUse(approval.requestId, approval.sessionId)
+        }
+        await sendMessage(sid, feedback, undefined, currentModel(), true)
+      } catch (error) {
+        setPlanActionPending(false)
+        throw error
       }
-      sendMessage(sid, feedback, undefined, currentModel(), true)
     } else {
-      // Approve — always send a message so plan_mode: false gets persisted
+      // Approve the plan and persist local plan mode/file state.
       setPlanMode(false)
       const tid = selectedTaskId()
       if (tid) setTaskPlanFilePath(tid, null)
-      if (approval && isExitPlanMode()) {
-        approveToolUse(approval.requestId, approval.sessionId)
+      try {
+        if (approval && isExitPlanMode()) {
+          await approveToolUse(approval.requestId, approval.sessionId)
+          return
+        }
+        // Persisted plan review has no live approval waiting on the backend, so
+        // we still need to send the implementation message explicitly.
+        await sendMessage(sid, 'The plan is approved. Please implement it now.', undefined, currentModel(), false)
+      } catch (error) {
+        setPlanActionPending(false)
+        throw error
       }
-      // Send implementation message (persists plan_mode: false so restart doesn't re-show)
-      sendMessage(sid, 'The plan is approved. Please implement it now.', undefined, currentModel(), false)
     }
   }
 
@@ -646,6 +669,7 @@ export const MessageInput: Component<Props> = (props) => {
 
   // Whether to show the full plan viewer (live approval OR persisted plan file)
   const showPlanViewer = () => {
+    if (planActionPending()) return false
     // Never show while session is running (implementing)
     if (props.isRunning && !isExitPlanMode()) return false
     if (isExitPlanMode()) return true
@@ -669,7 +693,7 @@ export const MessageInput: Component<Props> = (props) => {
         const inlinePlan = approval.toolInput.plan as string | undefined
         const filePath = approval.toolInput.planFilePath as string | undefined
         const tid = selectedTaskId()
-        if (tid && filePath) setTaskPlanFilePath(tid, filePath)
+        if (tid && filePath && !planActionPending()) setTaskPlanFilePath(tid, filePath)
         setPlanFilePathSignal(filePath || null)
         if (inlinePlan) {
           setPlanFileContent(inlinePlan)
@@ -709,6 +733,14 @@ export const MessageInput: Component<Props> = (props) => {
     return { plan: content, filePath: planFilePathSignal() }
   }
   const [planChanges, setPlanChanges] = createSignal('')
+
+  createEffect(on(() => currentApproval()?.requestId, (requestId) => {
+    if (requestId) setPlanActionPending(false)
+  }))
+
+  createEffect(on(() => props.isRunning, (isRunning) => {
+    if (!isRunning) setPlanActionPending(false)
+  }))
 
   const pendingCount = () => {
     const sid = props.sessionId
@@ -1450,7 +1482,7 @@ export const MessageInput: Component<Props> = (props) => {
       if (showPlanResponse() && !currentApproval()) {
         const active = document.activeElement
         const isInputFocused = active && (active.tagName === 'INPUT' || active.tagName === 'TEXTAREA')
-        if (e.key === 'Enter' && !e.shiftKey && !isInputFocused) {
+        if (e.key === 'Enter' && !e.shiftKey && !isInputFocused && !planActionPending()) {
           e.preventDefault()
           handleApprovePlan()
           return
@@ -1863,22 +1895,25 @@ export const MessageInput: Component<Props> = (props) => {
                 value={planChanges()}
                 onInput={(e) => setPlanChanges(e.currentTarget.value)}
                 onKeyDown={(e) => {
-                  if (e.key === 'Enter' && !e.shiftKey) {
+                  if (e.key === 'Enter' && !e.shiftKey && !planActionPending()) {
                     e.preventDefault()
                     handlePlanViewerAction(planChanges().trim())
                   }
                 }}
+                disabled={planActionPending()}
               />
               <button
                 class={clsx(
                   'px-4 py-2 rounded-lg text-sm font-medium transition-colors shrink-0',
+                  planActionPending() && 'opacity-60 cursor-not-allowed',
                   planChanges().trim()
                     ? 'bg-amber-500/15 text-amber-400 hover:bg-amber-500/25'
                     : 'bg-status-running/15 text-status-running hover:bg-status-running/25'
                 )}
+                disabled={planActionPending()}
                 onClick={() => handlePlanViewerAction(planChanges().trim())}
               >
-                {planChanges().trim() ? 'Send' : 'Approve'} <span class="text-text-dim ml-1">(Enter)</span>
+                {planActionPending() ? 'Working...' : planChanges().trim() ? 'Send' : 'Approve'} <span class="text-text-dim ml-1">(Enter)</span>
               </button>
             </div>
           </div>
@@ -1943,10 +1978,16 @@ export const MessageInput: Component<Props> = (props) => {
                 <X size={14} />
               </button>
               <button
-                class="px-3 py-1.5 rounded-lg bg-status-running/15 text-status-running text-xs font-medium hover:bg-status-running/25 transition-colors"
+                class={clsx(
+                  'px-3 py-1.5 rounded-lg text-xs font-medium transition-colors',
+                  planActionPending()
+                    ? 'bg-status-running/15 text-status-running opacity-60 cursor-not-allowed'
+                    : 'bg-status-running/15 text-status-running hover:bg-status-running/25'
+                )}
+                disabled={planActionPending()}
                 onClick={handleApprovePlan}
               >
-                Approve <span class="text-text-dim ml-1">(Enter)</span>
+                {planActionPending() ? 'Working...' : 'Approve'} <span class="text-text-dim ml-1">(Enter)</span>
               </button>
             </div>
           </div>

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -50,7 +50,7 @@ function formatItem(item: OutputItem): string {
       if (item.status === 'completed') {
         return `\r\n${GREEN}${DIM} Turn completed${RESET}\r\n`
       }
-      return `\r\n${RED}${DIM} Turn ended: ${item.status}${RESET}\r\n`
+      return `\r\n${RED}${DIM} ${item.error || `Turn ended: ${item.status}`}${RESET}\r\n`
 
     case 'raw':
       return `${DIM}${item.text}${RESET}\r\n`


### PR DESCRIPTION
## Summary

- **Plan approve double-submit** - adds `planActionPending` signal in `MessageInput` that blocks re-submission while an approve/deny is in flight; buttons show "Working..." and are disabled until the next approval arrives or the session stops running
- **SDK error parsing** - `stream.rs` now checks `is_error: true` on result events and falls back to the `result` field text when no explicit `error` field is present (fixes "Prompt is too long" and similar errors being swallowed)
- **Error display** - terminal shows the actual error message instead of generic "Turn ended: error"; chat suppresses the redundant system bubble when an error banner is already rendered

## Test plan

- [ ] Approve a plan and confirm the button disables/shows "Working..." until Claude starts running
- [ ] Trigger a "Prompt is too long" API error and verify it appears in the terminal and error banner
- [ ] Confirm no duplicate "Turn ended: error" system messages in chat when error banner is shown