### PR TITLE
feat: Next Steps UX overhaul + composer controls enabled while running

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ src/components/— UI components
 
 ## Key Rules
 
+- Always TDD: before implementing a fix or feature, write a new failing test (or adjust an existing one to be red) that captures the desired behaviour, run it to confirm it fails, then make the change and re-run to confirm it passes. Applies to both Rust (`cargo test`) and frontend (`pnpm test`).
 - Never do file I/O, git ops, or process management in JS — always in Rust
 - Never poll from frontend — use Tauri events (emit/listen)
 - Never await SQLite writes on the UI thread — fire and forget

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,13 @@ After making changes, update the following as needed:
 - Update the Features list if a user-facing capability was added or significantly changed
 - Do not rewrite sections that are still accurate
 
+## Pull Requests
+
+Before creating a PR, run `gh issue list` (or search by keyword) to find any open issues the change relates to. In the PR description, tag them explicitly:
+
+- `Closes #123` when the PR fully resolves the issue
+- `Related to #123` when the PR touches or partially addresses it
+
 ## Definition of Done
 
 A task is only complete when:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Unreleased
+
+- Plan/Think/Fast toggles no longer disabled while the agent is running, so mode changes can take effect on queued steps and steers
+- Composer model selector no longer disabled while the agent is running; the new selection applies to subsequent sends (manual, armed auto-send, or queued step)
+- Next Steps: click a step to edit inline (textarea + per-step mode toggles + model selector); removed the separate pencil icon and the edit-via-composer round-trip
+- Next Steps: armed state shown as an accent left-border; fire/arm/delete actions revealed on row hover to reduce visual noise
+- Next Steps: arm toggle now uses action-button semantics — armed step shows Pause (click to pause), disarmed shows Play (click to play)
+- Next Steps: fire button sits as the leftmost icon of the right-hand hover cluster (no longer prefixing the message) and is revealed only on hover
+- Next Steps: armed indicator is now an inset box-shadow instead of a left border, so armed rows keep the same horizontal alignment as disarmed ones
+- Next Steps: row contents vertically centered in view mode; buttons in edit mode no longer blur-save the textarea (WebKit fix)
+- ModelSelector: added `fixedPosition` option so the popover escapes overflow-clipping containers (used by inline step editing)
+- Composer: when the agent is running, the Enter button now uses a `ListPlus` icon to match its actual behaviour (add next step) instead of the send arrow
+- Next Steps: first idle step hides the arm/play button (redundant with the send button) and keeps its icons visible without hover; arm button no longer uses accent colour in the armed state
+- Next Steps: remove button uses an `X` icon instead of a trash bin, reflecting "dismiss from queue" semantics rather than permanent delete
+- Next Steps: "Next Steps" header sticks to the top of the list when scrolling so it remains visible as additional steps scroll past
+
 ## 0.7.3 — 2026-04-17
 
 - Creating a new session now focuses it even when a file tab is open

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -1,6 +1,6 @@
 import { Component, createSignal, createEffect, on, Show, For, onMount, onCleanup } from 'solid-js'
 import { sendMessage, abortMessage, createSession, clearOutputItems, pendingApprovals, approveToolUse, denyToolUse, answerQuestion, autoApprovedCounts, sessionCosts, sessionTokens, rateLimitInfo, taskPlanMode, setTaskPlanMode, taskThinkingMode, setTaskThinkingMode, taskFastMode, setTaskFastMode, taskPlanFilePath, setTaskPlanFilePath, outputItems, tryDrainSteps, sessionById, updateSessionModel } from '../store/sessions'
-import { setSelectedSessionId, selectedTaskId, editStepRequest, setEditStepRequest, chatPrefillRequest, setChatPrefillRequest } from '../store/ui'
+import { setSelectedSessionId, selectedTaskId, chatPrefillRequest, setChatPrefillRequest } from '../store/ui'
 import { isSetupRunning, queueMessage, queuedMessages, clearQueuedMessage } from '../store/setup'
 import { taskById } from '../store/tasks'
 import { addStep, getSteps, updateStep, extractStep } from '../store/steps'
@@ -413,26 +413,6 @@ export const MessageInput: Component<Props> = (props) => {
   // Per-session edit state so switching tasks preserves in-progress edits
   type SessionEditState = { messageIdx: number | null; stepId: string | null; draft: string; draftAttachments: Attachment[] }
   const sessionEditStates = new Map<string, SessionEditState>()
-
-  // React to edit requests from StepList (clicking Edit on a step)
-  createEffect(on(editStepRequest, (req) => {
-    if (!req) return
-    setEditStepRequest(null) // consume the request
-    setSavedDraft(message())
-    setSavedDraftAttachments(attachments())
-    setEditingStepId(req.stepId)
-    setMessage(req.message)
-    // Restore step's attachments into the input
-    const stepAttachments: Attachment[] = req.attachmentsJson ? deserializeAttachments(req.attachmentsJson) : []
-    setAttachments(stepAttachments)
-    requestAnimationFrame(() => {
-      if (inputRef) {
-        setInputContent(req.message)
-        setCursorToEnd()
-        inputRef.focus()
-      }
-    })
-  }))
 
   // React to prefill requests from the editor's merged hover ("Ask agent to fix")
   createEffect(on(chatPrefillRequest, (req) => {
@@ -2157,7 +2137,7 @@ export const MessageInput: Component<Props> = (props) => {
                 const sid = props.sessionId
                 if (sid) updateSessionModel(sid, m)
               }}
-              disabled={!props.sessionId || props.isRunning}
+              disabled={!props.sessionId}
             />
 
             <Show when={sessionAgent()?.supportsPlanMode !== false}>
@@ -2170,7 +2150,7 @@ export const MessageInput: Component<Props> = (props) => {
                   'disabled:opacity-30'
                 )}
                 onClick={() => setPlanMode(!planMode())}
-                disabled={!props.sessionId || props.isRunning}
+                disabled={!props.sessionId}
                 title="Plan mode - agent will plan before acting"
               >
                 <ListChecks size={13} />
@@ -2188,7 +2168,7 @@ export const MessageInput: Component<Props> = (props) => {
                   'disabled:opacity-30'
                 )}
                 onClick={() => setThinking(!thinkingMode())}
-                disabled={!props.sessionId || props.isRunning}
+                disabled={!props.sessionId}
                 title="Thinking mode - extended thinking for complex tasks"
               >
                 <Brain size={13} />
@@ -2206,7 +2186,7 @@ export const MessageInput: Component<Props> = (props) => {
                   'disabled:opacity-30'
                 )}
                 onClick={() => setFast(!fastMode())}
