### PR TITLE
feat: apply trust level changes to in-flight sessions immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Trust level changes apply mid-run: editing the policy during an in-flight turn now takes effect on the next tool-approval check instead of waiting for the next send_message
 - Task switching stays responsive across large workspaces by virtualizing diagnostics and source-control lists, caching chat block rebuilds, and avoiding repeated full-list scans in the file tree, tabs, and sidebar
 - `+` menu now surfaces closed sessions for the task under a "Recent" section - click one to restore it as a tab with full transcript replay; `+` button sticks to the left edge while the tab bar scrolls horizontally (#100)
 

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -959,6 +959,7 @@ pub async fn get_output_lines(
 #[tauri::command]
 pub async fn set_trust_level(
     db_tx: State<'_, DbWriteTx>,
+    active: State<'_, ActiveMap>,
     task_id: String,
     trust_level: String,
 ) -> Result<(), String> {
@@ -969,6 +970,18 @@ pub async fn set_trust_level(
             return Err(format!(
                 "Invalid trust level: {trust_level}. Must be normal, full_auto, or supervised"
             ))
+        }
+    }
+
+    // Push into live sessions so in-flight turns see the new value on the
+    // next tool-approval check — no need to wait for the next send_message.
+    let parsed = crate::policy::TrustLevel::from_str(&trust_level);
+    for entry in active.iter() {
+        if entry.value().task_id == task_id {
+            entry
+                .value()
+                .trust_level
+                .store(parsed.to_u8(), std::sync::atomic::Ordering::Relaxed);
         }
     }
 

--- a/src-tauri/src/policy.rs
+++ b/src-tauri/src/policy.rs
@@ -1,5 +1,6 @@
 use serde::Serialize;
 use std::path::Path;
+use std::sync::atomic::{AtomicU8, Ordering};
 
 // ---------------------------------------------------------------------------
 // Types
@@ -33,6 +34,26 @@ impl TrustLevel {
             Self::FullAuto => "full_auto",
             Self::Supervised => "supervised",
         }
+    }
+
+    pub fn to_u8(self) -> u8 {
+        match self {
+            Self::Normal => 0,
+            Self::FullAuto => 1,
+            Self::Supervised => 2,
+        }
+    }
+
+    pub fn from_u8(v: u8) -> Self {
+        match v {
+            1 => Self::FullAuto,
+            2 => Self::Supervised,
+            _ => Self::Normal,
+        }
+    }
+
+    pub fn from_atomic(atom: &AtomicU8) -> Self {
+        Self::from_u8(atom.load(Ordering::Relaxed))
     }
 }
 
@@ -1029,6 +1050,36 @@ mod tests {
         assert_eq!(TrustLevel::from_str("full_auto").as_str(), "full_auto");
         assert_eq!(TrustLevel::from_str("supervised").as_str(), "supervised");
         assert_eq!(TrustLevel::from_str("garbage").as_str(), "normal");
+    }
+
+    // -- TrustLevel <-> u8 for atomic sharing --
+
+    #[test]
+    fn trust_level_u8_roundtrip() {
+        for lvl in [
+            TrustLevel::Normal,
+            TrustLevel::FullAuto,
+            TrustLevel::Supervised,
+        ] {
+            assert_eq!(TrustLevel::from_u8(lvl.to_u8()), lvl);
+        }
+    }
+
+    #[test]
+    fn trust_level_unknown_u8_defaults_to_normal() {
+        assert_eq!(TrustLevel::from_u8(99), TrustLevel::Normal);
+        assert_eq!(TrustLevel::from_u8(u8::MAX), TrustLevel::Normal);
+    }
+
+    #[test]
+    fn trust_level_atomic_load_reflects_latest_store() {
+        use std::sync::atomic::{AtomicU8, Ordering};
+        let atom = AtomicU8::new(TrustLevel::Normal.to_u8());
+        assert_eq!(TrustLevel::from_atomic(&atom), TrustLevel::Normal);
+        atom.store(TrustLevel::FullAuto.to_u8(), Ordering::SeqCst);
+        assert_eq!(TrustLevel::from_atomic(&atom), TrustLevel::FullAuto);
+        atom.store(TrustLevel::Supervised.to_u8(), Ordering::SeqCst);
+        assert_eq!(TrustLevel::from_atomic(&atom), TrustLevel::Supervised);
     }
 
     // -- Input summarization --

--- a/src-tauri/src/stream.rs
+++ b/src-tauri/src/stream.rs
@@ -8,7 +8,7 @@ use crate::task::{
 };
 use serde::Serialize;
 use std::path::Path;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter};
