### PR TITLE
fix: new task disappears from sidebar after setup (#135)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Opening the New Task dialog after adding a project now works from every entry point (empty-state button no longer skips it)
 - Sidebar task tiles show unread/attention state as a pulsing left-edge strip (amber for attention, blue for unread) instead of a trailing dot
 - Cmd+1…9 now focuses the existing window when the target task is already open in a separate window (matching sidebar click behavior); sidebar tiles display the shortcut, which swaps to the archive button on hover (#142)
+- Fix newly created task occasionally disappearing from sidebar after setup - the `task-created` event now carries the source window label so the originating window skips its own reload, avoiding a race with the async DB write queue (#135)
 
 ## 0.7.3 — 2026-04-17
 

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -280,6 +280,7 @@ pub async fn create_task(
         .ok_or_else(|| format!("Project {project_id} not found"))?;
 
     let from_task_window = window.label().starts_with("task-");
+    let source_window = window.label().to_string();
 
     let branch = base_branch.unwrap_or(project.base_branch);
     let port_offset = db::next_port_offset(pool.inner(), &project_id).await?;
@@ -298,6 +299,7 @@ pub async fn create_task(
             from_task_window,
             agent_type: agent_type
                 .unwrap_or_else(|| crate::agent::AgentKind::Claude.as_str().to_string()),
+            source_window,
         },
     )
     .await?;

--- a/src-tauri/src/task.rs
+++ b/src-tauri/src/task.rs
@@ -354,6 +354,7 @@ pub struct CreateTaskParams {
     pub port_offset: i64,
     pub from_task_window: bool,
     pub agent_type: String, // flows to the first session, not stored on the task
+    pub source_window: String,
 }
 
 pub async fn create_task(
@@ -372,6 +373,7 @@ pub async fn create_task(
         port_offset,
         from_task_window,
         agent_type,
+        source_window,
     } = params;
     let id = Uuid::new_v4().to_string();
     let branch = funny_branch_name();
@@ -412,10 +414,17 @@ pub async fn create_task(
     // Auto-create the first session with the chosen agent
     let session = create_session(db_tx, task.id.clone(), agent_type, None).await?;
 
-    // Notify all windows about the new task so other windows can reload
+    // Notify all windows about the new task so other windows can reload.
+    // The source window skips the reload since it already has the task from
+    // the IPC response — this avoids a race where the DB write queue hasn't
+    // yet applied InsertTask and the reload would drop the new task.
     let _ = app.emit(
         "task-created",
-        serde_json::json!({ "taskId": task.id, "projectId": task.project_id }),
+        serde_json::json!({
+            "taskId": task.id,
+            "projectId": task.project_id,
+            "sourceWindow": source_window,
+        }),
     );
 
     // If created from a task window, also mark it as windowed BEFORE spawning the hook

--- a/src/lib/appInit.ts
+++ b/src/lib/appInit.ts
@@ -13,6 +13,7 @@ import { refreshTaskGit } from '../store/git'
 import { addToast, setSelectedTaskId, setSelectedProjectId, setPendingSessionNav } from '../store/ui'
 import { onNotificationClicked } from '@choochmeque/tauri-plugin-notifications-api'
 import { consumePendingNav, clearDeliveredNotifications } from './notifications'
+import { windowContext } from './windowContext'
 import * as ipc from './ipc'
 
 /**
@@ -74,8 +75,13 @@ export async function initListeners() {
     }
   })
 
-  // Cross-window sync: reload when tasks change in another window
-  listen<{ taskId: string; projectId: string }>('task-created', (event) => {
+  // Cross-window sync: reload when tasks change in another window.
+  // Skip events from our own window — we already have the task from the IPC
+  // response, and reloading would race with the async DB write queue (the
+  // InsertTask may not be applied yet when listTasks runs, causing the new
+  // task to vanish from the store until another refresh).
+  listen<{ taskId: string; projectId: string; sourceWindow?: string }>('task-created', (event) => {
+    if (event.payload.sourceWindow === windowContext.windowLabel) return
     loadTasks(event.payload.projectId)
     loadSessions(event.payload.taskId)
     refreshTaskGit(event.payload.taskId)

--- a/src/store/tasks.test.ts
+++ b/src/store/tasks.test.ts
@@ -1,0 +1,90 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+import type { Task, Session } from '../types'
+
+// Bug #135 — the task-created event handler calls loadTasks, which reads
+// from the DB before the async write queue has applied InsertTask. That
+// empty read wipes the placeholder out of the store. When ipc.createTask's
+// .then() later runs, it must still deposit the real task or the sidebar
+// loses it until the next refresh.
+
+let createTaskResolve: ((v: { task: Task; session: Session }) => void) | null = null
+let listTasksResult: Task[] = []
+
+vi.mock('../lib/ipc', () => ({
+  createTask: vi.fn(() => new Promise<{ task: Task; session: Session }>((resolve) => {
+    createTaskResolve = resolve
+  })),
+  listTasks: vi.fn(() => Promise.resolve(listTasksResult)),
+  deleteTask: vi.fn().mockResolvedValue(undefined),
+  archiveTask: vi.fn().mockResolvedValue(undefined),
+  restoreTask: vi.fn().mockResolvedValue(undefined),
+  renameTask: vi.fn().mockResolvedValue(undefined),
+}))
+
+import { tasks, setTasks, startTaskCreation, loadTasks } from './tasks'
+
+const makeTask = (overrides: Partial<Task> = {}): Task => ({
+  id: 'task-real',
+  projectId: 'project-1',
+  name: null,
+  worktreePath: '/tmp/worktree',
+  branch: 'spooky-armadillo',
+  createdAt: 1000,
+  mergeBaseSha: null,
+  portOffset: 0,
+  archived: false,
+  archivedAt: null,
+  lastCommitMessage: null,
+  parentTaskId: null,
+  agentType: 'claude',
+  ...overrides,
+})
+
+const makeSession = (): Session => ({
+  id: 'session-1',
+  taskId: 'task-real',
+  name: null,
+  resumeSessionId: null,
+  status: 'idle',
+  startedAt: 1000,
+  endedAt: null,
+  totalCost: 0,
+  parentSessionId: null,
+  forkedAtMessageUuid: null,
+  agentType: 'claude',
+  model: null,
+})
+
+describe('startTaskCreation', () => {
+  beforeEach(() => {
+    setTasks([])
+    createTaskResolve = null
+    listTasksResult = []
+    vi.clearAllMocks()
+  })
+
+  test('preserves the new task when loadTasks races before the IPC response (issue #135)', async () => {
+    // Kick off creation — placeholder lands in the store immediately
+    startTaskCreation('project-1', 'main')
+    expect(tasks.length).toBe(1)
+    expect(tasks[0].branch).toBe('setting up…')
+
+    // Simulate the task-created event handler running in the same window:
+    // loadTasks reads from the DB before the async write queue has applied
+    // InsertTask, so the returned list is stale (empty). This wipes the
+    // placeholder out of the store.
+    listTasksResult = []
+    await loadTasks('project-1')
+    expect(tasks.length).toBe(0)
+
+    // Now the IPC response arrives with the real task. The .then() handler
+    // must still land the task in the store, otherwise the sidebar shows
+    // nothing until the next refresh.
+    const real = makeTask()
+    createTaskResolve!({ task: real, session: makeSession() })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(tasks.length).toBe(1)
+    expect(tasks[0].id).toBe('task-real')
+  })
+})

--- a/src/store/tasks.ts
+++ b/src/store/tasks.ts
@@ -99,8 +99,15 @@ export function startTaskCreation(projectId: string, baseBranch: string, agentTy
 
   // Fire and forget — runs in background
   ipc.createTask(projectId, baseBranch, agentType).then(result => {
-    // Replace placeholder with real task
-    setTasks(prev => prev.map(t => t.id === placeholderId ? result.task : t))
+    // Replace placeholder with real task — upsert so the task still lands
+    // if the placeholder was dropped by a concurrent loadTasks reload.
+    setTasks(prev => {
+      if (prev.some(t => t.id === placeholderId)) {
+        return prev.map(t => t.id === placeholderId ? result.task : t)
+      }
+      if (prev.some(t => t.id === result.task.id)) return prev
+      return [result.task, ...prev]
+    })
     removeCreating(placeholderId)
 
     // Set up session
@@ -132,7 +139,13 @@ export function retryTaskCreation(placeholderId: string, projectId: string, base
   addCreating(placeholderId)
 
   ipc.createTask(projectId, baseBranch).then(result => {
-    setTasks(prev => prev.map(t => t.id === placeholderId ? result.task : t))
+    setTasks(prev => {
+      if (prev.some(t => t.id === placeholderId)) {
+        return prev.map(t => t.id === placeholderId ? result.task : t)
+      }
+      if (prev.some(t => t.id === result.task.id)) return prev
+      return [result.task, ...prev]
+    })
     removeCreating(placeholderId)
 
     import('./sessions').then(({ setSessions, setOutputItems }) => {


### PR DESCRIPTION
## Root cause

`create_task` in Rust enqueues `InsertTask` via an async mpsc write queue (fire-and-enqueue, not fire-and-apply), then immediately emits `task-created`. In the originating window, the event handler called `loadTasks()` which queries the DB before the write queue has applied the insert — returning a stale empty list — and replaced the entire project's task list in the store. When the IPC `.then()` ran, it tried to map-replace the placeholder, but the placeholder was already gone, so the real task was never added. The sidebar showed nothing until the next `loadTasks` (e.g. creating another task).

## Fix

- **Backend** (`task.rs`, `ipc.rs`): include `sourceWindow` (the webview label) in the `task-created` event payload.
- **Frontend** (`appInit.ts`): the originating window skips its own `task-created` event — it already has the task from the IPC response and doesn't need a DB reload.
- **Frontend** (`tasks.ts`): `startTaskCreation` and `retryTaskCreation` now upsert in `.then()` instead of map-replacing, so the task lands correctly even if the placeholder was concurrently dropped by some other path.

## Test

Added `src/store/tasks.test.ts` with a deterministic reproduction of the race:

1. Call `startTaskCreation` — placeholder inserted
2. Call `loadTasks` with a mocked empty DB response — placeholder wiped
3. Resolve the `ipc.createTask` promise — assert real task is in the store

Red against un-fixed code (`expected 0 to be 1`), green after.

## Checklist

- [x] Regression test (red → green)
- [x] `cargo check` clean
- [x] `pnpm check` clean
- [x] 63/63 frontend tests pass
- [x] 268/268 Rust tests pass
- [ ] `cargo clippy` — pre-existing warning in `stream.rs:189` (unrelated, from commit `a65f6d8`) blocks clippy step

Closes #135