### PR TITLE
fix: spurious "No coding agent CLIs found" toast on macOS cold launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fix terminals vanishing when opening a task in a detached window: Rust now keeps a per-PTY 256KB ring buffer and exposes `pty_list_for_task`, so a new window discovers existing PTYs, replays scrollback into xterm (TUIs like vim and Claude Code redraw correctly), and dedupes live events against the snapshot by seq number
 - Terminal panel open/closed state now persists per task, so a detached window inherits the same visibility the main window had
 - Closing a detached task window re-syncs the main window's terminal list against Rust, so PTYs spawned or closed in the other window reappear / disappear correctly when the task comes back
+- Fix "No coding agent CLIs found" toast firing at startup on macOS when agents are installed in nvm/homebrew/~/.local/bin: PATH reload now completes before agent detection runs (was racing in parallel threads, so detection often saw the stripped GUI PATH)
 
 ## 0.8.1 — 2026-04-20
 

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -1936,6 +1936,29 @@ pub fn new_agent_cache() -> AgentCache {
     std::sync::Arc::new(std::sync::RwLock::new(Vec::new()))
 }
 
+/// Reload the user's shell PATH, then detect installed agents and store
+/// the result in the cache. The ordering is load-bearing: GUI-launched
+/// apps on macOS start with a stripped PATH, so running detection first
+/// would mark agents installed in nvm/homebrew/~/.local/bin as missing.
+pub async fn init_agents_cache<R, D>(
+    cache: AgentCache,
+    reload_path: R,
+    detect: D,
+) -> Vec<AgentInfo>
+where
+    R: FnOnce() + Send + 'static,
+    D: FnOnce() -> Vec<AgentInfo> + Send + 'static,
+{
+    let agents = tokio::task::spawn_blocking(move || {
+        reload_path();
+        detect()
+    })
+    .await
+    .unwrap_or_default();
+    *cache.write().unwrap() = agents.clone();
+    agents
+}
+
 /// Blocking detection of all agents — run via spawn_blocking at startup.
 pub fn detect_all_agents() -> Vec<AgentInfo> {
     crate::agent::AgentKind::all()
@@ -1997,10 +2020,8 @@ pub async fn refresh_agents(
 ) -> Result<(), String> {
     let cache = std::sync::Arc::clone(&*cache);
     tauri::async_runtime::spawn(async move {
-        let agents = tokio::task::spawn_blocking(detect_all_agents)
-            .await
-            .unwrap_or_default();
-        *cache.write().unwrap() = agents.clone();
+        let agents =
+            init_agents_cache(cache, crate::env_path::reload_now, detect_all_agents).await;
         let _ = app.emit("agents-updated", agents);
     });
     Ok(())
@@ -2772,5 +2793,70 @@ mod tests {
         assert!(!entry.is_dir);
         assert!(!entry.is_symlink);
         assert_eq!(entry.size, Some(2));
+    }
+
+    /// Regression: GUI-launched apps on macOS inherit a stripped PATH.
+    /// If agent detection ran before env_path::reload_now finished, every
+    /// installed agent looked missing and the startup toast lied. Ordering
+    /// must be: reload PATH, then detect.
+    #[tokio::test]
+    async fn init_agents_cache_reloads_path_before_detecting() {
+        use std::sync::{Arc, Mutex};
+
+        let order: Arc<Mutex<Vec<&'static str>>> = Arc::new(Mutex::new(Vec::new()));
+        let o_reload = Arc::clone(&order);
+        let o_detect = Arc::clone(&order);
+
+        let cache = new_agent_cache();
+
+        init_agents_cache(
+            Arc::clone(&cache),
+            move || {
+                o_reload.lock().unwrap().push("reload");
+            },
+            move || {
+                o_detect.lock().unwrap().push("detect");
+                Vec::new()
+            },
+        )
+        .await;
+
+        assert_eq!(
+            *order.lock().unwrap(),
+            vec!["reload", "detect"],
+            "PATH reload must complete before agent detection runs"
+        );
+    }
+
+    #[tokio::test]
+    async fn init_agents_cache_stores_detected_agents() {
+        use std::sync::Arc;
+        let cache = new_agent_cache();
+        let sample = vec![AgentInfo {
+            id: "claude".into(),
+            name: "Claude".into(),
+            install_hint: "".into(),
+            update_hint: "".into(),
+            docs_url: "".into(),
+            models: Vec::new(),
+            installed: true,
+            cli_version: Some("1.0.0".into()),
+            supports_streaming: true,
+            supports_resume: true,
+            supports_plan_mode: true,
+            supports_model_selection: true,
+            supports_effort: false,
+            supports_skills: false,
+            supports_attachments: true,
+            supports_fork: true,
+        }];
+        let sample_clone = sample.clone();
+
+        let returned =
+            init_agents_cache(Arc::clone(&cache), || {}, move || sample_clone.clone()).await;
+
+        assert_eq!(returned.len(), 1);
+        assert_eq!(cache.read().unwrap().len(), 1);
+        assert_eq!(cache.read().unwrap()[0].id, "claude");
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -56,26 +56,25 @@ pub fn run() {
         .manage(file_search::new_search_map())
         .manage(WindowTaskMap::new())
         .setup(|app| {
-            // Capture the user's full PATH from their interactive shell so
-            // children (agents, lsp, git, gh, ...) inherit nvm/homebrew/etc.
-            // Then start the background watcher that re-captures whenever
-            // the integrated terminal looks idle after a user command.
-            std::thread::spawn(|| {
-                env_path::reload_now();
-                env_path::start_idle_watcher();
-            });
-
-            // Detect installed agents in the background so list_available_agents
-            // returns instantly once the cache is warm.
+            // Capture the user's full PATH from their interactive shell and
+            // detect installed agents. Ordering matters: GUI apps on macOS
+            // inherit a stripped PATH, so agent detection must run *after*
+            // reload_now or every installed agent looks missing.
             let agent_detect_handle = app.handle().clone();
             let agent_cache = std::sync::Arc::clone(&*app.state::<ipc::AgentCache>());
             tauri::async_runtime::spawn(async move {
-                let agents = tokio::task::spawn_blocking(ipc::detect_all_agents)
-                    .await
-                    .unwrap_or_default();
-                *agent_cache.write().unwrap() = agents.clone();
+                let agents = ipc::init_agents_cache(
+                    agent_cache,
+                    env_path::reload_now,
+                    ipc::detect_all_agents,
+                )
+                .await;
                 let _ = agent_detect_handle.emit("agents-updated", agents);
             });
+
+            // Re-capture PATH when the user commits a command in the integrated
+            // terminal (e.g. installs a new node/agent) and the PTY goes idle.
+            std::thread::spawn(env_path::start_idle_watcher);
 
             // Menu setup
             #[cfg(target_os = "macos")]


### PR DESCRIPTION
## Problem

On macOS, GUI-launched apps (Finder, Launchpad, login items) inherit a stripped `launchd` PATH that excludes `/opt/homebrew/bin`, `~/.local/bin`, `~/.nvm/versions/*/bin`, etc. At startup, `env_path::reload_now` (which sources the user's shell to capture the real PATH) and `detect_all_agents` were spawned into **separate concurrent threads with no ordering guarantee**. Detection would routinely win the race, find none of the agent CLIs, populate the cache with all-uninstalled, and fire the toast — even when every agent was properly installed.

Dev mode was unaffected because `pnpm tauri dev` launches from a terminal that already has the full shell PATH.

## Fix

Introduce `init_agents_cache(cache, reload_path, detect)` — a single `spawn_blocking` task that calls `reload_path` then `detect` sequentially. Startup and `refresh_agents` both route through it, guaranteeing the shell PATH is captured before any CLI lookups run.

`start_idle_watcher` (which re-captures PATH after integrated-terminal commands) is unchanged and still runs on its own thread.

## Tests

Two new `#[tokio::test]` cases in `ipc::tests`:

- `init_agents_cache_reloads_path_before_detecting` — uses an ordered log to assert reload runs before detect
- `init_agents_cache_stores_detected_agents` — verifies the cache is populated and the return value matches