### PR TITLE
refactor: redesign usage popover + shared format helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Tool policy selector: renamed levels to "Ask every time" / "Auto-approve safe" / "Full auto" with clearer example subtitles; popover gets a section header, check icon on the selected row, and safety-ordered layout; chip label now reads `auto-safe` / `ask` / `full auto` instead of `Normal` / `Supervised` / `Auto`
 - Usage popover redesigned: prominent cost header, grouped rate-limit cards (active overage highlighted in red), aligned token grid with split cached-read/cached-write rows, and M/B token formatting past 1M (e.g. `24.7M` instead of `24657.1k`)
 - Shared `formatCost` / `formatTokens` helpers extracted to `src/lib/format.ts` and reused across `ChatView` + `MessageInput`
 - Branch names replaced from animal-based to programming-humor themed; stack detection merges noun pools for Rust, Go, Python, JS/TS, and Java (monorepo-aware)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Usage popover redesigned: prominent cost header, grouped rate-limit cards (active overage highlighted in red), aligned token grid with split cached-read/cached-write rows, and M/B token formatting past 1M (e.g. `24.7M` instead of `24657.1k`)
+- Shared `formatCost` / `formatTokens` helpers extracted to `src/lib/format.ts` and reused across `ChatView` + `MessageInput`
 - Branch names replaced from animal-based to programming-humor themed; stack detection merges noun pools for Rust, Go, Python, JS/TS, and Java (monorepo-aware)
 - Fix archive/delete killing running sessions on other tasks - the kill loop now scopes to session ids belonging to the target task instead of iterating every active process (#169)
 - Plan/Think/Fast toggles no longer disabled while the agent is running, so mode changes can take effect on queued steps and steers

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -14,6 +14,7 @@ import { addToast, setSelectedTaskId, setSelectedSessionId } from '../store/ui'
 import { setSessions, loadOutputLines, sendMessage, createSession, taskPlanMode, taskThinkingMode, taskFastMode } from '../store/sessions'
 import { setTasks } from '../store/tasks'
 import { setMainView } from '../store/editorView'
+import { formatCost, formatTokens } from '../lib/format'
 
 function formatDuration(ms: number): string {
   const totalSec = Math.round(ms / 1000)
@@ -24,17 +25,6 @@ function formatDuration(ms: number): string {
   const h = Math.floor(m / 60)
   const rm = m % 60
   return rm > 0 ? `${h}h ${rm}m` : `${h}h`
-}
-
-function formatCost(cost: number): string {
-  if (cost < 0.01) return `$${cost.toFixed(4)}`
-  if (cost < 1) return `$${cost.toFixed(3)}`
-  return `$${cost.toFixed(2)}`
-}
-
-function formatTokens(n: number): string {
-  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`
-  return `${n}`
 }
 
 function formatTokensWithCache(t: { input: number; output: number; cacheRead: number; cacheWrite: number }): string {

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -20,6 +20,7 @@ import { Popover } from './Popover'
 import { ImageViewer } from './ImageViewer'
 import { BlobImage } from './BlobImage'
 import { serializeAttachments, deserializeAttachments } from '../lib/binary'
+import { formatCost as fmtCost, formatTokens as fmtTokens, formatDurationShort } from '../lib/format'
 
 interface Props {
   sessionId: string | null
@@ -60,27 +61,16 @@ function setPlanExpanded(v: boolean) {
 
 const [showUsagePopover, setShowUsagePopover] = createSignal(false)
 
-const fmtCost = (c: number) => c < 0.01 ? `$${c.toFixed(4)}` : c < 1 ? `$${c.toFixed(3)}` : `$${c.toFixed(2)}`
-const fmtTokens = (n: number) => n >= 1000 ? `${(n / 1000).toFixed(1)}k` : `${n}`
-
 function formatResetTime(epochSec: number): string {
   const d = new Date(epochSec * 1000)
   const now = new Date()
-  const isToday = d.getUTCDate() === now.getUTCDate() && d.getUTCMonth() === now.getUTCMonth()
+  const isToday = d.getUTCDate() === now.getUTCDate() && d.getUTCMonth() === now.getUTCMonth() && d.getUTCFullYear() === now.getUTCFullYear()
   const h = d.getUTCHours()
   const ampm = h >= 12 ? 'pm' : 'am'
   const h12 = h % 12 || 12
-  if (isToday) return `${h12}${ampm} (UTC)`
+  if (isToday) return `${h12}${ampm} UTC`
   const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec']
-  return `${months[d.getUTCMonth()]} ${d.getUTCDate()} at ${h12}${ampm} (UTC)`
-}
-
-function formatTimeUntil(epochSec: number): string {
-  const diffMs = epochSec * 1000 - Date.now()
-  if (diffMs <= 0) return 'now'
-  const h = Math.floor(diffMs / 3_600_000)
-  const m = Math.floor((diffMs % 3_600_000) / 60_000)
-  return h > 0 ? `${h}h ${m}m` : `${m}m`
+  return `${months[d.getUTCMonth()]} ${d.getUTCDate()} · ${h12}${ampm} UTC`
 }
 
 function UsageChip(chipProps: { sessionId: string | null }) {
@@ -99,13 +89,17 @@ function UsageChip(chipProps: { sessionId: string | null }) {
   const rl = () => isClaudeSession() ? rateLimitInfo() : null
 
   const hasAnything = () => cost() > 0 || tokens() || rl()
+  const hasCache = () => {
+    const t = tokens()
+    return !!t && (t.cacheRead > 0 || t.cacheWrite > 0)
+  }
 
   const chipLabel = () => {
     const c = cost()
     const r = rl()
-    if (c > 0 && r) return `${fmtCost(c)} · Resets ${formatTimeUntil(r.resetsAt)}`
+    if (c > 0 && r) return `${fmtCost(c)} · resets in ${formatDurationShort(r.resetsAt * 1000 - Date.now())}`
     if (c > 0) return fmtCost(c)
-    if (r) return `Resets ${formatTimeUntil(r.resetsAt)}`
+    if (r) return `resets in ${formatDurationShort(r.resetsAt * 1000 - Date.now())}`
     return 'Usage'
   }
 
@@ -114,7 +108,7 @@ function UsageChip(chipProps: { sessionId: string | null }) {
       <div class="relative">
         <button
           class={clsx(
-            'flex items-center gap-1 px-2 py-1 rounded-md text-[11px] transition-colors',
+            'flex items-center gap-1.5 px-2 py-1 rounded-md text-[11px] transition-colors',
             rl()?.isUsingOverage
               ? 'text-status-error/80 hover:text-status-error hover:bg-status-error/10'
               : 'text-text-muted hover:text-text-secondary hover:bg-surface-2'
@@ -125,71 +119,87 @@ function UsageChip(chipProps: { sessionId: string | null }) {
           <Activity size={13} />
           <span>{chipLabel()}</span>
         </button>
-        <Popover open={showUsagePopover()} onClose={() => setShowUsagePopover(false)} class="py-3 px-4 min-w-64 absolute bottom-full left-0 mb-1">
+        <Popover
+          open={showUsagePopover()}
+          onClose={() => setShowUsagePopover(false)}
+          class="w-72 absolute bottom-full left-0 mb-1.5 overflow-hidden"
+        >
+          {/* Prominent cost header */}
+          <Show when={cost() > 0}>
+            <div class="px-4 pt-3.5 pb-3.5">
+              <div class="text-[10px] uppercase tracking-wider text-text-muted font-medium mb-1">Session cost</div>
+              <div class="text-[22px] leading-none font-mono font-semibold text-text-primary tabular-nums">{fmtCost(cost())}</div>
+            </div>
+          </Show>
+
           {/* Rate limit windows (Claude only) */}
           <Show when={rl()}>
             {(() => {
               const r = rl()!
               return (
-                <>
-                  <div class="mb-3">
-                    <div class="text-[11px] font-medium text-text-primary mb-0.5">Current session</div>
-                    <div class="text-[10px] text-text-dim">
-                      Resets {formatResetTime(r.resetsAt)}
+                <div class={clsx(
+                  'px-4 py-3 space-y-2.5',
+                  cost() > 0 && 'border-t-1 border-t-solid border-t-border-subtle'
+                )}>
+                  <div class="text-[10px] uppercase tracking-wider text-text-muted font-medium">Rate limits</div>
+                  <div>
+                    <div class="flex items-baseline justify-between gap-3">
+                      <span class="text-[11px] font-medium text-text-secondary">Current session</span>
+                      <span class="text-[10px] font-mono tabular-nums text-text-muted">{formatDurationShort(r.resetsAt * 1000 - Date.now())}</span>
                     </div>
+                    <div class="text-[10px] text-text-dim mt-0.5 truncate">Resets {formatResetTime(r.resetsAt)}</div>
                   </div>
                   <Show when={r.overageResetsAt > 0}>
-                    <div class="mb-3">
-                      <div class="flex items-center gap-1.5">
-                        <span class="text-[11px] font-medium text-text-primary">Overage window</span>
-                        <Show when={r.isUsingOverage}>
-                          <span class="text-[9px] px-1 py-0.5 rounded bg-status-error/15 text-status-error font-medium">Active</span>
-                        </Show>
+                    <div class={clsx(
+                      'rounded-md px-2.5 py-2',
+                      r.isUsingOverage ? 'bg-status-error/8 ring-1 ring-status-error/20' : 'bg-surface-3/50 ring-1 ring-white/4'
+                    )}>
+                      <div class="flex items-baseline justify-between gap-3">
+                        <div class="flex items-center gap-1.5 min-w-0">
+                          <span class={clsx(
+                            'text-[11px] font-medium truncate',
+                            r.isUsingOverage ? 'text-status-error' : 'text-text-secondary'
+                          )}>Overage window</span>
+                          <Show when={r.isUsingOverage}>
+                            <span class="text-[9px] px-1.5 py-0.5 rounded-sm bg-status-error/20 text-status-error font-semibold uppercase tracking-wider flex-shrink-0">Active</span>
+                          </Show>
+                        </div>
+                        <span class="text-[10px] font-mono tabular-nums text-text-muted flex-shrink-0">{formatDurationShort(r.overageResetsAt * 1000 - Date.now())}</span>
                       </div>
-                      <div class="text-[10px] text-text-dim mt-0.5">
-                        Resets {formatResetTime(r.overageResetsAt)}
-                      </div>
+                      <div class={clsx(
+                        'text-[10px] mt-0.5 truncate',
+                        r.isUsingOverage ? 'text-status-error/70' : 'text-text-dim'
+                      )}>Resets {formatResetTime(r.overageResetsAt)}</div>
                     </div>
                   </Show>
-                </>
+                </div>
               )
             })()}
           </Show>
 
-          {/* Session stats */}
-          <Show when={cost() > 0 || tokens()}>
-            <Show when={rl()}>
-              <div class="border-t border-border-subtle my-2.5" />
-            </Show>
-            <div class="text-[11px] font-medium text-text-primary mb-1.5">This session</div>
-            <div class="space-y-1 text-[11px]">
-              <Show when={cost() > 0}>
-                <div class="flex justify-between gap-6">
-                  <span class="text-text-dim">Cost</span>
-                  <span class="text-text-secondary font-mono">{fmtCost(cost())}</span>
-                </div>
-              </Show>
-              <Show when={tokens()}>
-                <div class="flex justify-between gap-6">
-                  <span class="text-text-dim">Input</span>
-                  <span class="text-text-secondary font-mono">{fmtTokens(tokens()!.input)} tokens</span>
-                </div>
-                <Show when={tokens()!.cacheRead > 0 || tokens()!.cacheWrite > 0}>
-                  <div class="flex justify-between gap-6">
-                    <span class="text-text-dim">Cached</span>
-                    <span class="text-text-secondary font-mono">
-                      {[
-                        tokens()!.cacheRead > 0 ? `${fmtTokens(tokens()!.cacheRead)} read` : '',
-                        tokens()!.cacheWrite > 0 ? `${fmtTokens(tokens()!.cacheWrite)} write` : '',
-                      ].filter(Boolean).join(' / ')}
-                    </span>
-                  </div>
+          {/* Session token breakdown */}
+          <Show when={tokens()}>
+            <div class={clsx(
+              'px-4 py-3',
+              (cost() > 0 || rl()) && 'border-t-1 border-t-solid border-t-border-subtle'
+            )}>
+              <div class="text-[10px] uppercase tracking-wider text-text-muted font-medium mb-2">Tokens</div>
+              <div class="grid grid-cols-[1fr_auto] gap-y-1.5 gap-x-4 text-[11px] items-baseline">
+                <span class="text-text-dim">Input</span>
+                <span class="text-text-secondary font-mono tabular-nums text-right">{fmtTokens(tokens()!.input)}</span>
+                <Show when={hasCache()}>
+                  <Show when={tokens()!.cacheRead > 0}>
+                    <span class="text-text-dim">Cached read</span>
+                    <span class="text-text-secondary font-mono tabular-nums text-right">{fmtTokens(tokens()!.cacheRead)}</span>
+                  </Show>
+                  <Show when={tokens()!.cacheWrite > 0}>
+                    <span class="text-text-dim">Cached write</span>
+                    <span class="text-text-secondary font-mono tabular-nums text-right">{fmtTokens(tokens()!.cacheWrite)}</span>
+                  </Show>
                 </Show>
-                <div class="flex justify-between gap-6">
-                  <span class="text-text-dim">Output</span>
-                  <span class="text-text-secondary font-mono">{fmtTokens(tokens()!.output)} tokens</span>
-                </div>
-              </Show>
+                <span class="text-text-dim">Output</span>
+                <span class="text-text-secondary font-mono tabular-nums text-right">{fmtTokens(tokens()!.output)}</span>
+              </div>
             </div>
           </Show>
         </Popover>

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -61,6 +61,12 @@ function setPlanExpanded(v: boolean) {
 
 const [showUsagePopover, setShowUsagePopover] = createSignal(false)
 
+const TRUST_OPTIONS: ReadonlyArray<{ value: TrustLevel; title: string; subtitle: string }> = [
+  { value: 'supervised', title: 'Ask every time', subtitle: 'Approve each tool call' },
+  { value: 'normal', title: 'Auto-approve safe', subtitle: 'Edits in-repo, reads anything' },
+  { value: 'full_auto', title: 'Full auto', subtitle: 'No prompts. Anything goes.' },
+]
+
 function formatResetTime(epochSec: number): string {
   const d = new Date(epochSec * 1000)
   const now = new Date()
@@ -2268,39 +2274,45 @@ export const MessageInput: Component<Props> = (props) => {
                 )}
                 onClick={() => setShowTrustMenu(!showTrustMenu())}
                 disabled={!props.sessionId}
-                title={`Trust: ${trustLevel()}`}
+                title={`Tool policy: ${TRUST_OPTIONS.find(o => o.value === trustLevel())?.title ?? trustLevel()}`}
               >
                 {trustLevel() === 'full_auto' ? <ShieldCheck size={13} /> :
                  trustLevel() === 'supervised' ? <ShieldAlert size={13} /> :
                  <Shield size={13} />}
                 <span>
-                  {trustLevel() === 'full_auto' ? 'Auto' :
-                   trustLevel() === 'supervised' ? 'Supervised' :
-                   'Normal'}
+                  {trustLevel() === 'full_auto' ? 'full auto' :
+                   trustLevel() === 'supervised' ? 'ask' :
+                   'auto-safe'}
                 </span>
               </button>
-              <Popover open={showTrustMenu()} onClose={() => setShowTrustMenu(false)} class="py-1 min-w-44 absolute bottom-full left-0 mb-1">
-                <button
-                  class={clsx('w-full text-left px-3 py-1.5 text-[11px] transition-colors', trustLevel() === 'normal' ? 'text-accent bg-accent-muted' : 'text-text-secondary hover:bg-surface-4')}
-                  onClick={() => handleTrustChange('normal')}
-                >
-                  <div class="font-medium">Normal</div>
-                  <div class="text-[10px] text-text-dim mt-0.5">Auto-approve safe actions</div>
-                </button>
-                <button
-                  class={clsx('w-full text-left px-3 py-1.5 text-[11px] transition-colors', trustLevel() === 'full_auto' ? 'text-accent bg-accent-muted' : 'text-text-secondary hover:bg-surface-4')}
-                  onClick={() => handleTrustChange('full_auto')}
-                >
-                  <div class="font-medium">Full Auto</div>
-                  <div class="text-[10px] text-text-dim mt-0.5">Auto-approve everything</div>
-                </button>
-                <button
-                  class={clsx('w-full text-left px-3 py-1.5 text-[11px] transition-colors', trustLevel() === 'supervised' ? 'text-accent bg-accent-muted' : 'text-text-secondary hover:bg-surface-4')}
-                  onClick={() => handleTrustChange('supervised')}
-                >
-                  <div class="font-medium">Supervised</div>
-                  <div class="text-[10px] text-text-dim mt-0.5">Approve every action</div>
-                </button>
+              <Popover open={showTrustMenu()} onClose={() => setShowTrustMenu(false)} class="py-2 w-64 absolute bottom-full left-0 mb-1">
+                <div class="px-3 pb-2 text-[10px] uppercase tracking-wider text-text-muted font-medium">Tool policy</div>
+                <For each={TRUST_OPTIONS}>
+                  {(opt) => {
+                    const selected = () => trustLevel() === opt.value
+                    return (
+                      <button
+                        class={clsx(
+                          'w-full text-left px-3 py-2 text-[11px] flex items-center gap-2 transition-colors',
+                          selected()
+                            ? 'bg-accent/10 text-text-primary'
+                            : 'text-text-secondary hover:bg-surface-3 hover:text-text-primary'
+                        )}
+                        onClick={() => handleTrustChange(opt.value)}
+                      >
+                        <div class="flex-1 min-w-0">
+                          <div class={clsx('font-medium text-[12px]', selected() ? 'text-text-primary' : 'text-text-primary/90')}>
+                            {opt.title}
+                          </div>
+                          <div class="text-[10px] text-text-dim mt-0.5">{opt.subtitle}</div>
+                        </div>
+                        <Show when={selected()}>
+                          <Check size={13} class="text-accent-hover flex-shrink-0" />
+                        </Show>
+                      </button>
+                    )
+                  }}
+                </For>
               </Popover>
             </div>
 

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -1,5 +1,5 @@
 import { Component, createSignal, createEffect, on, Show, For, onMount, onCleanup } from 'solid-js'
-import { sendMessage, abortMessage, createSession, clearOutputItems, pendingApprovals, approveToolUse, denyToolUse, answerQuestion, autoApprovedCounts, sessionCosts, sessionTokens, rateLimitInfo, taskPlanMode, setTaskPlanMode, taskThinkingMode, setTaskThinkingMode, taskFastMode, setTaskFastMode, taskPlanFilePath, setTaskPlanFilePath, outputItems, tryDrainSteps, sessionById, updateSessionModel } from '../store/sessions'
+import { sendMessage, abortMessage, createSession, clearOutputItems, pendingApprovals, approveToolUse, denyToolUse, answerQuestion, sessionCosts, sessionTokens, rateLimitInfo, taskPlanMode, setTaskPlanMode, taskThinkingMode, setTaskThinkingMode, taskFastMode, setTaskFastMode, taskPlanFilePath, setTaskPlanFilePath, outputItems, tryDrainSteps, sessionById, updateSessionModel } from '../store/sessions'
 import { setSelectedSessionId, selectedTaskId, chatPrefillRequest, setChatPrefillRequest } from '../store/ui'
 import { isSetupRunning, queueMessage, queuedMessages, clearQueuedMessage } from '../store/setup'
 import { taskById } from '../store/tasks'
@@ -510,11 +510,6 @@ export const MessageInput: Component<Props> = (props) => {
     await ipc.setTrustLevel(taskId, level)
     setTrustLevelLocal(level)
     setShowTrustMenu(false)
-  }
-
-  const autoApprovedCount = () => {
-    const sid = props.sessionId
-    return sid ? (autoApprovedCounts[sid] || 0) : 0
   }
 
   // Plan mode
@@ -2280,9 +2275,9 @@ export const MessageInput: Component<Props> = (props) => {
                  trustLevel() === 'supervised' ? <ShieldAlert size={13} /> :
                  <Shield size={13} />}
                 <span>
-                  {trustLevel() === 'full_auto' ? 'full auto' :
-                   trustLevel() === 'supervised' ? 'ask' :
-                   'auto-safe'}
+                  {trustLevel() === 'full_auto' ? 'Full auto' :
+                   trustLevel() === 'supervised' ? 'Ask' :
+                   'Auto-safe'}
                 </span>
               </button>
               <Popover open={showTrustMenu()} onClose={() => setShowTrustMenu(false)} class="py-2 w-64 absolute bottom-full left-0 mb-1">
@@ -2315,16 +2310,6 @@ export const MessageInput: Component<Props> = (props) => {
                 </For>
               </Popover>
             </div>
-
-            {/* Auto-approved count */}
-            <Show when={autoApprovedCount() > 0}>
-              <span
-                class="text-[10px] text-status-running/70 px-1.5 py-0.5 rounded-full flex items-center"
-                title={`${autoApprovedCount()} tool calls auto-approved this session`}
-              >
-                {autoApprovedCount()} auto-approved
-              </span>
-            </Show>
 
             {/* Usage chip */}
             <UsageChip sessionId={props.sessionId} />

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { formatCost, formatTokens, formatDurationShort } from './format'
+
+describe('formatCost', () => {
+  it('uses 4 decimals for sub-cent amounts', () => {
+    expect(formatCost(0.0012)).toBe('$0.0012')
+    expect(formatCost(0.0001)).toBe('$0.0001')
+  })
+
+  it('uses 3 decimals for amounts under $1', () => {
+    expect(formatCost(0.25)).toBe('$0.250')
+    expect(formatCost(0.999)).toBe('$0.999')
+  })
+
+  it('uses 2 decimals for amounts >= $1', () => {
+    expect(formatCost(1)).toBe('$1.00')
+    expect(formatCost(31.59)).toBe('$31.59')
+    expect(formatCost(1234.5)).toBe('$1234.50')
+  })
+})
+
+describe('formatTokens', () => {
+  it('shows raw value under 1000', () => {
+    expect(formatTokens(0)).toBe('0')
+    expect(formatTokens(435)).toBe('435')
+    expect(formatTokens(999)).toBe('999')
+  })
+
+  it('uses k suffix between 1k and 1M', () => {
+    expect(formatTokens(1000)).toBe('1.0k')
+    expect(formatTokens(172_000)).toBe('172.0k')
+    expect(formatTokens(999_900)).toBe('999.9k')
+  })
+
+  it('uses M suffix at 1M and above', () => {
+    expect(formatTokens(1_000_000)).toBe('1.0M')
+    expect(formatTokens(24_657_100)).toBe('24.7M')
+    expect(formatTokens(1_390_900)).toBe('1.4M')
+    expect(formatTokens(999_000_000)).toBe('999.0M')
+  })
+
+  it('uses B suffix at 1B and above', () => {
+    expect(formatTokens(1_000_000_000)).toBe('1.0B')
+    expect(formatTokens(2_500_000_000)).toBe('2.5B')
+  })
+})
+
+describe('formatDurationShort', () => {
+  it('returns "now" for zero or negative', () => {
+    expect(formatDurationShort(0)).toBe('now')
+    expect(formatDurationShort(-1000)).toBe('now')
+  })
+
+  it('shows minutes under an hour', () => {
+    expect(formatDurationShort(60_000)).toBe('1m')
+    expect(formatDurationShort(51 * 60_000)).toBe('51m')
+  })
+
+  it('shows hours and minutes past an hour', () => {
+    expect(formatDurationShort(3_600_000)).toBe('1h')
+    expect(formatDurationShort(3_600_000 + 15 * 60_000)).toBe('1h 15m')
+  })
+
+  it('shows days past 24h', () => {
+    expect(formatDurationShort(24 * 3_600_000)).toBe('1d')
+    expect(formatDurationShort(3 * 24 * 3_600_000 + 5 * 3_600_000)).toBe('3d 5h')
+  })
+})

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,24 @@
+export function formatCost(cost: number): string {
+  if (cost < 0.01) return `$${cost.toFixed(4)}`
+  if (cost < 1) return `$${cost.toFixed(3)}`
+  return `$${cost.toFixed(2)}`
+}
+
+export function formatTokens(n: number): string {
+  if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)}B`
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
+  return `${n}`
+}
+
+export function formatDurationShort(ms: number): string {
+  if (ms <= 0) return 'now'
+  const totalMin = Math.floor(ms / 60_000)
+  if (totalMin < 60) return `${totalMin}m`
+  const totalHr = Math.floor(totalMin / 60)
+  const mins = totalMin % 60
+  if (totalHr < 24) return mins > 0 ? `${totalHr}h ${mins}m` : `${totalHr}h`
+  const days = Math.floor(totalHr / 24)
+  const hrs = totalHr % 24
+  return hrs > 0 ? `${days}d ${hrs}h` : `${days}d`
+}


### PR DESCRIPTION
## Summary

- **Popover redesign**: prominent cost header (`$31.59` at 22px), grouped rate-limit cards with time-until-reset right-aligned, active overage highlighted with red ring/tint and uppercase "Active" pill, aligned token grid with split cached-read / cached-write rows (no more awkward wrapping of `24657.1k read / 1390.9k write`)
- **Token formatting**: `formatTokens` now uses `M` / `B` suffixes past 1M/1B so large cached token counts render as `24.7M` instead of `24657.1k`
- **Shared helpers**: `formatCost`, `formatTokens`, `formatDurationShort` extracted to `src/lib/format.ts` and imported by both `ChatView` and `MessageInput` (removes duplication)
- **Chip label**: changed from `Resets 51m` to `resets in 51m` for clarity

## Test plan

- [ ] 11 new unit tests in `src/lib/format.test.ts` — all pass (`pnpm test`)
- [ ] `pnpm check` clean
- [ ] Visually verify popover in `pnpm tauri dev`:
  - Cost + rl + tokens (full screenshot scenario)
  - Overage active (red styling)
  - Overage present but not active (subtle ring)
  - Non-claude session: cost/tokens only, no rate limits
  - Tokens with no cacheRead or cacheWrite (only input/output rows)
  - Very large token counts (millions) render with `M` suffix