### PR TITLE
perf: eliminate redundant fetches on task switch (files tree + session output)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Sidebar task switching feels instant: output lines are cached per session after the first load so switching away and back no longer re-fetches and re-parses the full NDJSON transcript; steps now load in parallel with the chat view instead of blocking it; file tree skips the worktree walk when the root is already cached
 - Task naming (Haiku) now runs with `--strict-mcp-config` so large MCP server setups don't bloat context and cause failures
 - Fix Windows build: gate `libc::kill` (SIGTERM) behind `#[cfg(unix)]` - Windows falls through to SIGKILL
 

--- a/src/components/FileTree.tsx
+++ b/src/components/FileTree.tsx
@@ -1,11 +1,11 @@
-import { Component, For, Show, createEffect, on, onCleanup, onMount, createSignal } from 'solid-js'
+import { Component, For, Show, createEffect, on, onCleanup, createSignal } from 'solid-js'
 import { createVirtualizer } from '@tanstack/solid-virtual'
 import { Folder, FolderOpen, ChevronRight, ChevronDown, ExternalLink, RefreshCw, ClipboardCopy, FileText, Tag } from 'lucide-solid'
 import { ContextMenu, type ContextMenuItem } from './ContextMenu'
 import { fileHasErrors, fileHasWarnings, pathHasErrors, pathHasWarnings } from '../store/problems'
 import { getFileIcon } from '../lib/fileIcons'
 import {
-  getDirContents, loadDirectory, invalidateDirectory
+  getDirContents, loadDirectory, loadDirectoryIfMissing, invalidateDirectory
 } from '../store/files'
 import { isExpanded, toggleExpanded, expandDir, collapseDir, openFile, openFilePinned, revealRequest, mainView } from '../store/editorView'
 import { taskById } from '../store/tasks'
