### PR TITLE
fix: detached task window hydration, archive, focus, and cross-window sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
 - Opening the New Task dialog after adding a project now works from every entry point (empty-state button no longer skips it)
 - Sidebar task tiles show unread/attention state as a pulsing left-edge strip (amber for attention, blue for unread) instead of a trailing dot
 - Cmd+1…9 now focuses the existing window when the target task is already open in a separate window (matching sidebar click behavior); sidebar tiles display the shortcut, which swaps to the archive button on hover (#142)
+- Detached task windows now hydrate the projects + agents stores on mount, so the new-session menu lists installed agents and the Start button picks up the project's start command (#166)
+- Archiving a task closes its detached window instantly: the sidebar updates optimistically, `task-removed` fires before the destroy hook runs, and the destroy hook + last-commit-message capture finish in the background (#138)
+- `open_task_window` now unminimizes and shows the window before focusing, so Cmd+1…9 (and sidebar clicks) reliably bring detached windows forward on macOS even when minimized (#142)
+- Cross-window task state stays in sync: new sessions and closed sessions started in one window now broadcast `session-created` / `session-removed` so other windows update without a reload, plus a visibility-change backstop refreshes sessions for every loaded task (#143)
 - Fix newly created task occasionally disappearing from sidebar after setup - the `task-created` event now carries the source window label so the originating window skips its own reload, avoiding a race with the async DB write queue (#135)
 - Graceful shutdown for aborted claude sessions: close stdin, wait 5s, SIGTERM, wait 5s, then SIGKILL - prevents losing the last assistant message on `--resume` when the CLI is mid-write of its session JSONL
 - Strip `CLAUDECODE` from the spawned CLI's env and set `CLAUDE_CODE_ENTRYPOINT=verun` so nested-detection and telemetry are correct

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Tool policy selector: renamed levels to "Ask every time" / "Auto-approve safe" / "Full auto" with clearer example subtitles; popover gets a section header, check icon on the selected row, and safety-ordered layout; chip label now reads `auto-safe` / `ask` / `full auto` instead of `Normal` / `Supervised` / `Auto`
 - Usage popover redesigned: prominent cost header, grouped rate-limit cards (active overage highlighted in red), aligned token grid with split cached-read/cached-write rows, and M/B token formatting past 1M (e.g. `24.7M` instead of `24657.1k`)
 - Shared `formatCost` / `formatTokens` helpers extracted to `src/lib/format.ts` and reused across `ChatView` + `MessageInput`
+- Fix new session opening twice in the source window: `createSession` now dedups against the cross-window `session-created` broadcast (regression from #143)
 - Branch names replaced from animal-based to programming-humor themed; stack detection merges noun pools for Rust, Go, Python, JS/TS, and Java (monorepo-aware)
 - Fix archive/delete killing running sessions on other tasks - the kill loop now scopes to session ids belonging to the target task instead of iterating every active process (#169)
 - Plan/Think/Fast toggles no longer disabled while the agent is running, so mode changes can take effect on queued steps and steers

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -369,6 +369,10 @@ pub enum DbWrite {
         archived_at: i64,
         last_commit_message: Option<String>,
     },
+    SetLastCommitMessage {
+        id: String,
+        msg: Option<String>,
+    },
     RestoreTask {
         id: String,
     },
@@ -665,6 +669,14 @@ async fn process_write(pool: &SqlitePool, write: DbWrite) -> Result<(), sqlx::Er
         } => {
             sqlx::query("UPDATE tasks SET archived = 1, archived_at = ?, last_commit_message = ? WHERE id = ?")
                 .bind(archived_at).bind(&last_commit_message).bind(&id).execute(pool).await?;
+        }
+
+        DbWrite::SetLastCommitMessage { id, msg } => {
+            sqlx::query("UPDATE tasks SET last_commit_message = ? WHERE id = ?")
+                .bind(&msg)
+                .bind(&id)
+                .execute(pool)
+                .await?;
         }
 
         DbWrite::RestoreTask { id } => {
@@ -1419,6 +1431,81 @@ mod tests {
         // Sessions and output preserved
         assert!(get_session(&pool, "s-001").await.unwrap().is_some());
         assert!(!get_output_lines(&pool, "s-001").await.unwrap().is_empty());
+    }
+
+    // Issue #138 — archive_task now flips the archived flag with
+    // last_commit_message: None first, then writes the captured commit
+    // message asynchronously after the destroy hook finishes. This split
+    // lets the UI close the window instantly without waiting for the hook.
+    #[tokio::test]
+    async fn archive_task_with_none_message_then_set_last_commit_message() {
+        let pool = test_pool().await;
+        process_write(&pool, DbWrite::InsertProject(make_project()))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::InsertTask(make_task("p-001")))
+            .await
+            .unwrap();
+
+        // Phase 1: instant archive — no message yet
+        process_write(
+            &pool,
+            DbWrite::ArchiveTask {
+                id: "t-001".into(),
+                archived_at: 9999,
+                last_commit_message: None,
+            },
+        )
+        .await
+        .unwrap();
+        let task = get_task(&pool, "t-001").await.unwrap().unwrap();
+        assert!(task.archived);
+        assert_eq!(task.last_commit_message, None);
+
+        // Phase 2: background hook captured the message; backfill it
+        process_write(
+            &pool,
+            DbWrite::SetLastCommitMessage {
+                id: "t-001".into(),
+                msg: Some("captured later".into()),
+            },
+        )
+        .await
+        .unwrap();
+        let task = get_task(&pool, "t-001").await.unwrap().unwrap();
+        assert!(task.archived);
+        assert_eq!(task.last_commit_message.as_deref(), Some("captured later"));
+    }
+
+    #[tokio::test]
+    async fn set_last_commit_message_can_clear_with_none() {
+        let pool = test_pool().await;
+        process_write(&pool, DbWrite::InsertProject(make_project()))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::InsertTask(make_task("p-001")))
+            .await
+            .unwrap();
+        process_write(
+            &pool,
+            DbWrite::SetLastCommitMessage {
+                id: "t-001".into(),
+                msg: Some("hello".into()),
+            },
+        )
+        .await
+        .unwrap();
+        process_write(
+            &pool,
+            DbWrite::SetLastCommitMessage {
+                id: "t-001".into(),
+                msg: None,
+            },
+        )
+        .await
+        .unwrap();
+        let task = get_task(&pool, "t-001").await.unwrap().unwrap();
+        assert_eq!(task.last_commit_message, None);
     }
 
     #[tokio::test]

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -543,23 +543,25 @@ pub async fn rename_task(
 /// Create a new session (no process spawned — call send_message to talk to Claude)
 #[tauri::command]
 pub async fn create_session(
+    app: AppHandle,
     db_tx: State<'_, DbWriteTx>,
     task_id: String,
     agent_type: String,
     model: Option<String>,
 ) -> Result<Session, String> {
-    task::create_session(db_tx.inner(), task_id, agent_type, model).await
+    task::create_session(&app, db_tx.inner(), task_id, agent_type, model).await
 }
 
 /// Fork an existing session at a specific assistant message uuid into a new
 /// session inside the SAME task. The worktree is unchanged.
 #[tauri::command]
 pub async fn fork_session_in_task(
+    app: AppHandle,
     pool: State<'_, SqlitePool>,
     session_id: String,
     fork_after_message_uuid: String,
 ) -> Result<Session, String> {
-    task::fork_session_in_task(pool.inner(), session_id, fork_after_message_uuid).await
+    task::fork_session_in_task(&app, pool.inner(), session_id, fork_after_message_uuid).await
 }
 
 /// Fork an existing session at a specific assistant message uuid into a new
@@ -765,7 +767,9 @@ pub async fn update_session_model(
 /// Close a session (hides from UI, persists in DB as 'closed')
 #[tauri::command]
 pub async fn close_session(
+    app: AppHandle,
     active: State<'_, ActiveMap>,
+    pool: State<'_, SqlitePool>,
     db_tx: State<'_, DbWriteTx>,
     session_id: String,
 ) -> Result<(), String> {
@@ -774,10 +778,20 @@ pub async fn close_session(
     if let Some((_, mut proc)) = active.remove(&session_id) {
         task::graceful_shutdown(&mut proc.child, &proc.stdin).await;
     }
+    let task_id = db::get_session(pool.inner(), &session_id)
+        .await?
+        .map(|s| s.task_id);
     db_tx
-        .send(db::DbWrite::CloseSession { id: session_id })
+        .send(db::DbWrite::CloseSession {
+            id: session_id.clone(),
+        })
         .await
-        .map_err(|e| format!("DB write failed: {e}"))
+        .map_err(|e| format!("DB write failed: {e}"))?;
+    let _ = app.emit(
+        "session-removed",
+        serde_json::json!({ "sessionId": session_id, "taskId": task_id }),
+    );
+    Ok(())
 }
 
 /// Clear a session's Claude context (reset session_id + delete output lines)
@@ -2477,8 +2491,16 @@ pub async fn open_task_window(
     let label = format!("task-{task_id}");
 
     if let Some(win) = app.get_webview_window(&label) {
+        // unminimize + show first — set_focus alone is unreliable on macOS
+        // when the window is minimized or behind another app.
+        let _ = win.unminimize();
+        let _ = win.show();
         win.set_focus()
             .map_err(|e| format!("Failed to focus window: {e}"))?;
+        let _ = app.emit(
+            "task-window-changed",
+            serde_json::json!({ "taskId": task_id, "open": true }),
+        );
         return Ok(());
     }
 

--- a/src-tauri/src/task.rs
+++ b/src-tauri/src/task.rs
@@ -602,7 +602,7 @@ pub async fn create_task(
         .map_err(|e| format!("DB write failed: {e}"))?;
 
     // Auto-create the first session with the chosen agent
-    let session = create_session(db_tx, task.id.clone(), agent_type, None).await?;
+    let session = create_session(app, db_tx, task.id.clone(), agent_type, None).await?;
 
     // Notify all windows about the new task so other windows can reload.
     // The source window skips the reload since it already has the task from
@@ -753,27 +753,10 @@ pub async fn archive_task(
         hook_map.remove(&task.id);
     }
 
-    // Run destroy hook (unless skipped) and capture last commit message
-    let rp = repo_path.to_string();
-    let branch = task.branch.clone();
-    let hook = if skip_destroy_hook {
-        String::new()
-    } else {
-        destroy_hook.to_string()
-    };
-    let wtp = task.worktree_path.clone();
-    let env_vars = worktree::verun_env_vars(task.port_offset, repo_path);
-    let last_commit_message = tokio::task::spawn_blocking(move || {
-        if !hook.is_empty() {
-            if let Err(e) = worktree::run_hook(&wtp, &hook, &env_vars) {
-                eprintln!("[verun] destroy hook failed: {e}");
-            }
-        }
-        worktree::last_commit_message(&rp, &branch)
-    })
-    .await
-    .unwrap_or(None);
-
+    // Flip the archive flag and notify listeners immediately. The destroy
+    // hook + last-commit-message capture run in the background — the user
+    // gets instant feedback (window closes, sidebar updates) and the hook's
+    // exit status no longer blocks UI.
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
@@ -783,7 +766,7 @@ pub async fn archive_task(
         .send(db::DbWrite::ArchiveTask {
             id: task.id.clone(),
             archived_at: now,
-            last_commit_message,
+            last_commit_message: None,
         })
         .await
         .map_err(|e| format!("DB write failed: {e}"))?;
@@ -792,6 +775,39 @@ pub async fn archive_task(
         "task-removed",
         serde_json::json!({ "taskId": task.id, "reason": "archived" }),
     );
+
+    let rp = repo_path.to_string();
+    let branch = task.branch.clone();
+    let hook = if skip_destroy_hook {
+        String::new()
+    } else {
+        destroy_hook.to_string()
+    };
+    let wtp = task.worktree_path.clone();
+    let env_vars = worktree::verun_env_vars(task.port_offset, repo_path);
+    let task_id = task.id.clone();
+    let db_tx_bg = db_tx.clone();
+    tokio::spawn(async move {
+        let last_commit_message = tokio::task::spawn_blocking(move || {
+            if !hook.is_empty() {
+                if let Err(e) = worktree::run_hook(&wtp, &hook, &env_vars) {
+                    eprintln!("[verun] destroy hook failed: {e}");
+                }
+            }
+            worktree::last_commit_message(&rp, &branch)
+        })
+        .await
+        .unwrap_or(None);
+
+        if last_commit_message.is_some() {
+            let _ = db_tx_bg
+                .send(db::DbWrite::SetLastCommitMessage {
+                    id: task_id,
+                    msg: last_commit_message,
+                })
+                .await;
+        }
+    });
 
     Ok(())
 }
@@ -802,6 +818,7 @@ pub async fn archive_task(
 
 /// Create a new session record (no process spawned yet — that happens on send_message)
 pub async fn create_session(
+    app: &AppHandle,
     db_tx: &DbWriteTx,
     task_id: String,
     agent_type: String,
@@ -826,6 +843,8 @@ pub async fn create_session(
         .send(db::DbWrite::CreateSession(session.clone()))
         .await
         .map_err(|e| format!("DB write failed: {e}"))?;
+
+    let _ = app.emit("session-created", &session);
 
     Ok(session)
 }
@@ -1878,6 +1897,7 @@ pub enum WorktreeForkState {
 /// session's chat view shows the inherited history. Session row + output
 /// lines are written in a single transaction for consistency.
 pub async fn fork_session_in_task(
+    app: &AppHandle,
     pool: &sqlx::sqlite::SqlitePool,
     source_session_id: String,
     fork_after_message_uuid: String,
@@ -1956,6 +1976,8 @@ pub async fn fork_session_in_task(
     .await?;
     copy_turn_snapshots_tx(&mut tx, &parent.id, &new_verun_sid).await?;
     tx.commit().await.map_err(|e| format!("commit: {e}"))?;
+
+    let _ = app.emit("session-created", &new_session);
 
     Ok(new_session)
 }
@@ -2268,6 +2290,7 @@ pub async fn fork_session_to_new_task(
         "task-created",
         serde_json::json!({ "taskId": new_task.id, "projectId": new_task.project_id }),
     );
+    let _ = app.emit("session-created", &new_session);
 
     Ok((new_task, new_session))
 }

--- a/src/components/TaskWindowShell.test.tsx
+++ b/src/components/TaskWindowShell.test.tsx
@@ -1,0 +1,154 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+import { render, cleanup } from '@solidjs/testing-library'
+
+// Issue #166 — detached task windows mounted TaskWindowShell but never
+// hydrated the projects + agents stores, so the new-session menu showed
+// "no agents installed" and the Start button showed "set up a start command"
+// even when both were configured. The fix: load both stores on mount.
+
+const {
+  loadProjectsMock,
+  loadAgentsMock,
+  loadTasksMock,
+  initListenersMock,
+  dismissSplashMock,
+  initThemeMock,
+  initQuitListenerMock,
+  installContextMenuMock,
+  refreshTaskGitMock,
+  showWindowMock,
+} = vi.hoisted(() => ({
+  loadProjectsMock: vi.fn(() => Promise.resolve()),
+  loadAgentsMock: vi.fn(() => Promise.resolve()),
+  loadTasksMock: vi.fn(() => Promise.resolve()),
+  initListenersMock: vi.fn(() => Promise.resolve()),
+  dismissSplashMock: vi.fn(),
+  initThemeMock: vi.fn(),
+  initQuitListenerMock: vi.fn(),
+  installContextMenuMock: vi.fn(),
+  refreshTaskGitMock: vi.fn(),
+  showWindowMock: vi.fn(),
+}))
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(() => Promise.resolve(() => {})),
+  emit: vi.fn(),
+}))
+
+vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: () => ({
+    show: showWindowMock,
+    close: vi.fn(),
+    setTitle: vi.fn(),
+  }),
+}))
+
+vi.mock('../lib/windowContext', () => ({
+  useWindowContext: () => ({ taskId: undefined, projectId: 'p-001', windowLabel: 'task-test', windowType: 'task' }),
+}))
+
+vi.mock('../lib/appInit', () => ({
+  initListeners: initListenersMock,
+  dismissSplash: dismissSplashMock,
+  installContextMenu: installContextMenuMock,
+  initQuitListener: initQuitListenerMock,
+  showQuitConfirm: () => false,
+  closeQuitDialog: vi.fn(),
+}))
+
+vi.mock('../lib/theme', () => ({ initTheme: initThemeMock }))
+
+vi.mock('../store/git', () => ({ refreshTaskGit: refreshTaskGitMock }))
+
+vi.mock('../store/tasks', () => ({
+  loadTasks: loadTasksMock,
+  taskById: () => undefined,
+}))
+
+vi.mock('../store/projects', () => ({
+  loadProjects: loadProjectsMock,
+  projectById: () => undefined,
+}))
+
+vi.mock('../store/agents', () => ({
+  loadAgents: loadAgentsMock,
+}))
+
+vi.mock('../store/ui', () => ({
+  selectedTaskId: () => null,
+  setSelectedTaskId: vi.fn(),
+  setSelectedProjectId: vi.fn(),
+  showTerminal: () => false,
+  setShowTerminal: vi.fn(),
+  toggleTerminal: vi.fn(),
+  rightPanelTab: () => 'changes',
+  setRightPanelTab: vi.fn(),
+  setShowQuickOpen: vi.fn(),
+}))
+
+vi.mock('../lib/platform', () => ({ modPressed: () => false }))
+
+vi.mock('../store/terminals', () => ({
+  spawnTerminal: vi.fn(),
+  focusActiveTerminal: vi.fn(),
+  terminalsForTask: () => [],
+  activeTerminalId: () => null,
+  setActiveTerminalForTask: vi.fn(),
+  isStartCommandRunning: () => false,
+  spawnStartCommand: vi.fn(),
+  stopStartCommand: vi.fn(),
+}))
+
+vi.mock('../store/editorView', () => ({
+  requestCloseTab: vi.fn(),
+  reopenClosedTab: vi.fn(),
+  nextTab: vi.fn(),
+  prevTab: vi.fn(),
+  activeTabPath: () => null,
+  mainView: () => 'session',
+}))
+
+vi.mock('../lib/ipc', () => ({
+  getTask: vi.fn(() => Promise.resolve(null)),
+  quitApp: vi.fn(),
+  forceCloseTaskWindow: vi.fn(),
+}))
+
+// Stub the heavy children so we don't drag in editor/xterm modules.
+vi.mock('./TaskPanel', () => ({ TaskPanel: () => null }))
+vi.mock('./NewTaskDialog', () => ({ NewTaskDialog: () => null }))
+vi.mock('./ConfirmDialog', () => ({ ConfirmDialog: () => null }))
+vi.mock('./ToastContainer', () => ({ ToastContainer: () => null }))
+vi.mock('./SelectionMenu', () => ({ SelectionMenu: () => null }))
+
+import { TaskWindowShell } from './TaskWindowShell'
+
+describe('TaskWindowShell hydration (issue #166)', () => {
+  beforeEach(() => {
+    loadProjectsMock.mockClear()
+    loadAgentsMock.mockClear()
+    loadTasksMock.mockClear()
+    initListenersMock.mockClear()
+    dismissSplashMock.mockClear()
+    cleanup()
+  })
+
+  test('loads projects and agents on mount so detached windows have full data', async () => {
+    render(() => <TaskWindowShell />)
+    // onMount fires synchronously inside render; the awaited Promise.all
+    // resolves on the next microtask tick.
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(loadProjectsMock).toHaveBeenCalledTimes(1)
+    expect(loadAgentsMock).toHaveBeenCalledTimes(1)
+  })
+
+  test('still registers the IPC listeners and loads task data alongside the new hydration', async () => {
+    render(() => <TaskWindowShell />)
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(initListenersMock).toHaveBeenCalledTimes(1)
+    // ctx.projectId is set in the mock, so loadTasks(projectId) runs too.
+    expect(loadTasksMock).toHaveBeenCalledWith('p-001')
+  })
+})

--- a/src/components/TaskWindowShell.tsx
+++ b/src/components/TaskWindowShell.tsx
@@ -6,7 +6,9 @@ import { initListeners, dismissSplash, installContextMenu, initQuitListener, sho
 import { initTheme } from '../lib/theme'
 import { refreshTaskGit } from '../store/git'
 import { loadTasks, taskById } from '../store/tasks'
-import { selectedTaskId, setSelectedTaskId, setSelectedProjectId, addToast } from '../store/ui'
+import { loadProjects } from '../store/projects'
+import { loadAgents } from '../store/agents'
+import { selectedTaskId, setSelectedTaskId, setSelectedProjectId } from '../store/ui'
 import { modPressed } from '../lib/platform'
 import { toggleTerminal, showTerminal, setShowTerminal } from '../store/ui'
 import { spawnTerminal, focusActiveTerminal, terminalsForTask, activeTerminalId, setActiveTerminalForTask, isStartCommandRunning, spawnStartCommand, stopStartCommand } from '../store/terminals'
@@ -48,7 +50,10 @@ export const TaskWindowShell: Component = () => {
     initQuitListener()
     installContextMenu(setSelMenu)
 
-    // Register listeners and load task data in parallel for fast startup
+    // Register listeners and load task data in parallel for fast startup.
+    // Detached windows must hydrate the projects + agents stores too, because
+    // the new-session menu reads from `agents` and the start-command button
+    // reads from `projects[].startCommand`.
     const taskDataPromise = ctx.taskId
       ? ipc.getTask(ctx.taskId).then(async (task) => {
           if (task) {
@@ -60,8 +65,9 @@ export const TaskWindowShell: Component = () => {
       : ctx.projectId
         ? loadTasks(ctx.projectId)
         : Promise.resolve()
+    const storeHydratePromise = Promise.all([loadProjects(), loadAgents()])
 
-    await Promise.all([initListeners(), taskDataPromise])
+    await Promise.all([initListeners(), taskDataPromise, storeHydratePromise])
 
     dismissSplash()
     getCurrentWindow().show()
@@ -70,12 +76,12 @@ export const TaskWindowShell: Component = () => {
   // --- Task lifecycle listeners ---
 
   onMount(() => {
-    // Close window when task is deleted or archived
+    // Close window immediately when task is deleted or archived. The main
+    // window shows the toast (see appInit.ts) so it survives the close.
     const unlistenRemoved = listen<{ taskId: string; reason: string }>('task-removed', (event) => {
       const myTaskId = ctx.taskId || selectedTaskId()
       if (event.payload.taskId === myTaskId) {
-        addToast(event.payload.reason === 'archived' ? 'Task was archived' : 'Task was deleted', 'info')
-        setTimeout(() => getCurrentWindow().close(), 1500)
+        getCurrentWindow().close()
       }
     })
 

--- a/src/lib/appInit.ts
+++ b/src/lib/appInit.ts
@@ -2,7 +2,7 @@ import { createSignal } from 'solid-js'
 import { listen } from '@tauri-apps/api/event'
 import { loadProjects, initProjectListeners } from '../store/projects'
 import { loadAgents, initAgentListeners } from '../store/agents'
-import { initSessionListeners, syncSessionStatuses } from '../store/sessions'
+import { initSessionListeners, initSessionWindowFocusRefresh, syncSessionStatuses } from '../store/sessions'
 import { initTerminalListeners } from '../store/terminals'
 import { initGitListeners, initWindowFocusRefresh } from '../store/git'
 import { initOpenFilesRefresh } from '../store/fileSync'
@@ -45,6 +45,7 @@ export async function initListeners() {
     initAgentListeners(),
   ])
   initWindowFocusRefresh()
+  initSessionWindowFocusRefresh()
   initEnvPathFocusRefresh()
   initOpenFilesRefresh()
   document.addEventListener('visibilitychange', () => {

--- a/src/store/sessions.test.ts
+++ b/src/store/sessions.test.ts
@@ -1,5 +1,29 @@
-import { describe, test, expect, beforeEach } from 'vitest'
-import { sessions, setSessions, outputItems, setOutputItems, sessionsForTask, sessionById } from './sessions'
+import { describe, test, expect, beforeAll, beforeEach, vi } from 'vitest'
+
+// Capture every `listen(eventName, cb)` registration so tests can fire events
+// directly. Mock factory must be self-contained — vi.mock is hoisted above
+// imports, so referencing module-scope symbols is invalid.
+const listenCallbacks = new Map<string, (e: { payload: unknown }) => void>()
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn((event: string, cb: (e: { payload: unknown }) => void) => {
+    listenCallbacks.set(event, cb)
+    return Promise.resolve(() => listenCallbacks.delete(event))
+  }),
+  emit: vi.fn(),
+}))
+
+vi.mock('../lib/ipc', () => ({
+  listSessions: vi.fn().mockResolvedValue([]),
+  listSteps: vi.fn().mockResolvedValue([]),
+  syncSessionStatuses: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('../lib/notifications', () => ({
+  notify: vi.fn(),
+}))
+
+import { sessions, setSessions, outputItems, setOutputItems, sessionsForTask, sessionById, initSessionListeners, initSessionWindowFocusRefresh, loadSessions } from './sessions'
+import * as ipc from '../lib/ipc'
 import type { Session, OutputItem } from '../types'
 
 const makeSession = (overrides: Partial<Session> = {}): Session => ({
@@ -77,5 +101,109 @@ describe('sessions store', () => {
     setSessions([makeSession({ id: 's-1', status: 'running' })])
     setSessions(s => s.id === 's-1', 'status', 'idle')
     expect(sessions[0].status).toBe('idle')
+  })
+})
+
+// Cross-window session sync (issue #143). The Rust side broadcasts
+// `session-created` and `session-removed` whenever a session is created or
+// closed in any window; every other window must apply the change locally so
+// the sidebar's task phase chip stays current without forcing a reload.
+describe('cross-window session listeners', () => {
+  beforeAll(async () => {
+    // initSessionListeners is idempotent (module-scoped guard) — register once
+    // and the captured callbacks survive across every test in this suite.
+    await initSessionListeners()
+  })
+
+  beforeEach(() => {
+    setSessions([])
+    setOutputItems({})
+  })
+
+  test('session-created adds the session to the store', () => {
+    const fire = listenCallbacks.get('session-created')
+    expect(fire).toBeDefined()
+    const s = makeSession({ id: 's-new', taskId: 't-001' })
+    fire!({ payload: s })
+    expect(sessions.length).toBe(1)
+    expect(sessions[0].id).toBe('s-new')
+  })
+
+  test('session-created is idempotent — duplicate events do not double-insert', () => {
+    const fire = listenCallbacks.get('session-created')!
+    const s = makeSession({ id: 's-dup' })
+    fire({ payload: s })
+    fire({ payload: s })
+    expect(sessions.length).toBe(1)
+  })
+
+  test('session-removed deletes the session and its output items', () => {
+    setSessions([makeSession({ id: 's-1' }), makeSession({ id: 's-2' })])
+    setOutputItems('s-1', [{ kind: 'text', text: 'hi' }])
+    const fire = listenCallbacks.get('session-removed')!
+    fire({ payload: { sessionId: 's-1', taskId: 't-001' } })
+    expect(sessions.length).toBe(1)
+    expect(sessions[0].id).toBe('s-2')
+    expect(outputItems['s-1']).toBeUndefined()
+  })
+
+  test('session-removed for an unknown id is a no-op', () => {
+    setSessions([makeSession({ id: 's-1' })])
+    const fire = listenCallbacks.get('session-removed')!
+    fire({ payload: { sessionId: 's-unknown', taskId: 't-001' } })
+    expect(sessions.length).toBe(1)
+  })
+})
+
+// Backstop for #143 — when the window becomes visible, refresh sessions for
+// every task currently in the store so any missed cross-window event heals.
+describe('initSessionWindowFocusRefresh', () => {
+  beforeEach(() => {
+    setSessions([])
+    vi.mocked(ipc.listSessions).mockClear()
+    vi.mocked(ipc.listSessions).mockResolvedValue([])
+    initSessionWindowFocusRefresh()
+  })
+
+  test('refreshes sessions for every distinct task on visibility change', async () => {
+    setSessions([
+      makeSession({ id: 's-1', taskId: 't-001' }),
+      makeSession({ id: 's-2', taskId: 't-002' }),
+      makeSession({ id: 's-3', taskId: 't-001' }),
+    ])
+    Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true })
+    document.dispatchEvent(new Event('visibilitychange'))
+    await Promise.resolve()
+    const calls = vi.mocked(ipc.listSessions).mock.calls.map(c => c[0]).sort()
+    expect(calls).toEqual(['t-001', 't-002'])
+  })
+
+  test('does not refresh while the window is hidden', () => {
+    setSessions([makeSession()])
+    Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true })
+    document.dispatchEvent(new Event('visibilitychange'))
+    expect(vi.mocked(ipc.listSessions)).not.toHaveBeenCalled()
+  })
+})
+
+// Sanity check that the loadSessions helper still merges correctly when
+// the cross-window listeners are also applying writes.
+describe('loadSessions', () => {
+  beforeEach(() => {
+    setSessions([])
+    vi.mocked(ipc.listSessions).mockClear()
+  })
+
+  test('replaces only the target task, leaving other tasks untouched', async () => {
+    setSessions([
+      makeSession({ id: 's-other', taskId: 't-other' }),
+      makeSession({ id: 's-stale', taskId: 't-001' }),
+    ])
+    vi.mocked(ipc.listSessions).mockResolvedValueOnce([
+      makeSession({ id: 's-fresh', taskId: 't-001' }),
+    ])
+    await loadSessions('t-001')
+    const ids = sessions.map(s => s.id).sort()
+    expect(ids).toEqual(['s-fresh', 's-other'])
   })
 })

--- a/src/store/sessions.test.ts
+++ b/src/store/sessions.test.ts
@@ -16,13 +16,14 @@ vi.mock('../lib/ipc', () => ({
   listSessions: vi.fn().mockResolvedValue([]),
   listSteps: vi.fn().mockResolvedValue([]),
   syncSessionStatuses: vi.fn().mockResolvedValue(undefined),
+  createSession: vi.fn(),
 }))
 
 vi.mock('../lib/notifications', () => ({
   notify: vi.fn(),
 }))
 
-import { sessions, setSessions, outputItems, setOutputItems, sessionsForTask, sessionById, initSessionListeners, initSessionWindowFocusRefresh, loadSessions } from './sessions'
+import { sessions, setSessions, outputItems, setOutputItems, sessionsForTask, sessionById, initSessionListeners, initSessionWindowFocusRefresh, loadSessions, createSession } from './sessions'
 import * as ipc from '../lib/ipc'
 import type { Session, OutputItem } from '../types'
 
@@ -205,5 +206,42 @@ describe('loadSessions', () => {
     await loadSessions('t-001')
     const ids = sessions.map(s => s.id).sort()
     expect(ids).toEqual(['s-fresh', 's-other'])
+  })
+})
+
+// Regression — when the source window calls createSession, Rust both returns
+// the session AND broadcasts session-created. If the broadcast lands before the
+// IPC await resolves, the listener pushes first; without dedup the local push
+// duplicates it, doubling the entry in the sessions store (and the tab bar).
+describe('createSession dedup vs cross-window broadcast', () => {
+  beforeAll(async () => {
+    await initSessionListeners()
+  })
+
+  beforeEach(() => {
+    setSessions([])
+    setOutputItems({})
+    vi.mocked(ipc.createSession).mockReset()
+  })
+
+  test('does not double-insert when session-created event fires before IPC resolves', async () => {
+    const s = makeSession({ id: 's-race', taskId: 't-001' })
+    vi.mocked(ipc.createSession).mockImplementation(async () => {
+      // Simulate the broadcast arriving while the IPC is still in-flight
+      const fire = listenCallbacks.get('session-created')!
+      fire({ payload: s })
+      return s
+    })
+    await createSession('t-001', 'claude')
+    expect(sessions.filter(x => x.id === 's-race').length).toBe(1)
+  })
+
+  test('does not double-insert when broadcast arrives after IPC resolves', async () => {
+    const s = makeSession({ id: 's-after', taskId: 't-001' })
+    vi.mocked(ipc.createSession).mockResolvedValue(s)
+    await createSession('t-001', 'claude')
+    // Now the broadcast lands at the source window
+    listenCallbacks.get('session-created')!({ payload: s })
+    expect(sessions.filter(x => x.id === 's-after').length).toBe(1)
   })
 })

--- a/src/store/sessions.ts
+++ b/src/store/sessions.ts
@@ -50,6 +50,20 @@ export function setTaskPlanFilePath(taskId: string, path: string | null) {
   }
 }
 
+/**
+ * Backstop for cross-window session sync: when the window becomes visible,
+ * refresh sessions for every task currently in the store. The session-created
+ * / session-removed events cover the common case, but a missed event (e.g. the
+ * user was on another desktop) would leave the sidebar stale until reload.
+ */
+export function initSessionWindowFocusRefresh(): void {
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState !== 'visible') return
+    const taskIds = Array.from(new Set(sessions.map(s => s.taskId)))
+    for (const tid of taskIds) loadSessions(tid)
+  })
+}
+
 export async function loadSessions(taskId: string) {
   const list = await ipc.listSessions(taskId)
   // Merge — keep sessions from other tasks, replace sessions for this task
@@ -418,6 +432,26 @@ export async function initSessionListeners() {
         sendMessage(next.sessionId, next.message, attachments, next.model ?? undefined, next.planMode ?? undefined, next.thinkingMode ?? undefined, next.fastMode ?? undefined)
       }
     }
+  })
+
+  // Cross-window session lifecycle. New sessions or closes happening in another
+  // window must reflect locally so the sidebar's per-task phase chip stays in
+  // sync without forcing a full reload.
+  await listen<Session>('session-created', (event) => {
+    const s = event.payload
+    if (sessions.some(x => x.id === s.id)) return
+    setSessions(produce(list => { list.push(s) }))
+    if (s.totalCost > 0) setSessionCosts(s.id, s.totalCost)
+  })
+
+  await listen<{ sessionId: string; taskId: string | null }>('session-removed', (event) => {
+    const { sessionId } = event.payload
+    setSessions(prev => prev.filter(s => s.id !== sessionId))
+    setOutputItems(produce(store => { delete store[sessionId] }))
+    setPendingApprovals(produce(store => { delete store[sessionId] }))
+    setSessionCosts(produce(store => { delete store[sessionId] }))
+    setSessionTokens(produce(store => { delete store[sessionId] }))
+    clearSteps(sessionId)
   })
 
   await listen<{ taskId: string; name: string }>('task-name', (event) => {

--- a/src/store/sessions.ts
+++ b/src/store/sessions.ts
@@ -85,7 +85,9 @@ export async function loadSessions(taskId: string) {
 
 export async function createSession(taskId: string, agentType: string, model?: string): Promise<Session> {
   const session = await ipc.createSession(taskId, agentType, model)
-  setSessions(produce(s => s.push(session)))
+  // Dedup vs the session-created broadcast: Rust emits to all windows including
+  // the source, and the broadcast can land before this await resolves.
+  setSessions(produce(s => { if (!s.find(x => x.id === session.id)) s.push(session) }))
   setOutputItems(session.id, [])
   return session
 }

--- a/src/store/tasks.test.ts
+++ b/src/store/tasks.test.ts
@@ -9,6 +9,8 @@ import type { Task, Session } from '../types'
 
 let createTaskResolve: ((v: { task: Task; session: Session }) => void) | null = null
 let listTasksResult: Task[] = []
+let archiveTaskResolve: (() => void) | null = null
+let archiveTaskReject: ((e: Error) => void) | null = null
 
 vi.mock('../lib/ipc', () => ({
   createTask: vi.fn(() => new Promise<{ task: Task; session: Session }>((resolve) => {
@@ -16,12 +18,15 @@ vi.mock('../lib/ipc', () => ({
   })),
   listTasks: vi.fn(() => Promise.resolve(listTasksResult)),
   deleteTask: vi.fn().mockResolvedValue(undefined),
-  archiveTask: vi.fn().mockResolvedValue(undefined),
+  archiveTask: vi.fn(() => new Promise<void>((resolve, reject) => {
+    archiveTaskResolve = resolve
+    archiveTaskReject = reject
+  })),
   restoreTask: vi.fn().mockResolvedValue(undefined),
   renameTask: vi.fn().mockResolvedValue(undefined),
 }))
 
-import { tasks, setTasks, startTaskCreation, loadTasks } from './tasks'
+import { tasks, setTasks, startTaskCreation, loadTasks, archiveTask } from './tasks'
 
 const makeTask = (overrides: Partial<Task> = {}): Task => ({
   id: 'task-real',
@@ -53,6 +58,39 @@ const makeSession = (): Session => ({
   forkedAtMessageUuid: null,
   agentType: 'claude',
   model: null,
+})
+
+describe('archiveTask', () => {
+  beforeEach(() => {
+    setTasks([])
+    archiveTaskResolve = null
+    archiveTaskReject = null
+    vi.clearAllMocks()
+  })
+
+  test('marks the task archived in the store before the IPC resolves (issue #138)', async () => {
+    setTasks([makeTask({ id: 'task-real', archived: false })])
+
+    const promise = archiveTask('task-real')
+    // The IPC has not resolved yet; the optimistic update should already
+    // have flipped the task to archived so the sidebar reflects it instantly.
+    expect(tasks[0].archived).toBe(true)
+
+    archiveTaskResolve!()
+    await promise
+    expect(tasks[0].archived).toBe(true)
+  })
+
+  test('reverts archived flag if the IPC rejects', async () => {
+    setTasks([makeTask({ id: 'task-real', archived: false })])
+
+    const promise = archiveTask('task-real')
+    expect(tasks[0].archived).toBe(true)
+
+    archiveTaskReject!(new Error('boom'))
+    await expect(promise).rejects.toThrow('boom')
+    expect(tasks[0].archived).toBe(false)
+  })
 })
 
 describe('startTaskCreation', () => {

--- a/src/store/tasks.ts
+++ b/src/store/tasks.ts
@@ -191,6 +191,14 @@ export async function deleteTask(id: string, deleteBranch = true, skipDestroyHoo
 
 export async function archiveTask(id: string, skipDestroyHook = false) {
   addArchiving(id)
+  // Optimistic — flip the flag immediately so the sidebar (and any other
+  // window via the task-removed event) reflect the archive before the
+  // destroy hook finishes. Reverted on IPC failure.
+  const prevArchived = tasks.find(t => t.id === id)?.archived ?? false
+  setTasks(t => t.id === id, 'archived', true)
+  import('./ui').then(({ selectedTaskId, setSelectedTaskId }) => {
+    if (selectedTaskId() === id) setSelectedTaskId(null)
+  })
   try {
     stopLspClient(id).catch(() => {})
     closeTerminalsForTask(id)
@@ -202,10 +210,9 @@ export async function archiveTask(id: string, skipDestroyHook = false) {
     dropTaskSkills(id)
     cleanupTaskStorage(id)
     await ipc.archiveTask(id, skipDestroyHook)
-    setTasks(t => t.id === id, 'archived', true)
-    import('./ui').then(({ selectedTaskId, setSelectedTaskId }) => {
-      if (selectedTaskId() === id) setSelectedTaskId(null)
-    })
+  } catch (err) {
+    setTasks(t => t.id === id, 'archived', prevArchived)
+    throw err
   } finally {
     removeArchiving(id)
   }


### PR DESCRIPTION
## Summary

- **#166** - Detached task windows now hydrate `projects` + `agents` stores on mount. Previously the new-session menu showed "No agents installed" and the Start button showed "Set up a start command" even when both were configured.
- **#138** - Archiving a task now closes the detached window instantly. `task-removed` is emitted before the destroy hook; the hook and `last_commit_message` capture run in a background `tokio::spawn`. Frontend also optimistically flips the archived flag before awaiting IPC.
- **#142** - `open_task_window` now calls `unminimize()` + `show()` before `set_focus()`, making Cmd+1..9 reliably bring a minimized or background detached window to front on macOS.
- **#143** - `create_session`, `fork_session_in_task`, and `fork_session_to_new_task` now emit `session-created`; `close_session` emits `session-removed`. Frontend `initSessionListeners` subscribes to both and updates the sessions store cross-window. Added `initSessionWindowFocusRefresh` as a backstop that refreshes sessions for all tasks on `visibilitychange`.

## Tests

11 new tests added (9 frontend, 2 Rust), each verified red before the implementation:

- `sessions.test.ts`: 4 cross-window listener tests (session-created add/dedupe, session-removed cleanup/no-op), 2 visibility refresh tests, 1 loadSessions merge test
- `TaskWindowShell.test.tsx` (new file): 2 hydration tests (projects+agents called on mount, listeners+task data still register)
- `db.rs`: 2 Rust tests for two-phase archive (`SetLastCommitMessage` DB write)

Closes #138
Closes #142
Closes #143
Closes #166