### PR TITLE
fix: pass --strict-mcp-config to Haiku task naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Task naming (Haiku) now runs with `--strict-mcp-config` so large MCP server setups don't bloat context and cause failures
+
 ## 0.8.0 — 2026-04-20
 
 - Make Verun feel like home: a new Appearance settings tab with light, dark, and system mode; theme presets plus a fully custom palette (HSV picker for accent, surface, and foreground); bundled UI and code fonts (Inter, JetBrains Mono, Fira Code, Cascadia Code) on top of any system font; independent UI and code font sizes; Compact / Normal / Comfortable density that scales the whole UI; terminal cursor blink; and reduced motion. The default accent is a mode-tuned teal, and text on accent backgrounds auto-flips between black and white based on perceived luminance so primary buttons stay readable on any color you pick.

--- a/src-tauri/src/task.rs
+++ b/src-tauri/src/task.rs
@@ -1792,6 +1792,19 @@ pub async fn get_session_context_usage(
     }
 }
 
+fn title_generation_args(prompt: &str) -> Vec<String> {
+    vec![
+        "-p".into(),
+        prompt.into(),
+        "--output-format".into(),
+        "text".into(),
+        "--no-session-persistence".into(),
+        "--strict-mcp-config".into(),
+        "--model".into(),
+        "haiku".into(),
+    ]
+}
+
 /// Generate a short title using a standalone Haiku call (fast, doesn't affect session).
 /// Uses the Claude CLI regardless of agent type since title generation is a Verun feature.
 async fn generate_session_title(first_message: &str, worktree_path: &str) -> Option<String> {
@@ -1800,15 +1813,7 @@ async fn generate_session_title(first_message: &str, worktree_path: &str) -> Opt
         first_message.chars().take(300).collect::<String>()
     );
     let output = tokio::process::Command::new(AgentKind::Claude.implementation().cli_binary())
-        .args([
-            "-p",
-            &prompt,
-            "--output-format",
-            "text",
-            "--no-session-persistence",
-            "--model",
-            "haiku",
-        ])
+        .args(title_generation_args(&prompt))
         .env_remove("CLAUDECODE")
         .env("CLAUDE_CODE_ENTRYPOINT", "verun")
         .current_dir(worktree_path)
@@ -2432,5 +2437,23 @@ mod tests {
         let mut result = active_session_ids_for_task(active_ids, &task_b_session_ids);
         result.sort();
         assert_eq!(result, vec!["s3".to_string(), "s4".to_string()]);
+    }
+
+    #[test]
+    fn title_generation_args_disables_mcp() {
+        let args = title_generation_args("do something");
+        assert!(
+            args.iter().any(|a| a == "--strict-mcp-config"),
+            "title generation must pass --strict-mcp-config to avoid MCP context inflation"
+        );
+    }
+
+    #[test]
+    fn title_generation_args_includes_required_flags() {
+        let args = title_generation_args("test prompt");
+        assert!(args.iter().any(|a| a == "-p"));
+        assert!(args.iter().any(|a| a == "test prompt"));
+        assert!(args.iter().any(|a| a == "--no-session-persistence"));
+        assert!(args.iter().any(|a| a == "haiku"));
     }
 }


### PR DESCRIPTION
## Summary

- Haiku task naming invocation now passes `--strict-mcp-config`, which tells the Claude CLI to ignore all configured MCP servers
- Extracts `title_generation_args()` helper to make the CLI args unit-testable
- Adds two tests: one asserting `--strict-mcp-config` is present, one asserting all other required flags are intact

## Why

Users with many MCP servers get context-too-long errors that silently break task naming. Since this is a one-shot prompt with no need for tool access, there's no reason to load any MCP servers.