@@ -35,12 +35,6 @@ export const FileTree: Component<Props> = (props) => {
   const [contextMenu, setContextMenu] = createSignal<ContextMenuState | null>(null)
   const [selectedIndex, setSelectedIndex] = createSignal(-1)
 
-  // Load root directory on mount
-  onMount(() => {
-    loadDirectory(props.taskId, '')
-    ipc.watchWorktree(props.taskId)
-  })
-
   // Listen for file system changes
   const unlistenPromise = listen<FileTreeChangedEvent>('file-tree-changed', (event) => {
     if (event.payload.taskId === props.taskId) {
@@ -52,9 +46,12 @@ export const FileTree: Component<Props> = (props) => {
     unlistenPromise.then(fn => fn())
   })
 
-  // Reload root when task changes
+  // Load root on first mount and on task change — but skip the IPC when we
+  // already have cached contents. Switching between tasks is the hot path
+  // (1-5s felt delay on big repos) and a worktree WalkBuilder on every visit
+  // is the dominant cost. Watcher keeps the cache fresh after the first load.
   createEffect(on(() => props.taskId, (taskId) => {
-    loadDirectory(taskId, '')
+    loadDirectoryIfMissing(taskId, '')
     ipc.watchWorktree(taskId)
   }))
 

--- a/src/components/TaskPanel.tsx
+++ b/src/components/TaskPanel.tsx
@@ -176,8 +176,11 @@ export const TaskPanel: Component = () => {
   createEffect(on(selectedSessionId, async (sessionId) => {
     if (sessionId) {
       clearSessionUnread(sessionId)
-      await loadOutputLines(sessionId)
-      await loadSteps(sessionId)
+      // Fire these in parallel — the steps list renders reactively, it
+      // doesn't need to block the chat view from painting.
+      const outputs = loadOutputLines(sessionId)
+      loadSteps(sessionId).catch(() => {})
+      await outputs
       // Best-effort pre-warm so the first message on a Claude session doesn't
       // pay the CLI boot cost. No-op for non-persistent agents (Codex, etc).
       // Skip if the session is already running — it has a live process.

--- a/src/store/files.test.ts
+++ b/src/store/files.test.ts
@@ -1,0 +1,36 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('../lib/ipc', () => ({
+  listDirectory: vi.fn().mockResolvedValue([]),
+}))
+
+import { loadDirectory, loadDirectoryIfMissing, clearTaskFileCache, getDirContents } from './files'
+import * as ipc from '../lib/ipc'
+
+describe('loadDirectoryIfMissing', () => {
+  beforeEach(() => {
+    vi.mocked(ipc.listDirectory).mockReset()
+    vi.mocked(ipc.listDirectory).mockResolvedValue([
+      { name: 'src', relativePath: 'src', isDir: true, isSymlink: false, size: null },
+    ])
+  })
+
+  test('loads on first call', async () => {
+    await loadDirectoryIfMissing('t-first', '')
+    expect(vi.mocked(ipc.listDirectory)).toHaveBeenCalledTimes(1)
+    expect(getDirContents('t-first', '')).toBeDefined()
+  })
+
+  test('skips the IPC when contents are already cached', async () => {
+    await loadDirectory('t-hit', '')
+    await loadDirectoryIfMissing('t-hit', '')
+    expect(vi.mocked(ipc.listDirectory)).toHaveBeenCalledTimes(1)
+  })
+
+  test('reloads after clearTaskFileCache invalidates the entry', async () => {
+    await loadDirectory('t-clear', '')
+    clearTaskFileCache('t-clear')
+    await loadDirectoryIfMissing('t-clear', '')
+    expect(vi.mocked(ipc.listDirectory)).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/store/files.ts
+++ b/src/store/files.ts
@@ -40,6 +40,15 @@ export async function loadDirectory(taskId: string, relativePath: string) {
   setDirContents(key, entries)
 }
 
+/** Like loadDirectory, but a no-op when the directory is already in the cache.
+ * Use from task-switch effects where we only need to populate the tree once —
+ * the file watcher keeps it fresh after that via invalidateDirectory.
+ */
+export async function loadDirectoryIfMissing(taskId: string, relativePath: string) {
+  if (dirContents[cacheKey(taskId, relativePath)]) return
+  await loadDirectory(taskId, relativePath)
+}
+
 export function invalidateDirectory(taskId: string, relativePath: string) {
   const key = cacheKey(taskId, relativePath)
   if (dirContents[key]) {

--- a/src/store/sessions.test.ts
+++ b/src/store/sessions.test.ts
@@ -18,13 +18,16 @@ vi.mock('../lib/ipc', () => ({
   listSteps: vi.fn().mockResolvedValue([]),
   syncSessionStatuses: vi.fn().mockResolvedValue(undefined),
   createSession: vi.fn(),
+  getOutputLines: vi.fn().mockResolvedValue([]),
+  clearSession: vi.fn().mockResolvedValue(undefined),
+  closeSession: vi.fn().mockResolvedValue(undefined),
 }))
 
 vi.mock('../lib/notifications', () => ({
   notify: vi.fn(),
 }))
 
-import { sessions, setSessions, outputItems, setOutputItems, sessionsForTask, sessionById, initSessionListeners, initSessionWindowFocusRefresh, loadSessions, createSession, clearSessionContextsForTask } from './sessions'
+import { sessions, setSessions, outputItems, setOutputItems, sessionsForTask, sessionById, initSessionListeners, initSessionWindowFocusRefresh, loadSessions, loadOutputLines, clearOutputItems, closeSession, createSession, clearSessionContextsForTask } from './sessions'
 import * as ipc from '../lib/ipc'
 import { setPlanFilePathForSession, planFilePathForSession, sessionContexts, setSessionContexts } from './sessionContext'
 import type { Session, OutputItem } from '../types'
@@ -232,6 +235,53 @@ describe('loadSessions', () => {
     await loadSessions('t-001')
     const ids = sessions.map(s => s.id).sort()
     expect(ids).toEqual(['s-fresh', 's-other'])
+  })
+})
+
+// Task-switch perf: replaying all output_lines through JSON.parse on every
+// session selection is the dominant cost when switching between tasks. Once
+// we've loaded a session from DB, the live session-output listener keeps the
+// store fresh — re-fetching is pure waste.
+describe('loadOutputLines caching', () => {
+  beforeAll(async () => {
+    await initSessionListeners()
+  })
+
+  beforeEach(() => {
+    setSessions([])
+    setOutputItems({})
+    vi.mocked(ipc.getOutputLines).mockReset()
+    vi.mocked(ipc.getOutputLines).mockResolvedValue([])
+  })
+
+  test('does not re-query the DB for an already-loaded session', async () => {
+    await loadOutputLines('s-cache-hit')
+    await loadOutputLines('s-cache-hit')
+    expect(vi.mocked(ipc.getOutputLines)).toHaveBeenCalledTimes(1)
+  })
+
+  test('still re-queries after clearOutputItems invalidates the cache', async () => {
+    await loadOutputLines('s-clear')
+    await clearOutputItems('s-clear')
+    await loadOutputLines('s-clear')
+    expect(vi.mocked(ipc.getOutputLines)).toHaveBeenCalledTimes(2)
+  })
+
+  test('session-removed invalidates the cache so a re-created session reloads', async () => {
+    setSessions([makeSession({ id: 's-gone' })])
+    await loadOutputLines('s-gone')
+    const fire = listenCallbacks.get('session-removed')!
+    fire({ payload: { sessionId: 's-gone', taskId: 't-001' } })
+    await loadOutputLines('s-gone')
+    expect(vi.mocked(ipc.getOutputLines)).toHaveBeenCalledTimes(2)
+  })
+
+  test('closeSession invalidates the cache', async () => {
+    setSessions([makeSession({ id: 's-close' })])
+    await loadOutputLines('s-close')
+    await closeSession('s-close')
+    await loadOutputLines('s-close')
+    expect(vi.mocked(ipc.getOutputLines)).toHaveBeenCalledTimes(2)
   })
 })
 

--- a/src/store/sessions.ts
+++ b/src/store/sessions.ts
@@ -148,12 +148,22 @@ export async function closeSession(sessionId: string) {
   setSessionCosts(produce(store => { delete store[sessionId] }))
   setSessionTokens(produce(store => { delete store[sessionId] }))
   setAbortingSessions(produce(store => { delete store[sessionId] }))
+  loadedSessionOutputs.delete(sessionId)
   // Persist closure to DB (status = 'closed', filtered from future loads)
   await ipc.closeSession(sessionId)
 }
 
+// Sessions whose output_lines have been pulled from SQLite in this window.
+// Live streaming (session-output events) keeps the in-memory store fresh after
+// the first load, so re-fetching on every task/session switch is pure waste —
+// and it's not cheap: every NDJSON line round-trips through JSON.parse.
+// Invalidated on clearOutputItems, closeSession, session-removed.
+const loadedSessionOutputs = new Set<string>()
+
 export async function loadOutputLines(sessionId: string) {
+  if (loadedSessionOutputs.has(sessionId)) return
   const lines = await ipc.getOutputLines(sessionId)
+  loadedSessionOutputs.add(sessionId)
   const items: OutputItem[] = []
   for (const l of lines) {
     const parsed = parseNdjsonLine(l.line, l.emittedAt)
@@ -225,6 +235,7 @@ function parseNdjsonLine(line: string, emittedAt?: number): OutputItem[] | null 
 
 export async function clearOutputItems(sessionId: string) {
   setOutputItems(sessionId, [])
+  loadedSessionOutputs.delete(sessionId)
   // Also clear the Claude session context + persisted output in DB
   await ipc.clearSession(sessionId)
   setSessions(s => s.id === sessionId, 'resumeSessionId', null)
@@ -417,6 +428,7 @@ export async function initSessionListeners() {
     setPendingApprovals(produce(store => { delete store[sessionId] }))
     setSessionCosts(produce(store => { delete store[sessionId] }))
     setSessionTokens(produce(store => { delete store[sessionId] }))
+    loadedSessionOutputs.delete(sessionId)
     clearSteps(sessionId)
   })
 


### PR DESCRIPTION
## Summary

Task switching was taking 1–5s, especially with the Files tree panel open. Three fetches were re-running on every switch even when the data was already in memory:

- **Session output cache** — `loadOutputLines` was fetching every `output_lines` row from SQLite and JSON-parsing each one on every visit to a session. Added a `loadedSessionOutputs` Set; subsequent visits return immediately. Invalidated on `clearOutputItems`, `closeSession`, and the `session-removed` event.
- **Parallel steps load** — `loadSteps` was awaited in series behind `loadOutputLines`, blocking the chat view. Now fires in parallel.
- **File tree root cache** — `FileTree` called `loadDirectory` (worktree WalkBuilder) on every `taskId` change, even for tasks whose root was already populated. New `loadDirectoryIfMissing` helper skips the IPC when the store already has contents. Also removed the duplicate `onMount` call that fired on first render alongside the effect.

First switch into a task still pays the full cost; every subsequent switch is near-instant for all three.

## Test plan

- [x] `make check` passes (201 tests, zero clippy warnings)
- [ ] Switch between two tasks with Files tree visible — second visit is instant
- [ ] Switch between tasks in different projects — no perceptible delay after first visit
- [ ] Clear session output (via session context menu) — next switch re-fetches correctly
- [ ] Close a session tab — re-opening loads fresh from DB

Closes #99
Related to #112