### PR TITLE
fix: scope plan/think/fast modes and plan banner to session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix new session opening twice in the source window: `createSession` now dedups against the cross-window `session-created` broadcast (regression from #143)
 - Branch names replaced from animal-based to programming-humor themed; stack detection merges noun pools for Rust, Go, Python, JS/TS, and Java (monorepo-aware)
 - Fix archive/delete killing running sessions on other tasks - the kill loop now scopes to session ids belonging to the target task instead of iterating every active process (#169)
+- Plan/Think/Fast toggles and plan-review banner now scoped per session instead of per task — entering plan mode in one session no longer leaks into siblings (#155)
 - Plan/Think/Fast toggles no longer disabled while the agent is running, so mode changes can take effect on queued steps and steers
 - Composer model selector no longer disabled while the agent is running; the new selection applies to subsequent sends (manual, armed auto-send, or queued step)
 - Next Steps: click a step to edit inline (textarea + per-step mode toggles + model selector); removed the separate pencil icon and the edit-via-composer round-trip

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -11,7 +11,8 @@ import { Popover } from './Popover'
 import { parseMentions } from '../lib/mentions'
 import * as ipc from '../lib/ipc'
 import { addToast, setSelectedTaskId, setSelectedSessionId } from '../store/ui'
-import { setSessions, loadOutputLines, sendMessage, createSession, taskPlanMode, taskThinkingMode, taskFastMode } from '../store/sessions'
+import { setSessions, loadOutputLines, sendMessage, createSession } from '../store/sessions'
+import { planModeForSession, thinkingModeForSession, fastModeForSession } from '../store/sessionContext'
 import { setTasks } from '../store/tasks'
 import { setMainView } from '../store/editorView'
 import { formatCost, formatTokens } from '../lib/format'
@@ -657,12 +658,12 @@ const ErrorBlockView: Component<{
   const retryMessage = () => userMessageForTurn(props.output, props.turnIndex)
 
   const modeArgs = (): [string | undefined, boolean | undefined, boolean | undefined, boolean | undefined] => {
-    const tid = props.taskId
+    const sid = props.sessionId
     return [
       props.model ?? undefined,
-      tid ? taskPlanMode[tid] ?? undefined : undefined,
-      tid ? taskThinkingMode[tid] ?? undefined : undefined,
-      tid ? taskFastMode[tid] ?? undefined : undefined,
+      sid ? planModeForSession(sid) : undefined,
+      sid ? thinkingModeForSession(sid) : undefined,
+      sid ? fastModeForSession(sid) : undefined,
     ]
   }
 

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -607,16 +607,15 @@ export const MessageInput: Component<Props> = (props) => {
     if (feedback) {
       // Request changes
       setPlanChanges('')
-      const tid = selectedTaskId()
       try {
         if (approval && isExitPlanMode()) {
           // Forward the feedback as the tool-deny message so Claude sees it as
           // the reason and continues the same turn. No separate sendMessage.
-          if (tid) setTaskPlanFilePath(tid, null)
+          setPlanFilePathForSession(approval.sessionId, null)
           await denyToolUse(approval.requestId, approval.sessionId, feedback)
         } else {
           // Persisted plan viewer — no live approval, send as a new message.
-          if (tid) setTaskPlanFilePath(tid, null)
+          setPlanFilePathForSession(sid, null)
           await sendMessage(sid, feedback, undefined, currentModel(), true)
         }
       } catch (error) {
@@ -901,7 +900,7 @@ export const MessageInput: Component<Props> = (props) => {
     setAttachments([])
     setShowPalette(false)
     // Dismiss any persisted plan panel — the user has moved on from that plan.
-    if (tid && taskPlanFilePath[tid]) setTaskPlanFilePath(tid, null)
+    if (planFilePathForSession(sid)) setPlanFilePathForSession(sid, null)
     try {
       await sendMessage(sid, msg, atts.length > 0 ? atts : undefined, currentModel(), planMode(), thinkingMode(), fastMode())
     } catch (e) {

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -1,5 +1,6 @@
 import { Component, createSignal, createEffect, on, Show, For, onMount, onCleanup } from 'solid-js'
-import { sendMessage, abortMessage, createSession, clearOutputItems, pendingApprovals, approveToolUse, denyToolUse, answerQuestion, sessionCosts, sessionTokens, rateLimitInfo, taskPlanMode, setTaskPlanMode, taskThinkingMode, setTaskThinkingMode, taskFastMode, setTaskFastMode, taskPlanFilePath, setTaskPlanFilePath, outputItems, tryDrainSteps, sessionById, updateSessionModel } from '../store/sessions'
+import { sendMessage, abortMessage, createSession, clearOutputItems, pendingApprovals, approveToolUse, denyToolUse, answerQuestion, autoApprovedCounts, sessionCosts, sessionTokens, rateLimitInfo, outputItems, tryDrainSteps, sessionById, updateSessionModel } from '../store/sessions'
+import { planModeForSession, setPlanModeForSession, thinkingModeForSession, setThinkingModeForSession, fastModeForSession, setFastModeForSession, planFilePathForSession, setPlanFilePathForSession } from '../store/sessionContext'
 import { setSelectedSessionId, selectedTaskId, chatPrefillRequest, setChatPrefillRequest } from '../store/ui'
 import { isSetupRunning, queueMessage, queuedMessages, clearQueuedMessage } from '../store/setup'
 import { taskById } from '../store/tasks'
@@ -539,44 +540,44 @@ export const MessageInput: Component<Props> = (props) => {
   const [planFeedback, setPlanFeedback] = createSignal('')
 
   const planMode = () => {
-    const tid = selectedTaskId()
-    return tid ? (taskPlanMode[tid] ?? false) : false
+    const sid = props.sessionId
+    return sid ? planModeForSession(sid) : false
   }
 
   const setPlanMode = (on: boolean) => {
-    const tid = selectedTaskId()
-    if (!tid) return
-    setTaskPlanMode(tid, on)
+    const sid = props.sessionId
+    if (!sid) return
+    setPlanModeForSession(sid, on)
   }
 
   const thinkingMode = () => {
-    const tid = selectedTaskId()
-    return tid ? (taskThinkingMode[tid] ?? true) : true
+    const sid = props.sessionId
+    return sid ? thinkingModeForSession(sid) : true
   }
 
   const setThinking = (on: boolean) => {
-    const tid = selectedTaskId()
-    if (!tid) return
-    setTaskThinkingMode(tid, on)
+    const sid = props.sessionId
+    if (!sid) return
+    setThinkingModeForSession(sid, on)
   }
 
   const fastMode = () => {
-    const tid = selectedTaskId()
-    return tid ? (taskFastMode[tid] ?? false) : false
+    const sid = props.sessionId
+    return sid ? fastModeForSession(sid) : false
   }
 
   const setFast = (on: boolean) => {
-    const tid = selectedTaskId()
-    if (!tid) return
-    setTaskFastMode(tid, on)
+    const sid = props.sessionId
+    if (!sid) return
+    setFastModeForSession(sid, on)
   }
 
   const showPlanResponse = () => {
-    const tid = selectedTaskId()
-    if (!tid || props.isRunning) return false
+    const sid = props.sessionId
+    if (!sid || props.isRunning) return false
     if (showPlanViewer() && planContent()) return false
     if (currentApproval()) return false
-    return !!taskPlanFilePath[tid]
+    return !!planFilePathForSession(sid)
   }
 
   const [planActionPending, setPlanActionPending] = createSignal(false)
@@ -586,8 +587,7 @@ export const MessageInput: Component<Props> = (props) => {
     const sid = props.sessionId
     if (!sid) return
     setPlanActionPending(true)
-    const tid = selectedTaskId()
-    if (tid) setTaskPlanFilePath(tid, null)
+    setPlanFilePathForSession(sid, null)
     setPlanMode(false)
     try {
       await sendMessage(sid, 'The plan is approved. Please implement it now.', undefined, currentModel(), false)
@@ -626,8 +626,7 @@ export const MessageInput: Component<Props> = (props) => {
     } else {
       // Approve the plan and persist local plan mode/file state.
       setPlanMode(false)
-      const tid = selectedTaskId()
-      if (tid) setTaskPlanFilePath(tid, null)
+      setPlanFilePathForSession(sid, null)
       try {
         if (approval && isExitPlanMode()) {
           await approveToolUse(approval.requestId, approval.sessionId)
@@ -695,26 +694,25 @@ export const MessageInput: Component<Props> = (props) => {
     if (props.isRunning && !isExitPlanMode()) return false
     if (isExitPlanMode()) return true
     // No live approval — show viewer when plan file is pending and content is loaded
-    const tid = selectedTaskId()
-    if (tid && !props.isRunning && taskPlanFilePath[tid] && planFileContent()) return true
+    const sid = props.sessionId
+    if (sid && !props.isRunning && planFilePathForSession(sid) && planFileContent()) return true
     return false
   }
 
   // Load plan file content — from live approval or persisted path
   createEffect(on(
     () => {
-      const tid = selectedTaskId()
-      return [isExitPlanMode(), props.sessionId, tid ? taskPlanFilePath[tid] : null] as const
+      const sid = props.sessionId
+      return [isExitPlanMode(), sid, sid ? planFilePathForSession(sid) : null] as const
     },
-    async ([isExit, _sid]) => {
+    async ([isExit, sid]) => {
       // From live ExitPlanMode approval
       if (isExit) {
         const approval = currentApproval()
         if (!approval) return
         const inlinePlan = approval.toolInput.plan as string | undefined
         const filePath = approval.toolInput.planFilePath as string | undefined
-        const tid = selectedTaskId()
-        if (tid && filePath && !planActionPending()) setTaskPlanFilePath(tid, filePath)
+        if (filePath && !planActionPending()) setPlanFilePathForSession(approval.sessionId, filePath)
         setPlanFilePathSignal(filePath || null)
         if (inlinePlan) {
           setPlanFileContent(inlinePlan)
@@ -729,9 +727,8 @@ export const MessageInput: Component<Props> = (props) => {
         return
       }
       // From persisted plan file path
-      const tid = selectedTaskId()
-      if (tid) {
-        const filePath = taskPlanFilePath[tid]
+      if (sid) {
+        const filePath = planFilePathForSession(sid)
         if (filePath) {
           setPlanFilePathSignal(filePath)
           try {
@@ -1485,8 +1482,8 @@ export const MessageInput: Component<Props> = (props) => {
         }
         if (e.key === 'Escape') {
           e.preventDefault()
-          const tid = selectedTaskId()
-          if (tid) setTaskPlanFilePath(tid, null)
+          const sid = props.sessionId
+          if (sid) setPlanFilePathForSession(sid, null)
           return
         }
         return
@@ -1968,7 +1965,7 @@ export const MessageInput: Component<Props> = (props) => {
             <div class="flex items-center gap-1.5">
               <button
                 class="p-1 rounded-md text-text-dim hover:text-text-secondary hover:bg-surface-2 transition-colors"
-                onClick={() => { const tid = selectedTaskId(); if (tid) setTaskPlanFilePath(tid, null) }}
+                onClick={() => { const sid = props.sessionId; if (sid) setPlanFilePathForSession(sid, null) }}
                 title="Dismiss (Esc)"
               >
                 <X size={14} />

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -1,5 +1,5 @@
 import { Component, createSignal, createEffect, on, Show, For, onMount, onCleanup } from 'solid-js'
-import { sendMessage, abortMessage, createSession, clearOutputItems, pendingApprovals, approveToolUse, denyToolUse, answerQuestion, autoApprovedCounts, sessionCosts, sessionTokens, rateLimitInfo, outputItems, tryDrainSteps, sessionById, updateSessionModel } from '../store/sessions'
+import { sendMessage, abortMessage, createSession, clearOutputItems, pendingApprovals, approveToolUse, denyToolUse, answerQuestion, sessionCosts, sessionTokens, rateLimitInfo, outputItems, tryDrainSteps, sessionById, updateSessionModel } from '../store/sessions'
 import { planModeForSession, setPlanModeForSession, thinkingModeForSession, setThinkingModeForSession, fastModeForSession, setFastModeForSession, planFilePathForSession, setPlanFilePathForSession } from '../store/sessionContext'
 import { setSelectedSessionId, selectedTaskId, chatPrefillRequest, setChatPrefillRequest } from '../store/ui'
 import { isSetupRunning, queueMessage, queuedMessages, clearQueuedMessage } from '../store/setup'

--- a/src/store/sessionContext.test.ts
+++ b/src/store/sessionContext.test.ts
@@ -1,0 +1,94 @@
+import { describe, test, expect, beforeEach } from 'vitest'
+import { produce } from 'solid-js/store'
+import {
+  planModeForSession,
+  setPlanModeForSession,
+  thinkingModeForSession,
+  setThinkingModeForSession,
+  fastModeForSession,
+  setFastModeForSession,
+  planFilePathForSession,
+  setPlanFilePathForSession,
+  clearSessionContext,
+  sessionContexts,
+  setSessionContexts,
+} from './sessionContext'
+
+describe('sessionContext store', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    setSessionContexts(produce(store => {
+      for (const k of Object.keys(store)) delete store[k]
+    }))
+  })
+
+  test('defaults match prior task-level behavior', () => {
+    expect(planModeForSession('s-1')).toBe(false)
+    expect(thinkingModeForSession('s-1')).toBe(true)
+    expect(fastModeForSession('s-1')).toBe(false)
+    expect(planFilePathForSession('s-1')).toBe(null)
+  })
+
+  test('setters isolate by session id', () => {
+    setPlanModeForSession('s-1', true)
+    setThinkingModeForSession('s-1', false)
+    setFastModeForSession('s-1', true)
+    setPlanFilePathForSession('s-1', '/tmp/plan.md')
+
+    expect(planModeForSession('s-1')).toBe(true)
+    expect(thinkingModeForSession('s-1')).toBe(false)
+    expect(fastModeForSession('s-1')).toBe(true)
+    expect(planFilePathForSession('s-1')).toBe('/tmp/plan.md')
+
+    expect(planModeForSession('s-2')).toBe(false)
+    expect(thinkingModeForSession('s-2')).toBe(true)
+    expect(fastModeForSession('s-2')).toBe(false)
+    expect(planFilePathForSession('s-2')).toBe(null)
+  })
+
+  test('setters persist to localStorage under verun:sessionContext:<sid>', () => {
+    setPlanModeForSession('s-1', true)
+    setPlanFilePathForSession('s-1', '/tmp/plan.md')
+
+    const raw = localStorage.getItem('verun:sessionContext:s-1')
+    expect(raw).not.toBeNull()
+    const parsed = JSON.parse(raw!)
+    expect(parsed.planMode).toBe(true)
+    expect(parsed.planFilePath).toBe('/tmp/plan.md')
+    expect(parsed.thinkingMode).toBe(true)
+    expect(parsed.fastMode).toBe(false)
+  })
+
+  test('hydration from localStorage on first read', () => {
+    localStorage.setItem(
+      'verun:sessionContext:s-9',
+      JSON.stringify({ planMode: true, thinkingMode: false, fastMode: true, planFilePath: '/x.md' }),
+    )
+    setSessionContexts({})
+
+    expect(planModeForSession('s-9')).toBe(true)
+    expect(thinkingModeForSession('s-9')).toBe(false)
+    expect(fastModeForSession('s-9')).toBe(true)
+    expect(planFilePathForSession('s-9')).toBe('/x.md')
+  })
+
+  test('clearSessionContext removes store entry and storage key', () => {
+    setPlanModeForSession('s-1', true)
+    setPlanFilePathForSession('s-1', '/tmp/plan.md')
+    expect(localStorage.getItem('verun:sessionContext:s-1')).not.toBeNull()
+
+    clearSessionContext('s-1')
+
+    expect(sessionContexts['s-1']).toBeUndefined()
+    expect(localStorage.getItem('verun:sessionContext:s-1')).toBeNull()
+    expect(planModeForSession('s-1')).toBe(false)
+  })
+
+  test('setPlanFilePathForSession(null) clears the field', () => {
+    setPlanFilePathForSession('s-1', '/tmp/plan.md')
+    setPlanFilePathForSession('s-1', null)
+    expect(planFilePathForSession('s-1')).toBe(null)
+    const raw = localStorage.getItem('verun:sessionContext:s-1')
+    expect(JSON.parse(raw!).planFilePath).toBe(null)
+  })
+})

--- a/src/store/sessionContext.test.ts
+++ b/src/store/sessionContext.test.ts
@@ -64,7 +64,6 @@ describe('sessionContext store', () => {
       'verun:sessionContext:s-9',
       JSON.stringify({ planMode: true, thinkingMode: false, fastMode: true, planFilePath: '/x.md' }),
     )
-    setSessionContexts({})
 
     expect(planModeForSession('s-9')).toBe(true)
     expect(thinkingModeForSession('s-9')).toBe(false)

--- a/src/store/sessionContext.ts
+++ b/src/store/sessionContext.ts
@@ -1,0 +1,81 @@
+import { createStore, produce } from 'solid-js/store'
+import {
+  clearSessionContextStorage,
+  loadInitialSessionContext,
+  persistSessionContext,
+} from './sessionContextStorage'
+
+export interface SessionContextState {
+  planMode: boolean
+  thinkingMode: boolean
+  fastMode: boolean
+  planFilePath: string | null
+}
+
+function createEmptySessionContext(): SessionContextState {
+  return {
+    planMode: false,
+    thinkingMode: true,
+    fastMode: false,
+    planFilePath: null,
+  }
+}
+
+export const [sessionContexts, setSessionContexts] = createStore<Record<string, SessionContextState>>({})
+
+function ensureSessionContext(sessionId: string): SessionContextState {
+  const existing = sessionContexts[sessionId]
+  if (existing) return existing
+  const next: SessionContextState = { ...createEmptySessionContext(), ...loadInitialSessionContext(sessionId) }
+  setSessionContexts(sessionId, next)
+  return next
+}
+
+function updateSessionField<K extends keyof SessionContextState>(
+  sessionId: string,
+  field: K,
+  value: SessionContextState[K],
+) {
+  ensureSessionContext(sessionId)
+  setSessionContexts(sessionId, field, value)
+  persistSessionContext(sessionId, sessionContexts[sessionId]!)
+}
+
+export function planModeForSession(sessionId: string): boolean {
+  return ensureSessionContext(sessionId).planMode
+}
+
+export function setPlanModeForSession(sessionId: string, value: boolean) {
+  updateSessionField(sessionId, 'planMode', value)
+}
+
+export function thinkingModeForSession(sessionId: string): boolean {
+  return ensureSessionContext(sessionId).thinkingMode
+}
+
+export function setThinkingModeForSession(sessionId: string, value: boolean) {
+  updateSessionField(sessionId, 'thinkingMode', value)
+}
+
+export function fastModeForSession(sessionId: string): boolean {
+  return ensureSessionContext(sessionId).fastMode
+}
+
+export function setFastModeForSession(sessionId: string, value: boolean) {
+  updateSessionField(sessionId, 'fastMode', value)
+}
+
+export function planFilePathForSession(sessionId: string): string | null {
+  return ensureSessionContext(sessionId).planFilePath
+}
+
+export function setPlanFilePathForSession(sessionId: string, value: string | null) {
+  updateSessionField(sessionId, 'planFilePath', value)
+}
+
+export function clearSessionContext(sessionId: string) {
+  setSessionContexts(produce(store => {
+    delete store[sessionId]
+  }))
+  clearSessionContextStorage(sessionId)
+}

--- a/src/store/sessionContextStorage.ts
+++ b/src/store/sessionContextStorage.ts
@@ -1,0 +1,29 @@
+import type { SessionContextState } from './sessionContext'
+
+function storageKey(sessionId: string) {
+  return `verun:sessionContext:${sessionId}`
+}
+
+export function loadInitialSessionContext(sessionId: string): Partial<SessionContextState> | null {
+  if (typeof localStorage === 'undefined') return null
+  try {
+    const raw = localStorage.getItem(storageKey(sessionId))
+    return raw ? JSON.parse(raw) as Partial<SessionContextState> : null
+  } catch {
+    return null
+  }
+}
+
+export function persistSessionContext(sessionId: string, ctx: SessionContextState) {
+  if (typeof localStorage === 'undefined') return
+  try {
+    localStorage.setItem(storageKey(sessionId), JSON.stringify(ctx))
+  } catch {
+    // Ignore storage quota failures.
+  }
+}
+
+export function clearSessionContextStorage(sessionId: string) {
+  if (typeof localStorage === 'undefined') return
+  localStorage.removeItem(storageKey(sessionId))
+}

--- a/src/store/sessions.test.ts
+++ b/src/store/sessions.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, beforeAll, beforeEach, vi } from 'vitest'
+import { produce } from 'solid-js/store'
 
 // Capture every `listen(eventName, cb)` registration so tests can fire events
 // directly. Mock factory must be self-contained — vi.mock is hoisted above
@@ -23,8 +24,9 @@ vi.mock('../lib/notifications', () => ({
   notify: vi.fn(),
 }))
 
-import { sessions, setSessions, outputItems, setOutputItems, sessionsForTask, sessionById, initSessionListeners, initSessionWindowFocusRefresh, loadSessions, createSession } from './sessions'
+import { sessions, setSessions, outputItems, setOutputItems, sessionsForTask, sessionById, initSessionListeners, initSessionWindowFocusRefresh, loadSessions, createSession, clearSessionContextsForTask } from './sessions'
 import * as ipc from '../lib/ipc'
+import { setPlanFilePathForSession, planFilePathForSession, sessionContexts, setSessionContexts } from './sessionContext'
 import type { Session, OutputItem } from '../types'
 
 const makeSession = (overrides: Partial<Session> = {}): Session => ({
@@ -102,6 +104,30 @@ describe('sessions store', () => {
     setSessions([makeSession({ id: 's-1', status: 'running' })])
     setSessions(s => s.id === 's-1', 'status', 'idle')
     expect(sessions[0].status).toBe('idle')
+  })
+
+  test('clearSessionContextsForTask wipes only the target task sessions', () => {
+    localStorage.clear()
+    setSessionContexts(produce(store => {
+      for (const k of Object.keys(store)) delete store[k]
+    }))
+    setSessions([
+      makeSession({ id: 's-1', taskId: 't-001' }),
+      makeSession({ id: 's-2', taskId: 't-002' }),
+      makeSession({ id: 's-3', taskId: 't-001' }),
+    ])
+    setPlanFilePathForSession('s-1', '/tmp/1.md')
+    setPlanFilePathForSession('s-2', '/tmp/2.md')
+    setPlanFilePathForSession('s-3', '/tmp/3.md')
+
+    clearSessionContextsForTask('t-001')
+
+    expect(sessionContexts['s-1']).toBeUndefined()
+    expect(sessionContexts['s-3']).toBeUndefined()
+    expect(planFilePathForSession('s-2')).toBe('/tmp/2.md')
+    expect(localStorage.getItem('verun:sessionContext:s-1')).toBeNull()
+    expect(localStorage.getItem('verun:sessionContext:s-3')).toBeNull()
+    expect(localStorage.getItem('verun:sessionContext:s-2')).not.toBeNull()
   })
 })
 

--- a/src/store/sessions.ts
+++ b/src/store/sessions.ts
@@ -8,6 +8,8 @@ import { dequeueArmedStep, disarmAllSteps, clearSteps } from './steps'
 import * as ipc from '../lib/ipc'
 import { notify } from '../lib/notifications'
 import { deserializeAttachments } from '../lib/binary'
+import { clearSessionContext } from './sessionContext'
+import { clearSessionContextStorage } from './sessionContextStorage'
 
 const MAX_ITEMS_IN_MEMORY = 50_000
 
@@ -21,34 +23,6 @@ export const [sessionTokens, setSessionTokens] = createStore<Record<string, { in
 /// Set on abort click, cleared when the backend emits `session-aborted`.
 export const [abortingSessions, setAbortingSessions] = createStore<Record<string, boolean>>({})
 export const [rateLimitInfo, setRateLimitInfo] = createSignal<RateLimitInfo | null>(null)
-const [_taskPlanMode, _setTaskPlanMode] = createStore<Record<string, boolean>>({})
-const [_taskThinkingMode, _setTaskThinkingMode] = createStore<Record<string, boolean>>({})
-const [_taskFastMode, _setTaskFastMode] = createStore<Record<string, boolean>>({})
-export const taskPlanMode = _taskPlanMode
-export const taskThinkingMode = _taskThinkingMode
-export const taskFastMode = _taskFastMode
-export function setTaskPlanMode(taskId: string, v: boolean) {
-  _setTaskPlanMode(taskId, v)
-  localStorage.setItem(`verun:planMode:${taskId}`, String(v))
-}
-export function setTaskThinkingMode(taskId: string, v: boolean) {
-  _setTaskThinkingMode(taskId, v)
-  localStorage.setItem(`verun:thinkingMode:${taskId}`, String(v))
-}
-export function setTaskFastMode(taskId: string, v: boolean) {
-  _setTaskFastMode(taskId, v)
-  localStorage.setItem(`verun:fastMode:${taskId}`, String(v))
-}
-const [_taskPlanFilePath, _setTaskPlanFilePath] = createStore<Record<string, string | null>>({})
-export const taskPlanFilePath = _taskPlanFilePath
-export function setTaskPlanFilePath(taskId: string, path: string | null) {
-  _setTaskPlanFilePath(taskId, path)
-  if (path) {
-    localStorage.setItem(`verun:planFilePath:${taskId}`, path)
-  } else {
-    localStorage.removeItem(`verun:planFilePath:${taskId}`)
-  }
-}
 
 /**
  * Backstop for cross-window session sync: when the window becomes visible,
@@ -72,15 +46,6 @@ export async function loadSessions(taskId: string) {
   for (const s of list) {
     if (s.totalCost > 0) setSessionCosts(s.id, s.totalCost)
   }
-  // Restore mode switches from localStorage (authoritative source for toggles)
-  const savedPlan = localStorage.getItem(`verun:planMode:${taskId}`)
-  const savedThinking = localStorage.getItem(`verun:thinkingMode:${taskId}`)
-  const savedFast = localStorage.getItem(`verun:fastMode:${taskId}`)
-  if (savedPlan !== null) _setTaskPlanMode(taskId, savedPlan === 'true')
-  if (savedThinking !== null) _setTaskThinkingMode(taskId, savedThinking === 'true')
-  if (savedFast !== null) _setTaskFastMode(taskId, savedFast === 'true')
-  const savedPlanFilePath = localStorage.getItem(`verun:planFilePath:${taskId}`)
-  if (savedPlanFilePath) _setTaskPlanFilePath(taskId, savedPlanFilePath)
 }
 
 export async function createSession(taskId: string, agentType: string, model?: string): Promise<Session> {
@@ -492,23 +457,12 @@ export async function initSessionListeners() {
   }
 }
 
-export function clearPlanState(taskId: string) {
-  setTaskPlanFilePath(taskId, null) // also clears localStorage via wrapper
-  _setTaskPlanMode(taskId, false)
-  localStorage.removeItem(`verun:planMode:${taskId}`)
-}
-
-export function cleanupTaskModeStorage(taskId: string) {
-  const keys = [
-    `verun:planMode:${taskId}`,
-    `verun:thinkingMode:${taskId}`,
-    `verun:fastMode:${taskId}`,
-    `verun:planFilePath:${taskId}`,
-  ]
-  for (const k of keys) localStorage.removeItem(k)
+export function clearSessionContextsForTask(taskId: string) {
+  for (const s of sessionsForTask(taskId)) clearSessionContext(s.id)
 }
 
 export function cleanupSessionStorage(sessionId: string) {
+  clearSessionContextStorage(sessionId)
   localStorage.removeItem(`verun:draft-msg:${sessionId}`)
   localStorage.removeItem(`verun:draft-att:${sessionId}`)
 }

--- a/src/store/sessions.ts
+++ b/src/store/sessions.ts
@@ -9,7 +9,6 @@ import * as ipc from '../lib/ipc'
 import { notify } from '../lib/notifications'
 import { deserializeAttachments } from '../lib/binary'
 import { clearSessionContext } from './sessionContext'
-import { clearSessionContextStorage } from './sessionContextStorage'
 
 const MAX_ITEMS_IN_MEMORY = 50_000
 
@@ -462,7 +461,6 @@ export function clearSessionContextsForTask(taskId: string) {
 }
 
 export function cleanupSessionStorage(sessionId: string) {
-  clearSessionContextStorage(sessionId)
   localStorage.removeItem(`verun:draft-msg:${sessionId}`)
   localStorage.removeItem(`verun:draft-att:${sessionId}`)
 }

--- a/src/store/tasks.ts
+++ b/src/store/tasks.ts
@@ -6,7 +6,7 @@ import { closeTerminalsForTask } from './terminals'
 import { clearTaskGitState } from './git'
 import { clearProblemsForTask } from './problems'
 import { fireTaskCleanup } from './editorView'
-import { sessionsForTask, cleanupTaskModeStorage, cleanupSessionStorage, clearPlanState } from './sessions'
+import { sessionsForTask, cleanupSessionStorage, clearSessionContextsForTask } from './sessions'
 import { clearTaskContext } from './taskContext'
 import { clearTaskContextStorage } from './taskContextStorage'
 import { dropTaskSkills } from './commands'
@@ -180,7 +180,7 @@ export async function deleteTask(id: string, deleteBranch = true, skipDestroyHoo
   closeTerminalsForTask(id)
   clearTaskGitState(id)
   clearProblemsForTask(id)
-  clearPlanState(id)
+  clearSessionContextsForTask(id)
   fireTaskCleanup(id)
   clearTaskContext(id)
   dropTaskSkills(id)
@@ -204,7 +204,7 @@ export async function archiveTask(id: string, skipDestroyHook = false) {
     closeTerminalsForTask(id)
     clearTaskGitState(id)
     clearProblemsForTask(id)
-    clearPlanState(id)
+    clearSessionContextsForTask(id)
     fireTaskCleanup(id)
     clearTaskContext(id)
     dropTaskSkills(id)
@@ -233,7 +233,6 @@ export const taskById = (id: string) =>
 
 /** Remove all localStorage keys associated with a task */
 export function cleanupTaskStorage(id: string) {
-  cleanupTaskModeStorage(id)
   clearTaskContextStorage(id)
   for (const s of sessionsForTask(id)) {
     cleanupSessionStorage(s.id)


### PR DESCRIPTION
## Summary

- Plan mode banner ("Plan ready") was showing across all sessions in a task when only one session triggered `ExitPlanMode` — now scoped to the triggering session only
- Plan / thinking / fast mode toggles were shared task-wide — now each session has its own independent state
- Introduces `sessionContext` / `sessionContextStorage` stores, mirroring the existing `taskContext` pattern, with a single typed state object per session persisted as one JSON blob under `verun:sessionContext:<sessionId>`
- Removes four ad hoc task-keyed stores (`_taskPlanMode`, `_taskThinkingMode`, `_taskFastMode`, `_taskPlanFilePath`) from `sessions.ts`
- Task deletion / archive correctly clears all session contexts for every session in the task

## Test plan

- [ ] `pnpm test -- --run` — 110/110 pass (6 new `sessionContext` unit tests + 1 new `sessions` task-cleanup test)
- [ ] `pnpm check` — no TypeScript errors
- [ ] Manual: two sessions in one task — toggle plan mode ON in session A, verify session B is unaffected; trigger `ExitPlanMode` in A, confirm banner only in A; switch to B and back
- [ ] Manual: close and reopen app — each session's context (toggles + plan file) restored independently
- [ ] Manual: delete task — no orphan `verun:sessionContext:*` keys remain

Closes #155