### PR TITLE
fix: scope archive/delete process kill to task sessions only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Branch names replaced from animal-based to programming-humor themed; stack detection merges noun pools for Rust, Go, Python, JS/TS, and Java (monorepo-aware)
-
+- Fix archive/delete killing running sessions on other tasks - the kill loop now scopes to session ids belonging to the target task instead of iterating every active process (#169)
 - Plan/Think/Fast toggles no longer disabled while the agent is running, so mode changes can take effect on queued steps and steers
 - Composer model selector no longer disabled while the agent is running; the new selection applies to subsequent sends (manual, armed auto-send, or queued step)
 - Next Steps: click a step to edit inline (textarea + per-step mode toggles + model selector); removed the separate pencil icon and the edit-via-composer round-trip

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -993,6 +993,19 @@ pub async fn list_sessions_for_task(
     .map_err(|e| e.to_string())
 }
 
+/// All session ids for a task, regardless of status. Used by archive/delete to
+/// scope process kills to a single task without missing in-flight sessions.
+pub async fn list_all_session_ids_for_task(
+    pool: &SqlitePool,
+    task_id: &str,
+) -> Result<Vec<String>, String> {
+    sqlx::query_scalar::<_, String>("SELECT id FROM sessions WHERE task_id = ?")
+        .bind(task_id)
+        .fetch_all(pool)
+        .await
+        .map_err(|e| e.to_string())
+}
+
 // Output
 
 pub async fn get_output_lines(

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -122,6 +122,7 @@ pub async fn delete_project(
     for t in &tasks {
         task::delete_task(
             &app,
+            pool.inner(),
             db_tx.inner(),
             active.inner(),
             &project.repo_path,
@@ -413,6 +414,7 @@ pub async fn delete_task(
 
     task::delete_task(
         &app,
+        pool.inner(),
         db_tx.inner(),
         active.inner(),
         &project.repo_path,
@@ -443,6 +445,7 @@ pub async fn archive_task(
 
     task::archive_task(
         &app,
+        pool.inner(),
         db_tx.inner(),
         active.inner(),
         &t,

--- a/src-tauri/src/task.rs
+++ b/src-tauri/src/task.rs
@@ -5,6 +5,7 @@ use crate::stream;
 use crate::worktree;
 use dashmap::DashMap;
 use serde::Deserialize;
+use sqlx::SqlitePool;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -207,6 +208,21 @@ pub type ActiveMap = Arc<DashMap<String, ActiveProcess>>;
 
 pub fn new_active_map() -> ActiveMap {
     Arc::new(DashMap::new())
+}
+
+/// Intersect currently-active session ids with the session ids belonging to a
+/// given task. Used by archive/delete to scope the kill to one task only.
+fn active_session_ids_for_task<I, S>(active_ids: I, task_session_ids: &[S]) -> Vec<String>
+where
+    I: IntoIterator<Item = String>,
+    S: AsRef<str>,
+{
+    let task_set: std::collections::HashSet<&str> =
+        task_session_ids.iter().map(|s| s.as_ref()).collect();
+    active_ids
+        .into_iter()
+        .filter(|id| task_set.contains(id.as_str()))
+        .collect()
 }
 
 /// task_id → true while the setup hook is still running in the background
@@ -629,6 +645,7 @@ pub async fn create_task(
 #[allow(clippy::too_many_arguments)]
 pub async fn delete_task(
     app: &AppHandle,
+    pool: &SqlitePool,
     db_tx: &DbWriteTx,
     active: &ActiveMap,
     repo_path: &str,
@@ -637,9 +654,12 @@ pub async fn delete_task(
     delete_branch: bool,
     skip_destroy_hook: bool,
 ) -> Result<(), String> {
-    // Kill any active processes for this task's sessions
-    let keys: Vec<String> = active.iter().map(|e| e.key().clone()).collect();
-    for sid in keys {
+    // Kill active processes belonging to THIS task only - never sessions on other tasks.
+    let task_session_ids = db::list_all_session_ids_for_task(pool, &task.id)
+        .await
+        .unwrap_or_default();
+    let active_ids = active.iter().map(|e| e.key().clone());
+    for sid in active_session_ids_for_task(active_ids, &task_session_ids) {
         abort_message(app, db_tx, active, &sid).await?;
     }
 
@@ -698,8 +718,10 @@ pub async fn delete_task(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn archive_task(
     app: &AppHandle,
+    pool: &SqlitePool,
     db_tx: &DbWriteTx,
     active: &ActiveMap,
     task: &Task,
@@ -707,9 +729,12 @@ pub async fn archive_task(
     repo_path: &str,
     skip_destroy_hook: bool,
 ) -> Result<(), String> {
-    // Kill any active processes for this task's sessions
-    let keys: Vec<String> = active.iter().map(|e| e.key().clone()).collect();
-    for sid in keys {
+    // Kill active processes belonging to THIS task only - never sessions on other tasks.
+    let task_session_ids = db::list_all_session_ids_for_task(pool, &task.id)
+        .await
+        .unwrap_or_default();
+    let active_ids = active.iter().map(|e| e.key().clone());
+    for sid in active_session_ids_for_task(active_ids, &task_session_ids) {
         abort_message(app, db_tx, active, &sid).await?;
     }
 
@@ -2354,5 +2379,35 @@ mod tests {
         assert!(a.starts_with("req_"));
         assert!(b.starts_with("req_"));
         assert_ne!(a, b);
+    }
+
+    // Regression: archiving / deleting a task must not kill sessions on other tasks.
+    // See https://github.com/SoftwareSavants/verun/issues/169
+    #[test]
+    fn active_session_ids_for_task_returns_only_matching_sessions() {
+        let active_ids = vec!["s1".to_string(), "s2".to_string(), "s3".to_string()];
+        let task_session_ids = ["s2".to_string(), "s4".to_string()];
+        let result = active_session_ids_for_task(active_ids, &task_session_ids);
+        assert_eq!(result, vec!["s2".to_string()]);
+    }
+
+    #[test]
+    fn active_session_ids_for_task_empty_when_no_overlap() {
+        let active_ids = vec!["s1".to_string()];
+        let task_session_ids = ["s2".to_string()];
+        let result = active_session_ids_for_task(active_ids, &task_session_ids);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn active_session_ids_for_task_excludes_other_tasks_sessions() {
+        // Active sessions: s1, s2 belong to task A; s3, s4 belong to task B.
+        // Archiving task B should return only s3, s4 - never s1, s2.
+        let active_ids: Vec<String> =
+            vec!["s1".into(), "s2".into(), "s3".into(), "s4".into()];
+        let task_b_session_ids = ["s3".to_string(), "s4".to_string()];
+        let mut result = active_session_ids_for_task(active_ids, &task_b_session_ids);
+        result.sort();
+        assert_eq!(result, vec!["s3".to_string(), "s4".to_string()]);
     }
 }


### PR DESCRIPTION
## Summary

- Archiving or deleting a task was aborting every process in the global active map, killing running sessions on unrelated tasks
- Added `db::list_all_session_ids_for_task` (no status filter) to get all session ids belonging to a task
- Added pure helper `active_session_ids_for_task` that intersects active session ids with a task's session ids — used by both `archive_task` and `delete_task`
- Both functions now take a `pool: &SqlitePool` to enable the scoped DB query
- Three unit tests cover: correct match, no overlap, and the regression case (sessions from other tasks excluded)

Closes #169

## Test plan

- [ ] `cargo test` — 289 tests pass (3 new)
- [ ] `cargo clippy` — zero warnings
- [ ] `pnpm check` — no TS errors
- [ ] Manual: run 2+ tasks with active sessions, archive one — confirm the other keeps running