@@ -1088,7 +1088,7 @@ pub async fn stream_and_capture(
     db_tx: DbWriteTx,
     worktree_path: String,
     repo_path: String,
-    trust_level: TrustLevel,
+    trust_level: Arc<AtomicU8>,
     agent: Box<dyn crate::agent::Agent>,
 ) -> StreamResult {
     let mut reader = BufReader::new(stdout).lines();
@@ -1169,7 +1169,7 @@ pub async fn stream_and_capture(
                             &app, &session_id, &task_id, &v, &stdin,
                             &pending_approvals, &pending_approval_meta,
                             &worktree_path, &repo_path,
-                            trust_level, &db_tx,
+                            &trust_level, &db_tx,
                         ).await {
                             if cr.handled {
                                 if let Some(tool_start) = cr.tool_start {
@@ -1364,7 +1364,7 @@ async fn handle_control_request(
     pending_meta: &PendingApprovalMeta,
     worktree_path: &str,
     repo_path: &str,
-    trust_level: TrustLevel,
+    trust_level: &Arc<AtomicU8>,
     db_tx: &DbWriteTx,
 ) -> Option<ControlRequestResult> {
     if v.get("type").and_then(|t| t.as_str()) != Some("control_request") {
@@ -1410,13 +1410,13 @@ async fn handle_control_request(
         input: input_str,
     };
 
-    // Evaluate policy
+    // Evaluate policy — load trust level fresh so mid-run IPC edits apply.
     let result = policy::evaluate(
         &tool_name,
         &tool_input,
         worktree_path,
         repo_path,
-        trust_level,
+        TrustLevel::from_atomic(trust_level),
     );
     let input_summary = policy::summarize_input(&tool_name, &tool_input);
 

--- a/src-tauri/src/task.rs
+++ b/src-tauri/src/task.rs
@@ -6,7 +6,7 @@ use crate::worktree;
 use dashmap::DashMap;
 use serde::Deserialize;
 use sqlx::SqlitePool;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager};
@@ -177,6 +177,9 @@ pub fn generate_branch_name(repo_path: &str) -> String {
 
 pub struct ActiveProcess {
     pub child: Child,
+    /// Task this session belongs to. Lets `set_trust_level` find the right
+    /// active processes to notify without a DB roundtrip.
+    pub task_id: String,
     /// Kept alive so `stream_and_capture` can write control_response messages via the Arc clone.
     /// For persistent agents this stays Some across turns; for one-shot agents it's
     /// `take()`n on `turn_end` to close the fd and let the process exit.
@@ -185,6 +188,10 @@ pub struct ActiveProcess {
     /// flips this to false on `turn_end` so the next `send_message` can take
     /// the fast path instead of erroring as "already processing".
     pub busy: Arc<AtomicBool>,
+    /// Live trust level for this task. Shared with the stream loop so policy
+    /// evaluation re-reads it on every tool call — IPC edits mid-run take
+    /// effect on the next `can_use_tool` check instead of the next spawn.
+    pub trust_level: Arc<AtomicU8>,
     /// Which agent owns this process. Lets `abort_message` /
     /// `close_session` / app-exit dispatch on the trait without a DB read.
     pub kind: AgentKind,
@@ -1440,12 +1447,15 @@ pub async fn spawn_session_process(
 
     // Track the active process
     let kind = AgentKind::parse(&agent_type);
+    let trust_level_atom = Arc::new(AtomicU8::new(trust_level.to_u8()));
     active.insert(
         session_id.clone(),
         ActiveProcess {
             child,
+            task_id: task_id.clone(),
             stdin: stdin.clone(),
             busy: busy.clone(),
+            trust_level: trust_level_atom.clone(),
             kind,
             current_permission_mode: if plan_mode { "plan" } else { "default" }.to_string(),
             current_model: model.clone(),
@@ -1466,7 +1476,7 @@ pub async fn spawn_session_process(
     let monitor_pending_ctrl = pending_control_responses.clone();
     let monitor_wt = worktree_path.clone();
     let monitor_repo = repo_path;
-    let monitor_trust = trust_level;
+    let monitor_trust = trust_level_atom.clone();
     let monitor_agent = AgentKind::parse(&agent_type).implementation();
     let monitor_busy = busy.clone();
     tokio::spawn(async move {


### PR DESCRIPTION
## Summary

- `ActiveProcess` now carries a `task_id` field and a shared `Arc<AtomicU8>` for the trust level
- `stream_and_capture` / `handle_control_request` accept the atomic and call `TrustLevel::from_atomic` on every tool-approval check
- `set_trust_level` IPC iterates active processes for the target task and stores the new level atomically — no need to wait for the next `send_message`

## Test plan

- [ ] 3 new unit tests in `policy.rs` cover u8 roundtrip, unknown-value fallback, and live atomic load/store
- [ ] `make check` passes (22 test files, 206 tests, zero clippy warnings)
- [ ] Manual: flip policy mid-turn (e.g. Normal → Full Auto) and confirm the very next Bash approval is auto-approved without restarting the session