### PR TITLE
feat: sidebar task tile UX improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 - Next Steps: first idle step hides the arm/play button (redundant with the send button) and keeps its icons visible without hover; arm button no longer uses accent colour in the armed state
 - Next Steps: remove button uses an `X` icon instead of a trash bin, reflecting "dismiss from queue" semantics rather than permanent delete
 - Next Steps: "Next Steps" header sticks to the top of the list when scrolling so it remains visible as additional steps scroll past
+- Opening the New Task dialog after adding a project now works from every entry point (empty-state button no longer skips it)
+- Sidebar task tiles show unread/attention state as a pulsing left-edge strip (amber for attention, blue for unread) instead of a trailing dot
+- Cmd+1…9 now focuses the existing window when the target task is already open in a separate window (matching sidebar click behavior); sidebar tiles display the shortcut, which swaps to the archive button on hover (#142)
 
 ## 0.7.3 — 2026-04-17
 

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -6,12 +6,12 @@ import { TaskPanel } from './TaskPanel'
 import { SettingsPage, selectSettingsSection, setSettingsSaveRequested } from './SettingsPage'
 import { ArchivedPage } from './ArchivedPage'
 import { NewTaskDialog } from './NewTaskDialog'
-import { sidebarWidth, setSidebarWidth, showSettings, setShowSettings, showArchived, setShowArchived, toggleTerminal, showTerminal, setShowTerminal, setAddProjectPath } from '../store/ui'
+import { sidebarWidth, setSidebarWidth, showSettings, setShowSettings, showArchived, setShowArchived, toggleTerminal, showTerminal, setShowTerminal, setAddProjectPath, newTaskProjectId, setNewTaskProjectId, requestNewTaskForProject, focusOrSelectTask } from '../store/ui'
 import * as ipc from '../lib/ipc'
 import { spawnTerminal, focusActiveTerminal, terminalsForTask, activeTerminalId, setActiveTerminalForTask, isStartCommandRunning, spawnStartCommand, stopStartCommand } from '../store/terminals'
 import { activeTasksForProject, taskById } from '../store/tasks'
 import { projects, projectById } from '../store/projects'
-import { selectedProjectId, setSelectedProjectId, setSelectedTaskId, selectedTaskId } from '../store/ui'
+import { selectedProjectId, selectedTaskId } from '../store/ui'
 import { modPressed } from '../lib/platform'
 import { requestCloseTab, reopenClosedTab, nextTab, prevTab, activeTabPath, mainView } from '../store/editorView'
 import { rightPanelTab, setRightPanelTab, setShowQuickOpen } from '../store/ui'
@@ -24,7 +24,6 @@ async function pickAndAddProject() {
 
 export const Layout: Component = () => {
   const [dragging, setDragging] = createSignal(false)
-  const [newTaskProjectId, setNewTaskProjectId] = createSignal<string | null>(null)
 
   // Restore sidebar width from localStorage
   onMount(() => {
@@ -68,8 +67,8 @@ export const Layout: Component = () => {
       if (modPressed(e) && e.key === 'n') {
         e.preventDefault()
         const pid = selectedProjectId()
-        if (pid) setNewTaskProjectId(pid)
-        else if (projects.length > 0) setNewTaskProjectId(projects[projects.length - 1].id)
+        if (pid) requestNewTaskForProject(pid)
+        else if (projects.length > 0) requestNewTaskForProject(projects[projects.length - 1].id)
         else pickAndAddProject()
       }
       if (modPressed(e) && e.key >= '1' && e.key <= '9') {
@@ -87,9 +86,7 @@ export const Layout: Component = () => {
           // Match sidebar ordering: iterate projects, then tasks within each project
           const ordered = projects.flatMap(p => activeTasksForProject(p.id))
           if (idx < ordered.length) {
-            setSelectedTaskId(ordered[idx].id)
-            setSelectedProjectId(ordered[idx].projectId)
-            setShowArchived(false)
+            focusOrSelectTask(ordered[idx])
           }
         }
       }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -37,12 +37,13 @@ import {
   setAddProjectPath,
   isTaskWindowed,
   markTaskWindowed,
+  requestNewTaskForProject,
+  focusOrSelectTask,
 } from "../store/ui";
 import { sessionsForTask, loadSessions } from "../store/sessions";
 import { isStartCommandRunning } from "../store/terminals";
 import { deleteProject } from "../store/projects";
 import { ConfirmDialog } from "./ConfirmDialog";
-import { NewTaskDialog } from "./NewTaskDialog";
 import { AddProjectDialog } from "./AddProjectDialog";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { selectSettingsSection } from "./SettingsPage";
@@ -187,8 +188,20 @@ export const Sidebar: Component = () => {
     action: () => void;
   } | null>(null);
   const [archiveTaskTarget, setArchiveTaskTarget] = createSignal<string | null>(null);
-  const [newTaskProjectId, setNewTaskProjectId] = createSignal<string | null>(null);
   const [renamingTaskId, setRenamingTaskId] = createSignal<string | null>(null);
+
+  // Cmd+1…Cmd+9 selects tasks in sidebar order. Returns 0-8 for keybound tasks,
+  // null for tasks beyond the 9th (no shortcut) so we don't show ⌘0 etc.
+  const taskBindingIndex = (taskId: string): number | null => {
+    let idx = 0;
+    for (const p of projects) {
+      for (const t of activeTasksForProject(p.id)) {
+        if (t.id === taskId) return idx < 9 ? idx : null;
+        idx++;
+      }
+    }
+    return null;
+  };
 
   // Track which tasks have open windows
   onMount(() => {
@@ -355,7 +368,7 @@ export const Sidebar: Component = () => {
                     class="p-0.5 rounded opacity-0 group-hover:opacity-100 transition-opacity text-text-muted hover:text-text-secondary shrink-0"
                     onClick={(e) => {
                       e.stopPropagation();
-                      setNewTaskProjectId(project.id);
+                      requestNewTaskForProject(project.id);
                     }}
                     title="New Task (⌘N)"
                   >
@@ -367,7 +380,7 @@ export const Sidebar: Component = () => {
                   <div class="px-2 pt-1">
                     <button
                       class="text-[10px] text-text-dim hover:text-text-muted transition-colors cursor-pointer"
-                      onClick={() => setNewTaskProjectId(project.id)}
+                      onClick={() => requestNewTaskForProject(project.id)}
                     >
                       + New task
                     </button>
@@ -388,27 +401,21 @@ export const Sidebar: Component = () => {
                         const hasIndicator = () => attention() || unread();
                         const disabled = () => creating() || archiving();
                         const windowed = () => isTaskWindowed(task.id);
+                        const bindingIdx = () => taskBindingIndex(task.id);
 
-                        const handleClick = () => {
-                          if (windowed()) {
-                            // Redirect to the existing task window
-                            ipc.openTaskWindow(task.id, task.name || undefined);
-                            return;
-                          }
-                          setSelectedTaskId(task.id);
-                          setSelectedProjectId(task.projectId);
-                          setShowSettings(false);
-                          setShowArchived(false);
-                        };
+                        const handleClick = () => focusOrSelectTask(task);
 
                         const isSelected = () => !windowed() && selectedTaskId() === task.id;
 
                         return (
                           <div
                             class={clsx(
-                              "group/task relative pl-3 pr-2 py-1.5 rounded-md flex items-start gap-2 cursor-pointer",
-                              "hover:bg-surface-2",
-                              isSelected() && "bg-surface-2",
+                              "group/task relative pl-3 pr-2 py-1.5 rounded-md flex items-center gap-2 cursor-pointer",
+                              isSelected()
+                                ? "bg-surface-2"
+                                : "hover:bg-surface-2",
+                              !isSelected() && attention() && "task-attention-pulse",
+                              !isSelected() && !attention() && unread() && "task-unread-pulse",
                               archiving() && "opacity-50 pointer-events-none",
                               windowed() && "opacity-50",
                             )}
@@ -419,23 +426,17 @@ export const Sidebar: Component = () => {
                             title={windowed() ? 'Open in separate window — click to focus' : archiving() ? 'Archiving…' : creating() ? 'Setting up…' : hasError() ? 'Setup failed' : config().title}
                           >
                             <span
-                              class={clsx("shrink-0 mt-0.5", disabled() ? 'text-accent' : hasError() ? 'text-status-error' : config().color)}
+                              class={clsx("shrink-0", disabled() ? 'text-accent' : hasError() ? 'text-status-error' : config().color)}
                             >
                               {disabled() ? <Loader2 size={12} class="animate-spin" /> : hasError() ? <AlertCircle size={12} /> : <PhaseIcon phase={phase()} />}
                             </span>
                             <div class="flex-1 min-w-0">
                               <Show when={renamingTaskId() === task.id} fallback={
                                 <div class={clsx(
-                                  "text-xs truncate flex items-center gap-1.5",
+                                  "text-xs truncate",
                                   hasIndicator() || isSelected() ? "text-text-primary font-medium" : "text-text-secondary"
                                 )}>
-                                  <span class="truncate">{task.name || "New task"}</span>
-                                  <Show when={attention()}>
-                                    <span class="shrink-0 w-1.5 h-1.5 rounded-full bg-amber-400" />
-                                  </Show>
-                                  <Show when={unread()}>
-                                    <span class="shrink-0 w-1.5 h-1.5 rounded-full bg-accent" />
-                                  </Show>
+                                  {task.name || "New task"}
                                 </div>
                               }>
                                 <input
@@ -473,8 +474,13 @@ export const Sidebar: Component = () => {
                               </div>
                             </div>
                             <Show when={!archiving()}>
+                              <Show when={bindingIdx() !== null}>
+                                <kbd class="absolute right-2 top-1/2 -translate-y-1/2 -mt-px h-5 flex items-center leading-none text-[10px] font-mono text-text-dim pointer-events-none group-hover/task:opacity-0 transition-opacity">
+                                  {'\u2318'}{bindingIdx()! + 1}
+                                </kbd>
+                              </Show>
                               <button
-                                class="absolute right-2 top-1 p-0.5 rounded opacity-0 group-hover/task:opacity-100 text-text-dim hover:text-text-muted bg-surface-2"
+                                class="absolute right-2 top-1/2 -translate-y-1/2 w-5 h-5 flex items-center justify-center rounded opacity-0 group-hover/task:opacity-100 text-text-dim hover:text-text-muted bg-surface-2"
                                 onClick={(e) => {
                                   e.stopPropagation();
                                   setArchiveTaskTarget(task.id);
@@ -586,17 +592,11 @@ export const Sidebar: Component = () => {
         onCancel={() => setArchiveTaskTarget(null)}
       />
 
-      <NewTaskDialog
-        open={!!newTaskProjectId()}
-        projectId={newTaskProjectId()}
-        onClose={() => setNewTaskProjectId(null)}
-      />
-
       <AddProjectDialog
         open={!!addProjectPath()}
         repoPath={addProjectPath()}
         onClose={() => setAddProjectPath(null)}
-        onAdded={(id) => { setSelectedProjectId(id); setNewTaskProjectId(id) }}
+        onAdded={(id) => { setSelectedProjectId(id); requestNewTaskForProject(id) }}
       />
     </>
   );

--- a/src/components/TaskPanel.tsx
+++ b/src/components/TaskPanel.tsx
@@ -1,5 +1,5 @@
 import { Component, Show, For, createEffect, on, createSignal, onCleanup } from 'solid-js'
-import { selectedTaskId, selectedSessionId, setSelectedSessionId, setSelectedProjectId, addToast, showTerminal, setShowTerminal, setShowSettings, toggleTerminal, terminalHeight, setTerminalHeightAndPersist, isSessionUnread, clearSessionUnread, rightPanelWidth, setRightPanelWidth, consumePendingSessionNav, getLastSessionForTask } from '../store/ui'
+import { selectedTaskId, selectedSessionId, setSelectedSessionId, setSelectedProjectId, addToast, showTerminal, setShowTerminal, setShowSettings, toggleTerminal, terminalHeight, setTerminalHeightAndPersist, isSessionUnread, clearSessionUnread, rightPanelWidth, setRightPanelWidth, consumePendingSessionNav, getLastSessionForTask, requestNewTaskForProject } from '../store/ui'
 import { refitActiveTerminal, setActiveTerminalForTask, startCommandTerminalId, isStartCommandRunning, spawnStartCommand, stopStartCommand } from '../store/terminals'
 import { projects, addProject, projectById } from '../store/projects'
 import { open as openDialog } from '@tauri-apps/plugin-dialog'
@@ -275,6 +275,7 @@ export const TaskPanel: Component = () => {
                           const project = await addProject(selected as string)
                           setSelectedProjectId(project.id)
                           addToast(`Added ${project.name}`, 'success')
+                          requestNewTaskForProject(project.id)
                         } catch (e) {
                           addToast(String(e), 'error')
                         }

--- a/src/store/ui.test.ts
+++ b/src/store/ui.test.ts
@@ -1,0 +1,65 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('../lib/ipc', () => ({
+  openTaskWindow: vi.fn(),
+}))
+
+import {
+  newTaskProjectId,
+  setNewTaskProjectId,
+  requestNewTaskForProject,
+  focusOrSelectTask,
+  markTaskWindowed,
+  selectedTaskId,
+  setSelectedTaskId,
+  selectedProjectId,
+  setSelectedProjectId,
+} from './ui'
+import * as ipc from '../lib/ipc'
+
+describe('new-task dialog signal', () => {
+  beforeEach(() => {
+    setNewTaskProjectId(null)
+  })
+
+  test('newTaskProjectId starts null', () => {
+    expect(newTaskProjectId()).toBeNull()
+  })
+
+  test('requestNewTaskForProject sets newTaskProjectId so the dialog opens', () => {
+    requestNewTaskForProject('p-001')
+    expect(newTaskProjectId()).toBe('p-001')
+  })
+})
+
+describe('focusOrSelectTask', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setSelectedTaskId(null)
+    setSelectedProjectId(null)
+    // Reset windowed state
+    markTaskWindowed('t-001', false)
+    markTaskWindowed('t-002', false)
+  })
+
+  test('focuses existing window when task is already windowed', () => {
+    markTaskWindowed('t-001', true)
+    focusOrSelectTask({ id: 't-001', projectId: 'p-001', name: 'my-task' })
+    expect(ipc.openTaskWindow).toHaveBeenCalledWith('t-001', 'my-task')
+    expect(selectedTaskId()).toBeNull()
+    expect(selectedProjectId()).toBeNull()
+  })
+
+  test('passes undefined for taskName when task has no name', () => {
+    markTaskWindowed('t-001', true)
+    focusOrSelectTask({ id: 't-001', projectId: 'p-001', name: null })
+    expect(ipc.openTaskWindow).toHaveBeenCalledWith('t-001', undefined)
+  })
+
+  test('selects task in main view when not windowed', () => {
+    focusOrSelectTask({ id: 't-002', projectId: 'p-002', name: null })
+    expect(ipc.openTaskWindow).not.toHaveBeenCalled()
+    expect(selectedTaskId()).toBe('t-002')
+    expect(selectedProjectId()).toBe('p-002')
+  })
+})

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -1,6 +1,7 @@
 import { createSignal } from 'solid-js'
 import { registerWindowedTaskChecker } from '../lib/windowContext'
 import { pendingSessionNavForTask, selectedSessionForTask, setPendingSessionNavForTask, setSelectedSessionForTask, setTerminalOpenForTask, terminalOpenForTask } from './taskContext'
+import { openTaskWindow } from '../lib/ipc'
 
 export const [selectedProjectId, setSelectedProjectId] = createSignal<string | null>(null)
 
@@ -122,6 +123,15 @@ export function setRightPanelTab(tab: 'changes' | 'files') {
 }
 
 export const [showNewTaskDialog, setShowNewTaskDialog] = createSignal(false)
+
+// Set to a project id to open the New Task dialog for that project. Shared
+// across Layout, Sidebar, and post-addProject flows so every entry point that
+// creates a project can open the dialog consistently.
+export const [newTaskProjectId, setNewTaskProjectId] = createSignal<string | null>(null)
+
+export function requestNewTaskForProject(projectId: string) {
+  setNewTaskProjectId(projectId)
+}
 
 export const [addProjectPath, setAddProjectPath] = createSignal<string | null>(null)
 export const [showSettings, setShowSettings] = createSignal(false)
@@ -263,3 +273,17 @@ export function markTaskWindowed(taskId: string, open: boolean) {
 
 // Register the windowed-task checker so windowContext can use it without circular deps
 registerWindowedTaskChecker(isTaskWindowed)
+
+// Single entry point for "user wants to look at task X": if the task is open in
+// its own OS window, focus that window; otherwise select it in the main view.
+// Keeps Sidebar clicks and Cmd+Number shortcuts consistent.
+export function focusOrSelectTask(task: { id: string; projectId: string; name: string | null }) {
+  if (isTaskWindowed(task.id)) {
+    openTaskWindow(task.id, task.name || undefined)
+    return
+  }
+  setSelectedTaskId(task.id)
+  setSelectedProjectId(task.projectId)
+  setShowSettings(false)
+  setShowArchived(false)
+}

--- a/uno.config.ts
+++ b/uno.config.ts
@@ -90,6 +90,29 @@ export default defineConfig({
           animation: tabUnreadPulse 3s ease-in-out infinite;
         }
 
+        /* Sidebar task tile indicator — inset left-edge strip (matches the
+           selected-state visual language). Hover pauses animation at the
+           high-intensity color so the affordance is obvious. */
+        @keyframes taskAttentionPulse {
+          0%, 100% { box-shadow: inset 2px 0 0 rgba(251, 191, 36, 0.2); }
+          50%      { box-shadow: inset 2px 0 0 rgba(251, 191, 36, 0.5); }
+        }
+        .task-attention-pulse { animation: taskAttentionPulse 2s ease-in-out infinite; }
+        .task-attention-pulse:hover {
+          animation: none;
+          box-shadow: inset 2px 0 0 rgba(251, 191, 36, 0.6);
+        }
+
+        @keyframes taskUnreadPulse {
+          0%, 100% { box-shadow: inset 2px 0 0 rgba(96, 165, 250, 0.25); }
+          50%      { box-shadow: inset 2px 0 0 rgba(96, 165, 250, 0.55); }
+        }
+        .task-unread-pulse { animation: taskUnreadPulse 2.5s ease-in-out infinite; }
+        .task-unread-pulse:hover {
+          animation: none;
+          box-shadow: inset 2px 0 0 rgba(96, 165, 250, 0.65);
+        }
+
         /* Hide scrollbar but keep scrolling */
         .scrollbar-hide::-webkit-scrollbar { display: none; }
         .scrollbar-hide { scrollbar-width: none; }


### PR DESCRIPTION
## Summary

- **New task dialog consistency**: opening the dialog now works from every entry point - empty-state button, Cmd+N, and post-project-add flow all share a single `requestNewTaskForProject` signal in the ui store
- **Cmd+1..9 window focus** (#142): when the target task is already open in a separate OS window, the shortcut focuses that window instead of silently switching selection
- **Keyboard shortcut display**: tiles show ⌘N binding that fades out on hover, replaced by a square archive button
- **Tile layout**: phase icon and trailing controls are vertically centered; archive button is explicitly 20×20px square
- **Indicator strips**: unread/attention state shown as a pulsing inset left-edge strip (sky-blue for unread, amber for attention) — consistent with the selected-tile visual language, distinct from the accent-green selected state

## Test plan

- [ ] Add a project — new task dialog opens automatically
- [ ] Cmd+N with a project selected — new task dialog opens
- [ ] Empty-state "+ New task" button — dialog opens
- [ ] Cmd+1 on a task open in its own window — that window focuses
- [ ] Hover a sidebar tile — shortcut fades, archive button appears square and centered
- [ ] Trigger unread/attention on a task — left-edge strip pulses in correct color, stops on hover