-                disabled={!props.sessionId || props.isRunning}
+                disabled={!props.sessionId}
                 title="Fast mode - less thinking, quicker responses"
               >
                 <Zap size={13} />
@@ -2375,8 +2355,7 @@ export const MessageInput: Component<Props> = (props) => {
                 disabled={(!message().trim() && attachments().length === 0) || !props.sessionId || sending()}
                 title="Add next step (Enter)"
               >
-                <ArrowUp size={16} />
-                <div class="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-accent" />
+                <ListPlus size={16} />
               </button>
             </Show>
           </div>

--- a/src/components/ModelSelector.tsx
+++ b/src/components/ModelSelector.tsx
@@ -17,12 +17,17 @@ interface Props {
   agentType: AgentType
   onChange: (model: ModelId) => void
   disabled?: boolean
+  /** Render popover with fixed positioning so it escapes overflow-clipping ancestors */
+  fixedPosition?: boolean
+  compact?: boolean
 }
 
 export const ModelSelector: Component<Props> = (props) => {
   const [open, setOpen] = createSignal(false)
   const [query, setQuery] = createSignal('')
   const [updateModel, setUpdateModel] = createSignal<ModelOption | null>(null)
+  const [popoverPos, setPopoverPos] = createSignal<{ x: number; y: number } | undefined>()
+  let buttonRef: HTMLButtonElement | undefined
 
   const agentInfo = () => agents.find(a => a.id === props.agentType)
   const cliVersion = () => agentInfo()?.cliVersion
@@ -71,22 +76,40 @@ export const ModelSelector: Component<Props> = (props) => {
     setOpen(false)
   }
 
+  const handleToggle = () => {
+    if (!open() && props.fixedPosition && buttonRef) {
+      const r = buttonRef.getBoundingClientRect()
+      setPopoverPos({ x: r.left, y: r.top })
+    }
+    setOpen(o => !o)
+  }
+
   return (
     <div class="relative">
       <button
+        ref={buttonRef}
         class={clsx(
-          'flex items-center gap-1.5 px-2 py-1 rounded-md text-[11px] text-text-muted hover:text-text-secondary hover:bg-surface-2 transition-colors disabled:opacity-30',
+          'flex items-center gap-1.5 rounded-md text-text-muted hover:text-text-secondary hover:bg-surface-2 transition-colors disabled:opacity-30',
+          props.compact ? 'px-1.5 py-0.5 text-[10px]' : 'px-2 py-1 text-[11px]',
           open() && 'text-text-secondary bg-surface-2',
         )}
-        onClick={() => setOpen(o => !o)}
+        onClick={handleToggle}
         disabled={props.disabled}
       >
-        <SvgIcon svg={agentSvg()} size={12} />
+        <SvgIcon svg={agentSvg()} size={props.compact ? 10 : 12} />
         <span>{currentOpt()?.label ?? resolvedModel()}</span>
-        <ChevronDown size={9} class={clsx('transition-transform', open() && 'rotate-180')} />
+        <ChevronDown size={props.compact ? 8 : 9} class={clsx('transition-transform', open() && 'rotate-180')} />
       </button>
 
-      <Popover open={open()} onClose={() => setOpen(false)} class="py-1 min-w-52 absolute bottom-full left-0 mb-1">
+      <Popover
+        open={open()}
+        onClose={() => setOpen(false)}
+        pos={props.fixedPosition ? popoverPos() : undefined}
+        class={clsx(
+          'py-1 min-w-52',
+          props.fixedPosition ? '-translate-y-full -mt-1' : 'absolute bottom-full left-0 mb-1',
+        )}
+      >
         <div class="px-3 py-1.5 text-[10px] text-text-dim uppercase tracking-wider flex items-center gap-1.5">
           <SvgIcon svg={agentSvg()} size={10} />
           {AGENT_DISPLAY_NAMES[props.agentType]}

--- a/src/components/StepList.test.tsx
+++ b/src/components/StepList.test.tsx
@@ -1,0 +1,468 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+import { render, fireEvent } from '@solidjs/testing-library'
+
+vi.mock('../lib/ipc', () => ({
+  listSteps: vi.fn().mockResolvedValue([]),
+  addStep: vi.fn().mockResolvedValue(undefined),
+  updateStep: vi.fn().mockResolvedValue(undefined),
+  deleteStep: vi.fn().mockResolvedValue(undefined),
+  reorderSteps: vi.fn().mockResolvedValue(undefined),
+  disarmAllSteps: vi.fn().mockResolvedValue(undefined),
+}))
+
+const sendMessageMock = vi.fn()
+vi.mock('../store/sessions', () => ({
+  sendMessage: (...args: unknown[]) => sendMessageMock(...args),
+  sessionById: () => ({ id: 's-001', agentType: 'claude' }),
+}))
+
+vi.mock('../store/agents', () => ({
+  agents: [{
+    id: 'claude',
+    name: 'Claude',
+    models: [{ id: 'sonnet', label: 'Sonnet' }, { id: 'opus', label: 'Opus' }],
+    supportsPlanMode: true,
+    supportsEffort: true,
+  }],
+}))
+
+// Mock ModelSelector to avoid pulling in Tauri-coupled dialogs; expose onChange hook.
+const modelChangeMock = vi.fn()
+vi.mock('./ModelSelector', () => ({
+  ModelSelector: (props: { model: string | null | undefined; onChange: (m: string) => void }) => {
+    return (
+      <button
+        data-testid="model-selector"
+        onClick={() => {
+          modelChangeMock()
+          props.onChange('opus')
+        }}
+      >
+        {props.model ?? 'none'}
+      </button>
+    )
+  },
+}))
+
+import { StepList } from './StepList'
+import { addStep, clearSteps, getSteps } from '../store/steps'
+import * as ipc from '../lib/ipc'
+
+const SID = 's-001'
+
+function seedStep(overrides: Partial<Parameters<typeof addStep>[0]> = {}) {
+  addStep({
+    sessionId: SID,
+    message: 'Original message',
+    armed: false,
+    ...overrides,
+  })
+  return getSteps(SID)[getSteps(SID).length - 1]
+}
+
+describe('<StepList />', () => {
+  beforeEach(() => {
+    clearSteps(SID)
+    clearSteps('s-002')
+    sendMessageMock.mockReset()
+    modelChangeMock.mockReset()
+    vi.mocked(ipc.updateStep).mockClear()
+    vi.mocked(ipc.deleteStep).mockClear()
+  })
+
+  test('renders nothing when there are no steps', () => {
+    const { container } = render(() => <StepList sessionId={SID} isRunning={false} />)
+    expect(container.textContent).toBe('')
+  })
+
+  test('renders the step message in view mode and does not show a pencil / edit button', () => {
+    seedStep({ message: 'do the thing' })
+    const { container, queryByTitle } = render(() => <StepList sessionId={SID} isRunning={false} />)
+    expect(container.textContent).toContain('do the thing')
+    // No pencil/edit affordance — editing is click-to-edit on the message itself.
+    expect(queryByTitle('Edit')).toBeNull()
+  })
+
+  test('clicking the message enters edit mode (textarea + mode toggles)', async () => {
+    seedStep({ message: 'click me' })
+    const { container } = render(() => <StepList sessionId={SID} isRunning={false} />)
+    const msg = container.querySelector('.cursor-text') as HTMLElement
+    expect(msg).toBeTruthy()
+    fireEvent.click(msg)
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement
+    expect(textarea).toBeTruthy()
+    expect(textarea.value).toBe('click me')
+    // Mode buttons visible in edit mode
+    expect(container.textContent).toContain('Plan')
+    expect(container.textContent).toContain('Think')
+    expect(container.textContent).toContain('Fast')
+    // Model selector present (mocked)
+    expect(container.querySelector('[data-testid="model-selector"]')).toBeTruthy()
+  })
+
+  test('mode buttons and model selector are hidden in view mode', () => {
+    seedStep({ message: 'view only' })
+    const { container, queryByTitle } = render(() => <StepList sessionId={SID} isRunning={false} />)
+    // Plan/Think/Fast buttons only render in edit mode
+    expect(queryByTitle('Plan mode')).toBeNull()
+    expect(queryByTitle('Thinking mode')).toBeNull()
+    expect(queryByTitle('Fast mode')).toBeNull()
+    expect(container.querySelector('[data-testid="model-selector"]')).toBeNull()
+  })
+
+  test('Enter saves edits and exits edit mode', () => {
+    const step = seedStep({ message: 'before' })
+    const { container } = render(() => <StepList sessionId={SID} isRunning={false} />)
+    fireEvent.click(container.querySelector('.cursor-text')!)
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement
+    fireEvent.input(textarea, { target: { value: 'after' } })
+    fireEvent.keyDown(textarea, { key: 'Enter' })
+
+    expect(getSteps(SID)[0].message).toBe('after')
+    expect(container.querySelector('textarea')).toBeNull()
+    expect(ipc.updateStep).toHaveBeenCalledWith(step.id, 'after', false, null, null, null, null, null)
+  })
+
+  test('Shift+Enter does not save — handled as native newline', () => {
+    seedStep({ message: 'keep editing' })
+    const { container } = render(() => <StepList sessionId={SID} isRunning={false} />)
+    fireEvent.click(container.querySelector('.cursor-text')!)
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement
+    fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: true })
+    // Still in edit mode
+    expect(container.querySelector('textarea')).toBeTruthy()
+    // Message unchanged in store
+    expect(getSteps(SID)[0].message).toBe('keep editing')
+  })
+
+  test('Escape cancels without saving', () => {
+    seedStep({ message: 'unchanged' })
+    const { container } = render(() => <StepList sessionId={SID} isRunning={false} />)
+    fireEvent.click(container.querySelector('.cursor-text')!)
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement
+    fireEvent.input(textarea, { target: { value: 'should-be-discarded' } })
+    fireEvent.keyDown(textarea, { key: 'Escape' })
+
+    expect(getSteps(SID)[0].message).toBe('unchanged')
+    expect(container.querySelector('textarea')).toBeNull()
+  })
+
+  test('empty-string Enter does not update the message (guard against losing content)', () => {
+    seedStep({ message: 'has content' })
+    const { container } = render(() => <StepList sessionId={SID} isRunning={false} />)
+    fireEvent.click(container.querySelector('.cursor-text')!)
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement
+    fireEvent.input(textarea, { target: { value: '   ' } })
+    fireEvent.keyDown(textarea, { key: 'Enter' })
+
+    expect(getSteps(SID)[0].message).toBe('has content')
+  })
+
+  test('blur outside the editing row saves', () => {
+    seedStep({ message: 'start' })
+    const { container } = render(() => <StepList sessionId={SID} isRunning={false} />)
+    fireEvent.click(container.querySelector('.cursor-text')!)
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement
+    fireEvent.input(textarea, { target: { value: 'via-blur' } })
+    // blur with no relatedTarget simulates click outside
+    fireEvent.blur(textarea, { relatedTarget: null })
+
+    expect(getSteps(SID)[0].message).toBe('via-blur')
+    expect(container.querySelector('textarea')).toBeNull()
+  })
+
+  test('blur to a sibling inside the row (e.g. mode toggle) does NOT save', () => {
+    seedStep({ message: 'keep-editing' })
+    const { container } = render(() => <StepList sessionId={SID} isRunning={false} />)
+    fireEvent.click(container.querySelector('.cursor-text')!)
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement
+    fireEvent.input(textarea, { target: { value: 'draft' } })
+
+    const planBtn = container.querySelector('button[title="Plan mode"]') as HTMLElement
+    expect(planBtn).toBeTruthy()
+    fireEvent.blur(textarea, { relatedTarget: planBtn })
+
+    // Still in edit mode
+    expect(container.querySelector('textarea')).toBeTruthy()
+  })
+
+  test('clicking Plan/Think/Fast toggles update the step immediately (inline)', () => {
+    const step = seedStep({ message: 'm', planMode: false, thinkingMode: false, fastMode: false })
+    const { container } = render(() => <StepList sessionId={SID} isRunning={false} />)
+    fireEvent.click(container.querySelector('.cursor-text')!)
+
+    fireEvent.click(container.querySelector('button[title="Plan mode"]')!)
+    fireEvent.click(container.querySelector('button[title="Thinking mode"]')!)
+    fireEvent.click(container.querySelector('button[title="Fast mode"]')!)
+
+    const after = getSteps(SID).find(s => s.id === step.id)!
+    expect(after.planMode).toBe(true)
+    expect(after.thinkingMode).toBe(true)
+    expect(after.fastMode).toBe(true)
+  })
+
+  test('clicking the model selector updates the step model', () => {
+    const step = seedStep({ message: 'm', model: 'sonnet' })
+    const { container } = render(() => <StepList sessionId={SID} isRunning={false} />)
+    fireEvent.click(container.querySelector('.cursor-text')!)
+    fireEvent.click(container.querySelector('[data-testid="model-selector"]')!)
+
+    expect(modelChangeMock).toHaveBeenCalled()
+    expect(getSteps(SID).find(s => s.id === step.id)!.model).toBe('opus')
+  })
+
+  test('armed step uses a non-layout-shifting accent indicator (inset shadow, not a border)', () => {
+    seedStep({ message: 'armed', armed: true })
+    const { container } = render(() => <StepList sessionId={SID} isRunning={false} />)
+    const row = container.querySelector('[data-step-id]') as HTMLElement
+    // No border class that would add layout width and push content right
+    expect(row.className).not.toContain('border-l-2')
+    expect(row.className).not.toContain('border-l-accent')
+    // Inset box-shadow draws the accent bar without affecting layout
+    expect(row.className).toMatch(/shadow-\[inset/)
+  })
+
+  test('disarmed step gets no accent indicator', () => {
+    seedStep({ message: 'paused', armed: false })
+    const { container } = render(() => <StepList sessionId={SID} isRunning={false} />)
+    const row = container.querySelector('[data-step-id]') as HTMLElement
+    expect(row.className).not.toMatch(/shadow-\[inset/)
+    expect(row.className).not.toContain('border-l-accent')
+  })
+
+  test('editing row does not render the armed indicator even when the step is armed', () => {
+    seedStep({ message: 'armed and editing', armed: true })
+    const { container } = render(() => <StepList sessionId={SID} isRunning={false} />)
+    fireEvent.click(container.querySelector('.cursor-text')!)
+    const row = container.querySelector('[data-step-id]') as HTMLElement
+    // When editing, we use ring styling, not the armed shadow
+    expect(row.className).not.toMatch(/shadow-\[inset/)
+    expect(row.className).toContain('ring-accent/40')
+  })
+
+  test('arm/pause toggle button flips the armed state without entering edit mode', () => {
+    seedStep({ message: 'first', armed: false })
+    const step = seedStep({ message: 'toggle me', armed: false })
+    const { container } = render(() => <StepList sessionId={SID} isRunning={false} />)
+    const armBtn = container.querySelector('button[title^="Arm"]') as HTMLElement
+    expect(armBtn).toBeTruthy()
+    fireEvent.click(armBtn)
+    expect(getSteps(SID).find(s => s.id === step.id)!.armed).toBe(true)
+    // Should not have opened the editor
+    expect(container.querySelector('textarea')).toBeNull()
+  })
+
+  test('delete button removes the step', () => {
+    const step = seedStep({ message: 'bye', armed: false })
+    const { container } = render(() => <StepList sessionId={SID} isRunning={false} />)
+    fireEvent.click(container.querySelector('button[title="Remove"]')!)
+    expect(getSteps(SID).find(s => s.id === step.id)).toBeUndefined()
+    expect(ipc.deleteStep).toHaveBeenCalledWith(step.id)
+  })
+
+  test('remove button uses the X icon (dismiss from queue, not permanent delete)', () => {
+    seedStep({ message: 'bye', armed: false })
+    const { container } = render(() => <StepList sessionId={SID} isRunning={false} />)
+    const btn = container.querySelector('button[title="Remove"]') as HTMLElement
+    expect(btn.querySelector('.lucide-x')).toBeTruthy()
+    expect(btn.querySelector('.lucide-trash-2')).toBeNull()
+  })
+
+  test('fire button sends the first step when idle', async () => {
+    const step = seedStep({
+      message: 'fire me',
+      armed: false,
+      model: 'opus',
+      planMode: true,
+      thinkingMode: false,
+      fastMode: true,
+    })
+    const { container } = render(() => <StepList sessionId={SID} isRunning={false} />)
+    fireEvent.click(container.querySelector('button[title="Send now"]')!)
+
+    expect(sendMessageMock).toHaveBeenCalledWith(SID, 'fire me', undefined, 'opus', true, false, true)
+    // Fire extracts the step, so it should be gone from the store
+    expect(getSteps(SID).find(s => s.id === step.id)).toBeUndefined()
+  })
+
+  test('fire button is not rendered when running', () => {
+    seedStep({ message: 'no fire', armed: false })
+    const { queryByTitle } = render(() => <StepList sessionId={SID} isRunning={true} />)
+    expect(queryByTitle('Send now')).toBeNull()
+  })
+
+  test('fire button is only shown on the first step', () => {
+    seedStep({ message: 'first', armed: false })
+    seedStep({ message: 'second', armed: false })
+    const { container } = render(() => <StepList sessionId={SID} isRunning={false} />)
+    const fireButtons = container.querySelectorAll('button[title="Send now"]')
+    expect(fireButtons.length).toBe(1)
+  })
+
+  // ─── UI regression suite for the reported issues ────────────────────
+
+  test('view-mode row vertically centers contents (items-center)', () => {
+    seedStep({ message: 'x' })
+    const { container } = render(() => <StepList sessionId={SID} isRunning={false} />)
+    const row = container.querySelector('[data-step-id]') as HTMLElement
+    expect(row.className).toContain('items-center')
+    expect(row.className).not.toContain('items-start')
+  })
+
+  test('armed step shows Pause icon (state-indicator semantics: armed means "playing", so pause to act)', () => {
+    seedStep({ message: 'first', armed: false })
+    seedStep({ armed: true })
+    const { container } = render(() => <StepList sessionId={SID} isRunning={false} />)
+    const btn = container.querySelector('button[title^="Disarm"]') as HTMLElement
+    expect(btn).toBeTruthy()
+    expect(btn.querySelector('.lucide-pause')).toBeTruthy()
+    expect(btn.querySelector('.lucide-play')).toBeNull()
+  })
+
+  test('armed pause button is not accent-colored (accent is reserved for primary actions)', () => {
+    seedStep({ message: 'first', armed: false })
+    seedStep({ armed: true })
+    const { container } = render(() => <StepList sessionId={SID} isRunning={false} />)
+    const btn = container.querySelector('button[title^="Disarm"]') as HTMLElement
+    expect(btn).toBeTruthy()
+    expect(btn.className).not.toMatch(/(?:^|\s)text-accent(?:\s|$|\/)/)
+  })
+
+  test('disarmed step shows Play icon', () => {
+    seedStep({ message: 'first', armed: false })
+    seedStep({ armed: false })
+    const { container } = render(() => <StepList sessionId={SID} isRunning={false} />)
+    const btn = container.querySelector('button[title^="Arm"]') as HTMLElement
+    expect(btn).toBeTruthy()
+    expect(btn.querySelector('.lucide-play')).toBeTruthy()
+    expect(btn.querySelector('.lucide-pause')).toBeNull()
+  })
+
+  test('arm toggle button is revealed only on row hover for non-first step (lives inside group-hover element)', () => {
+    seedStep({ message: 'first', armed: false })
+    seedStep({ armed: false })
+    const { container } = render(() => <StepList sessionId={SID} isRunning={false} />)
+    const btn = container.querySelector('button[title^="Arm"]') as HTMLElement
+    expect(btn).toBeTruthy()
+    // Walk up to find a group-hover:opacity-100 wrapper
+    let el: HTMLElement | null = btn
+    let found = false
+    while (el && el.getAttribute('data-step-id') === null) {
+      if ((el.className || '').includes('group-hover:opacity-100')) { found = true; break }
+      el = el.parentElement
+    }
+    expect(found).toBe(true)
+  })
+
+  test('first idle step hides the arm/play button (redundant with the send button)', () => {
+    seedStep({ message: 'first', armed: false })
+    const { container } = render(() => <StepList sessionId={SID} isRunning={false} />)
+    expect(container.querySelector('button[title^="Arm"]')).toBeNull()
+    expect(container.querySelector('button[title^="Disarm"]')).toBeNull()
+  })
+
+  test('first running step still shows the arm/play button (no send button during run)', () => {
+    seedStep({ message: 'first', armed: false })
+    const { container } = render(() => <StepList sessionId={SID} isRunning={true} />)
+    expect(container.querySelector('button[title^="Arm"]')).toBeTruthy()
+  })
+
+  test('first idle step action cluster is always visible (not hover-gated)', () => {
+    seedStep({ message: 'first', armed: false })
+    const { container } = render(() => <StepList sessionId={SID} isRunning={false} />)
+    const fireBtn = container.querySelector('button[title="Send now"]') as HTMLElement
+    expect(fireBtn).toBeTruthy()
+    // Walk up: from the fire button to the row boundary, nothing should be hover-gated.
+    let el: HTMLElement | null = fireBtn
+    while (el && el.getAttribute('data-step-id') === null) {
+      const cls = el.className || ''
+      expect(cls).not.toContain('opacity-0')
+      expect(cls).not.toContain('group-hover:opacity-100')
+      el = el.parentElement
+    }
+  })
+
+  test('non-first idle step action cluster remains hover-gated', () => {
+    seedStep({ message: 'first', armed: false })
+    seedStep({ message: 'second', armed: false })
+    const { container } = render(() => <StepList sessionId={SID} isRunning={false} />)
+    const rows = container.querySelectorAll('[data-step-id]')
+    const secondRow = rows[1] as HTMLElement
+    const delBtn = secondRow.querySelector('button[title="Remove"]') as HTMLElement
+    expect(delBtn).toBeTruthy()
+    let el: HTMLElement | null = delBtn
+    let found = false
+    while (el && el.getAttribute('data-step-id') === null) {
+      if ((el.className || '').includes('group-hover:opacity-100')) { found = true; break }
+      el = el.parentElement
+    }
+    expect(found).toBe(true)
+  })
+
+  test('fire button renders AFTER the message (so it does not push the message text right)', () => {
+    seedStep({ message: 'first', armed: false })
+    const { container } = render(() => <StepList sessionId={SID} isRunning={false} />)
+    const row = container.querySelector('[data-step-id]') as HTMLElement
+    const fireBtn = row.querySelector('button[title="Send now"]') as HTMLElement
+    const messageArea = row.querySelector('.cursor-text') as HTMLElement
+    expect(fireBtn).toBeTruthy()
+    expect(messageArea).toBeTruthy()
+    // messageArea should precede fireBtn in DOM order
+    expect(messageArea.compareDocumentPosition(fireBtn) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
+  test('fire button is the leftmost icon in the right-hand action cluster (before delete)', () => {
+    seedStep({ message: 'first', armed: false })
+    const { container } = render(() => <StepList sessionId={SID} isRunning={false} />)
+    const row = container.querySelector('[data-step-id]') as HTMLElement
+    const fireBtn = row.querySelector('button[title="Send now"]') as HTMLElement
+    const delBtn = row.querySelector('button[title="Remove"]') as HTMLElement
+    expect(fireBtn.compareDocumentPosition(delBtn) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
+  test('mousedown on a mode toggle in edit mode is preventDefault-ed (keeps textarea focus so click does not blur-save)', () => {
+    seedStep({ message: 'keep focus', planMode: false })
+    const { container } = render(() => <StepList sessionId={SID} isRunning={false} />)
+    fireEvent.click(container.querySelector('.cursor-text')!)
+
+    const planBtn = container.querySelector('button[title="Plan mode"]') as HTMLElement
+    expect(planBtn).toBeTruthy()
+    const evt = new MouseEvent('mousedown', { bubbles: true, cancelable: true })
+    planBtn.dispatchEvent(evt)
+    expect(evt.defaultPrevented).toBe(true)
+  })
+
+  test('mousedown on model selector in edit mode is preventDefault-ed', () => {
+    seedStep({ message: 'keep focus 2' })
+    const { container } = render(() => <StepList sessionId={SID} isRunning={false} />)
+    fireEvent.click(container.querySelector('.cursor-text')!)
+
+    const model = container.querySelector('[data-testid="model-selector"]') as HTMLElement
+    const evt = new MouseEvent('mousedown', { bubbles: true, cancelable: true })
+    model.dispatchEvent(evt)
+    expect(evt.defaultPrevented).toBe(true)
+  })
+
+  test('mousedown on the textarea itself is NOT preventDefault-ed (so the caret moves)', () => {
+    seedStep({ message: 'caret' })
+    const { container } = render(() => <StepList sessionId={SID} isRunning={false} />)
+    fireEvent.click(container.querySelector('.cursor-text')!)
+
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement
+    const evt = new MouseEvent('mousedown', { bubbles: true, cancelable: true })
+    textarea.dispatchEvent(evt)
+    expect(evt.defaultPrevented).toBe(false)
+  })
+
+  test('"Next Steps" header stays above the scroll container (header is outside the scrollable list)', () => {
+    seedStep({ message: 'x' })
+    const { container, getByText } = render(() => <StepList sessionId={SID} isRunning={false} />)
+    const header = getByText('Next Steps').parentElement as HTMLElement
+    const row = container.querySelector('[data-step-id]') as HTMLElement
+    const scroller = row.parentElement as HTMLElement
+    // The scroll container is the rows' direct parent and owns overflow-y-auto
+    expect(scroller.className).toContain('overflow-y-auto')
+    // The header must NOT live inside the scroll container, otherwise it scrolls away
+    expect(scroller.contains(header)).toBe(false)
+  })
+})

--- a/src/components/StepList.tsx
+++ b/src/components/StepList.tsx
@@ -1,29 +1,36 @@
 import { Component, For, Show, createSignal } from 'solid-js'
-import { GripVertical, Play, Pause, Pencil, Trash2, ArrowUp, ListChecks, Zap, Paperclip } from 'lucide-solid'
+import { GripVertical, Play, Pause, X, ArrowUp, ListChecks, Zap, Paperclip, Brain } from 'lucide-solid'
 import { getSteps, removeStep, updateStep, reorderSteps, extractStep } from '../store/steps'
-import { sendMessage } from '../store/sessions'
-import { setEditStepRequest } from '../store/ui'
+import { sendMessage, sessionById } from '../store/sessions'
+import { agents } from '../store/agents'
 import { clsx } from 'clsx'
+import { ModelSelector } from './ModelSelector'
+import type { AgentType, ModelId } from '../types'
 
 interface Props {
   sessionId: string | null
   isRunning: boolean
 }
 
+const ROW_HEIGHT = 32
+
 export const StepList: Component<Props> = (props) => {
   const [dragging, setDragging] = createSignal<number | null>(null)
   const [dropTarget, setDropTarget] = createSignal<number | null>(null)
+  const [editingId, setEditingId] = createSignal<string | null>(null)
+  const [editText, setEditText] = createSignal('')
 
   const stepList = () => getSteps(props.sessionId)
+
+  const sessionAgent = () => {
+    const sid = props.sessionId
+    const at = sid ? sessionById(sid)?.agentType : undefined
+    return at ? agents.find(a => a.id === at) : undefined
+  }
 
   const toggleArmed = (stepId: string, currentArmed: boolean) => {
     if (!props.sessionId) return
     updateStep(props.sessionId, stepId, { armed: !currentArmed })
-  }
-
-  const handleEdit = (stepId: string, message: string, attachmentsJson?: string | null) => {
-    if (!props.sessionId) return
-    setEditStepRequest({ sessionId: props.sessionId, stepId, message, attachmentsJson })
   }
 
   const handleDelete = (stepId: string) => {
@@ -43,7 +50,25 @@ export const StepList: Component<Props> = (props) => {
     )
   }
 
-  const ROW_HEIGHT = 32
+  const startEdit = (stepId: string, message: string) => {
+    setEditingId(stepId)
+    setEditText(message)
+  }
+
+  const saveEdit = () => {
+    const id = editingId()
+    if (!id || !props.sessionId) return
+    const msg = editText().trim()
+    if (msg) updateStep(props.sessionId, id, { message: msg })
+    setEditingId(null)
+  }
+
+  const cancelEdit = () => setEditingId(null)
+
+  const autoResize = (el: HTMLTextAreaElement) => {
+    el.style.height = 'auto'
+    el.style.height = `${el.scrollHeight}px`
+  }
 
   const startDrag = (e: MouseEvent, dragIndex: number) => {
     e.preventDefault()
@@ -80,93 +105,203 @@ export const StepList: Component<Props> = (props) => {
 
   return (
     <Show when={stepList().length > 0}>
-      <div class="border-t border-border px-3 py-1.5 max-h-40 overflow-y-auto">
+      <div class="border-t border-border px-3 py-1.5 max-h-48 flex flex-col min-h-0">
         <div class="flex items-center justify-between mb-1">
           <span class="text-[10px] text-text-dim font-medium uppercase tracking-wider">Next Steps</span>
         </div>
-        <For each={stepList()}>
-          {(step, i) => (
-            <div
-              class={clsx(
-                'flex items-center gap-1 px-1.5 py-1 rounded text-xs transition-colors',
-                dragging() === i() && 'opacity-40',
-                dropTarget() === i() && dragging() !== null && dragging() !== i() && 'border-t-2 border-accent',
-                'hover:bg-surface-2',
-              )}
-              style={{ height: `${ROW_HEIGHT}px` }}
-            >
-              {/* Drag handle */}
+        <div class="flex-1 overflow-y-auto min-h-0">
+          <For each={stepList()}>
+          {(step, i) => {
+            const isEditing = () => editingId() === step.id
+            const attachmentCount = () => {
+              if (!step.attachmentsJson) return 0
+              try { return JSON.parse(step.attachmentsJson).length } catch { return 0 }
+            }
+            return (
               <div
-                class="cursor-grab text-text-dim hover:text-text-muted shrink-0 flex items-center"
-                onMouseDown={(e) => startDrag(e, i())}
-              >
-                <GripVertical size={12} />
-              </div>
-
-              {/* Number */}
-              <span class="text-text-dim w-4 text-right shrink-0">{i() + 1}.</span>
-
-              {/* Message + mode indicators */}
-              <div class="flex-1 flex items-center gap-1 min-w-0">
-                <span class="truncate text-text-secondary">{step.message}</span>
-                <Show when={step.planMode}>
-                  <span class="text-text-dim shrink-0 flex items-center" title="Plan mode"><ListChecks size={11} /></span>
-                </Show>
-                <Show when={step.fastMode}>
-                  <span class="text-text-dim shrink-0 flex items-center" title="Fast mode"><Zap size={11} /></span>
-                </Show>
-                <Show when={step.attachmentsJson}>
-                  {(() => {
-                    try { const n = JSON.parse(step.attachmentsJson!).length; return n > 0 ? <span class="text-text-dim shrink-0 flex items-center" title={`${n} attachment${n > 1 ? 's' : ''}`}><Paperclip size={11} /></span> : null } catch { return null }
-                  })()}
-                </Show>
-              </div>
-
-              {/* Armed toggle */}
-              <button
+                data-step-id={step.id}
                 class={clsx(
-                  'p-0.5 rounded transition-colors shrink-0',
-                  step.armed
-                    ? 'text-accent hover:text-accent/80'
-                    : 'text-text-dim hover:text-text-muted',
+                  'group flex gap-1 px-1.5 py-1 rounded text-xs relative transition-colors',
+                  isEditing() ? 'items-start' : 'items-center',
+                  dragging() === i() && 'opacity-40',
+                  dropTarget() === i() && dragging() !== null && dragging() !== i() && 'border-t-2 border-accent',
+                  !isEditing() && 'hover:bg-surface-2',
+                  isEditing() && 'bg-surface-2 ring-1 ring-accent/40',
+                  !isEditing() && step.armed && 'shadow-[inset_2px_0_0_0_#2d6e4f]',
                 )}
-                onClick={() => toggleArmed(step.id, step.armed)}
-                title={step.armed ? 'Disarm (won\'t auto-send)' : 'Arm (auto-send when idle)'}
+                style={!isEditing() ? { height: `${ROW_HEIGHT}px` } : undefined}
+                onMouseDown={(e) => {
+                  // Keep textarea focused when clicking buttons/selector in edit mode
+                  // so the blur-to-save doesn't fire. WebKit (Tauri) does not focus
+                  // buttons on click, so relatedTarget-based detection is unreliable.
+                  if (!isEditing()) return
+                  const t = e.target as HTMLElement
+                  if (!t.closest('textarea, input')) e.preventDefault()
+                }}
               >
-                {step.armed ? <Play size={12} /> : <Pause size={12} />}
-              </button>
-
-              {/* Fire button — only for first step when idle */}
-              <Show when={i() === 0 && !props.isRunning}>
-                <button
-                  class="p-0.5 rounded text-accent hover:bg-accent/10 transition-colors shrink-0"
-                  onClick={() => handleFire(step.id)}
-                  title="Send now"
+                {/* Drag handle */}
+                <div
+                  class={clsx(
+                    'text-text-dim shrink-0 flex items-center',
+                    isEditing() ? 'pt-1' : 'cursor-grab hover:text-text-muted',
+                  )}
+                  onMouseDown={(e) => { if (!isEditing()) startDrag(e, i()) }}
                 >
-                  <ArrowUp size={13} />
-                </button>
-              </Show>
+                  <GripVertical size={12} />
+                </div>
 
-              {/* Edit */}
-              <button
-                class="p-0.5 rounded text-text-dim hover:text-text-muted hover:bg-surface-3 transition-colors shrink-0"
-                onClick={() => handleEdit(step.id, step.message, step.attachmentsJson)}
-                title="Edit"
-              >
-                <Pencil size={12} />
-              </button>
+                <Show
+                  when={isEditing()}
+                  fallback={
+                    <>
+                      {/* Message (click to edit) */}
+                      <div
+                        class="flex-1 flex items-center gap-1 min-w-0 cursor-text"
+                        onClick={() => startEdit(step.id, step.message)}
+                      >
+                        <span class="truncate text-text-secondary">{step.message}</span>
+                        <Show when={step.planMode}>
+                          <span class="text-text-dim shrink-0 flex items-center" title="Plan mode"><ListChecks size={11} /></span>
+                        </Show>
+                        <Show when={step.fastMode}>
+                          <span class="text-text-dim shrink-0 flex items-center" title="Fast mode"><Zap size={11} /></span>
+                        </Show>
+                        <Show when={attachmentCount() > 0}>
+                          <span class="text-text-dim shrink-0 flex items-center" title={`${attachmentCount()} attachment${attachmentCount() > 1 ? 's' : ''}`}>
+                            <Paperclip size={11} />
+                          </span>
+                        </Show>
+                      </div>
 
-              {/* Delete */}
-              <button
-                class="p-0.5 rounded text-text-dim hover:text-status-error hover:bg-status-error/10 transition-colors shrink-0"
-                onClick={() => handleDelete(step.id)}
-                title="Remove"
-              >
-                <Trash2 size={12} />
-              </button>
-            </div>
-          )}
-        </For>
+                      {/* Action cluster: fire (first idle step) → arm → delete.
+                          First idle step shows icons always; other rows hover-reveal. */}
+                      <div
+                        class={clsx(
+                          'flex items-center shrink-0 transition-opacity',
+                          !(i() === 0 && !props.isRunning) && 'opacity-0 group-hover:opacity-100',
+                        )}
+                      >
+                        <Show when={i() === 0 && !props.isRunning}>
+                          <button
+                            class="p-0.5 rounded text-accent hover:bg-accent/10 transition-colors shrink-0"
+                            onClick={() => handleFire(step.id)}
+                            title="Send now"
+                          >
+                            <ArrowUp size={13} />
+                          </button>
+                        </Show>
+
+                        <Show when={!(i() === 0 && !props.isRunning)}>
+                          <button
+                            class="p-0.5 rounded transition-colors shrink-0 text-text-dim hover:text-text-muted"
+                            onClick={() => toggleArmed(step.id, step.armed)}
+                            title={step.armed ? 'Disarm (won\'t auto-send)' : 'Arm (auto-send when idle)'}
+                          >
+                            {step.armed ? <Pause size={12} /> : <Play size={12} />}
+                          </button>
+                        </Show>
+
+                        <button
+                          class="p-0.5 rounded text-text-dim hover:text-status-error hover:bg-status-error/10 transition-colors shrink-0"
+                          onClick={() => handleDelete(step.id)}
+                          title="Remove"
+                        >
+                          <X size={12} />
+                        </button>
+                      </div>
+                    </>
+                  }
+                >
+                  {/* Edit mode */}
+                  <div class="flex-1 flex flex-col gap-1 min-w-0">
+                    <textarea
+                      class="w-full bg-transparent text-text-primary outline-none resize-none text-xs leading-tight py-0.5"
+                      rows={1}
+                      value={editText()}
+                      ref={(el) => {
+                        requestAnimationFrame(() => {
+                          autoResize(el)
+                          el.focus()
+                          el.setSelectionRange(el.value.length, el.value.length)
+                        })
+                      }}
+                      onInput={(e) => { setEditText(e.currentTarget.value); autoResize(e.currentTarget) }}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); saveEdit() }
+                        else if (e.key === 'Escape') { e.preventDefault(); cancelEdit() }
+                      }}
+                      onBlur={(e) => {
+                        const row = e.currentTarget.closest('[data-step-id]')
+                        const next = e.relatedTarget as HTMLElement | null
+                        if (!next || !row || !row.contains(next)) saveEdit()
+                      }}
+                    />
+                    <div class="flex items-center gap-1 flex-wrap">
+                      <Show when={sessionAgent()?.supportsPlanMode !== false}>
+                        <button
+                          class={clsx(
+                            'flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] transition-colors',
+                            step.planMode
+                              ? 'text-accent bg-accent-muted hover:bg-accent-muted/80'
+                              : 'text-text-muted hover:bg-surface-3',
+                          )}
+                          onClick={() => updateStep(props.sessionId!, step.id, { planMode: !step.planMode })}
+                          title="Plan mode"
+                        >
+                          <ListChecks size={10} />
+                          <span>Plan</span>
+                        </button>
+                      </Show>
+                      <Show when={sessionAgent()?.supportsEffort !== false}>
+                        <button
+                          class={clsx(
+                            'flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] transition-colors',
+                            step.thinkingMode
+                              ? 'text-accent bg-accent-muted hover:bg-accent-muted/80'
+                              : 'text-text-muted hover:bg-surface-3',
+                          )}
+                          onClick={() => updateStep(props.sessionId!, step.id, { thinkingMode: !step.thinkingMode })}
+                          title="Thinking mode"
+                        >
+                          <Brain size={10} />
+                          <span>Think</span>
+                        </button>
+                        <button
+                          class={clsx(
+                            'flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] transition-colors',
+                            step.fastMode
+                              ? 'text-accent bg-accent-muted hover:bg-accent-muted/80'
+                              : 'text-text-muted hover:bg-surface-3',
+                          )}
+                          onClick={() => updateStep(props.sessionId!, step.id, { fastMode: !step.fastMode })}
+                          title="Fast mode"
+                        >
+                          <Zap size={10} />
+                          <span>Fast</span>
+                        </button>
+                      </Show>
+                      <ModelSelector
+                        model={step.model as ModelId | null | undefined}
+                        agentType={sessionAgent()?.id ?? ('claude' as AgentType)}
+                        onChange={(m) => updateStep(props.sessionId!, step.id, { model: m })}
+                        fixedPosition
+                        compact
+                      />
+                      <Show when={attachmentCount() > 0}>
+                        <span class="text-text-dim flex items-center gap-1 text-[10px] px-1.5 py-0.5">
+                          <Paperclip size={10} />
+                          <span>{attachmentCount()}</span>
+                        </span>
+                      </Show>
+                      <span class="ml-auto text-[10px] text-text-dim">Enter to save · Esc to cancel</span>
+                    </div>
+                  </div>
+                </Show>
+              </div>
+            )
+          }}
+          </For>
+        </div>
       </div>
     </Show>
   )

--- a/src/components/StepList.tsx
+++ b/src/components/StepList.tsx
@@ -105,7 +105,7 @@ export const StepList: Component<Props> = (props) => {
 
   return (
     <Show when={stepList().length > 0}>
-      <div class="border-t border-border px-3 py-1.5 max-h-48 flex flex-col min-h-0">
+      <div class="border-t border-border bg-surface-1 px-3 py-1.5 max-h-48 flex flex-col min-h-0">
         <div class="flex items-center justify-between mb-1">
           <span class="text-[10px] text-text-dim font-medium uppercase tracking-wider">Next Steps</span>
         </div>

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -239,9 +239,6 @@ export function dismissToast(id: string) {
   })
 }
 
-// Shared edit-step signal — set by StepList edit button, consumed by MessageInput
-export const [editStepRequest, setEditStepRequest] = createSignal<{ sessionId: string; stepId: string; message: string; attachmentsJson?: string | null } | null>(null)
-
 // Shared chat-prefill signal — set by the editor's merged hover ("Ask agent to fix")
 // button and consumed by MessageInput. Draft is set but NOT sent — the user
 // reviews and sends manually.

--- a/uno.config.ts
+++ b/uno.config.ts
@@ -239,8 +239,8 @@ export default defineConfig({
 
         /* Entry animation */
         @keyframes fadeInUp {
-          from { opacity: 0; transform: translateY(4px); }
-          to { opacity: 1; transform: translateY(0); }
+          from { opacity: 0; }
+          to { opacity: 1; }
         }
         .animate-in { animation: fadeInUp 0.2s ease-out; }
 


### PR DESCRIPTION
## Summary

- **Inline step editing** - click a step to edit in-place with its own mode toggles and model selector, removing the old composer round-trip
- **Cleaner step rows** - arm/fire/delete actions revealed on hover only; armed state shown as inset box-shadow (no layout shift); arm toggle uses Play/Pause semantics; remove button uses X icon
- **Composer unblocked while running** - model selector, Plan/Think/Fast toggles no longer disabled when agent is active; Enter button shows `ListPlus` when adding to queue
- **ModelSelector** - new `fixedPosition` and `compact` props so the popover escapes overflow-clipped containers
- **Animation fix** - `animate-in` keyframe no longer animates `translateY`, which was conflicting with popovers that use `-translate-y-full` for upward positioning
- **Visual separation** - Next Steps block gets a `surface-1` background to differentiate from the chat area above

Closes #116

## Test plan

- [ ] Open a session, add 2-3 Next Steps
- [ ] Click a step to verify inline editing opens with textarea, mode toggles, model selector
- [ ] Arm a step - confirm inset shadow appears, hover reveals fire/pause/X actions
- [ ] Confirm model/Plan/Think/Fast toggles are clickable while agent is running
- [ ] Open model selector from inline step editor - verify it opens upward without flicker
- [ ] Add a next step while agent is running - confirm `ListPlus` icon on Enter button