### PR TITLE
fix: gate libc::kill behind cfg(unix) to fix Windows build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Task naming (Haiku) now runs with `--strict-mcp-config` so large MCP server setups don't bloat context and cause failures
+- Fix Windows build: gate `libc::kill` (SIGTERM) behind `#[cfg(unix)]` - Windows falls through to SIGKILL
 
 ## 0.8.0 — 2026-04-20
 

--- a/src-tauri/src/task.rs
+++ b/src-tauri/src/task.rs
@@ -515,16 +515,20 @@ pub async fn graceful_shutdown(child: &mut Child, stdin: &Arc<TokioMutex<Option<
     }
 
     // 3. SIGTERM. tokio::process::Child only exposes SIGKILL directly; send SIGTERM via libc.
-    if let Some(pid) = child.id() {
-        unsafe {
-            libc::kill(pid as i32, libc::SIGTERM);
-        }
-    }
-    if tokio::time::timeout(Duration::from_secs(5), child.wait())
-        .await
-        .is_ok()
+    //    libc::kill is Unix-only; on Windows we fall through to SIGKILL.
+    #[cfg(unix)]
     {
-        return;
+        if let Some(pid) = child.id() {
+            unsafe {
+                libc::kill(pid as i32, libc::SIGTERM);
+            }
+        }
+        if tokio::time::timeout(Duration::from_secs(5), child.wait())
+            .await
+            .is_ok()
+        {
+            return;
+        }
     }
 
     // 4. SIGKILL as last resort.


### PR DESCRIPTION
## Summary

- `libc::kill` and `libc::SIGTERM` are Unix-only symbols — they don't exist in `libc` on Windows, causing the CI Windows build to fail with `E0425: cannot find function 'kill' in crate 'libc'`
- Wrapped the SIGTERM block in `#[cfg(unix)]` so Windows falls through directly to `SIGKILL`
- No behaviour change on macOS/Linux

## Test plan

- [ ] macOS: graceful shutdown still sends SIGTERM then SIGKILL as before
- [ ] Windows CI build passes (`cargo check` clean)