### PR TITLE
fix: notification click navigation and Notification Center clearing

### DIFF
--- a/.verun.json
+++ b/.verun.json
@@ -3,5 +3,5 @@
     "setup": "pnpm install --frozen-lockfile",
     "destroy": "rm -rf node_modules src-tauri/target"
   },
-  "startCommand": "TASK_ID=$(basename \"$PWD\") && VITE_PORT=$VERUN_PORT_0 VITE_HMR_PORT=$VERUN_PORT_1 pnpm tauri dev --config src-tauri/tauri.dev.conf.json --config '{\"productName\":\"Verun ('\"$TASK_ID\"')\",\"identifier\":\"com.softwaresavants.verun.dev.'\"$TASK_ID\"'\",\"build\":{\"devUrl\":\"http://localhost:'\"$VERUN_PORT_0\"'\"}}'"
+  "startCommand": "TASK_ID=$(basename \"$PWD\") && VITE_PORT=$VERUN_PORT_0 VITE_HMR_PORT=$VERUN_PORT_1 pnpm tauri dev --config src-tauri/tauri.dev.conf.json --features dev-notifications --config '{\"productName\":\"Verun ('\"$TASK_ID\"')\",\"identifier\":\"com.softwaresavants.verun.dev.'\"$TASK_ID\"'\",\"build\":{\"devUrl\":\"http://localhost:'\"$VERUN_PORT_0\"'\"}}'"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ src/components/— UI components
 
 ## Commands
 
-pnpm tauri dev --config src-tauri/tauri.dev.conf.json   # run dev (separate bundle id + app data dir from release)
+pnpm tauri dev --config src-tauri/tauri.dev.conf.json --features dev-notifications   # run dev (separate bundle id + app data dir; --features enables notify-rust fallback since dev is unbundled)
 pnpm tauri build        # production build
 pnpm check              # typecheck frontend
 cargo check             # check Rust

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Task switching stays responsive across large workspaces by virtualizing diagnostics and source-control lists, caching chat block rebuilds, and avoiding repeated full-list scans in the file tree, tabs, and sidebar
 - `+` menu now surfaces closed sessions for the task under a "Recent" section - click one to restore it as a tab with full transcript replay; `+` button sticks to the left edge while the tab bar scrolls horizontally (#100)
 - File tree treats symlinked directories as directories so they expand on click instead of appearing as dead entries (broken symlinks stay non-expandable)
+- Notifications: clicking a banner now navigates to the source task/session, and the Notification Center is cleared when the app regains focus - dropped the `notify-rust` fallback so the native macOS `UNUserNotificationCenter` backend is used in release builds (dev builds no longer emit notifications, which matches expectations - they previously appeared as Terminal.app and swallowed click data anyway)
 
 ## 0.8.1 — 2026-04-20
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: dev build check test test-rust test-frontend lint setup clean
 
 dev:
-	pnpm tauri dev --config src-tauri/tauri.dev.conf.json
+	pnpm tauri dev --config src-tauri/tauri.dev.conf.json --features dev-notifications
 
 build:
 	pnpm tauri build

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2947,9 +2947,9 @@ dependencies = [
 
 [[package]]
 name = "notify-rust"
-version = "4.15.0"
+version = "4.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c8146c105ae33d744e2d645f684d063b01176a99daf5986556266777b428816"
+checksum = "5e551a9f0db223eaf3eb156906f99f46897fd951ee66dd1cb0be14db4d36d2fa"
 dependencies = [
  "futures-lite",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,7 +19,7 @@ tauri-plugin-shell = "2"
 tauri-plugin-sql = { version = "2", features = ["sqlite"] }
 tauri-plugin-fs = "2"
 tauri-plugin-dialog = "2"
-tauri-plugin-notifications = { version = "0.4", default-features = false, features = ["notify-rust"] }
+tauri-plugin-notifications = { version = "0.4", default-features = false }
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
 tokio = { version = "1", features = ["full"] }
@@ -42,6 +42,14 @@ yash-syntax = "0.19"
 rstest = "0.18"
 insta = { version = "1", features = ["json", "toml"] }
 tempfile = "3"
+
+# Dev builds run unbundled, so the native macOS notifications backend can't
+# initialize (UNUserNotificationCenter requires a .app). Enable this feature
+# via `pnpm tauri dev` / `make dev`, which pulls in the notify-rust fallback.
+# Release builds omit it and get the native backend with click routing +
+# Notification Center clearing.
+[features]
+dev-notifications = ["tauri-plugin-notifications/notify-rust"]
 
 [profile.dev]
 opt-level = 0

--- a/src/lib/notifications.test.ts
+++ b/src/lib/notifications.test.ts
@@ -1,0 +1,76 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+
+const pluginSend = vi.fn().mockResolvedValue(undefined)
+const removeAllActive = vi.fn().mockResolvedValue(undefined)
+const isPermissionGranted = vi.fn().mockResolvedValue(true)
+const requestPermission = vi.fn().mockResolvedValue('granted')
+
+vi.mock('@choochmeque/tauri-plugin-notifications-api', () => ({
+  sendNotification: (...args: unknown[]) => pluginSend(...args),
+  removeAllActive: () => removeAllActive(),
+  isPermissionGranted: () => isPermissionGranted(),
+  requestPermission: () => requestPermission(),
+  onNotificationClicked: vi.fn(),
+}))
+
+vi.mock('../store/ui', () => ({
+  selectedTaskId: vi.fn(() => null),
+  addToast: vi.fn(),
+  dismissToast: vi.fn(),
+}))
+
+import { notify, consumePendingNav, clearDeliveredNotifications } from './notifications'
+
+describe('notifications JS flow', () => {
+  let now = 1_000_000
+  beforeEach(() => {
+    pluginSend.mockClear()
+    removeAllActive.mockClear()
+    // Jump well past the 1s throttle between tests
+    now += 60_000
+    vi.spyOn(Date, 'now').mockReturnValue(now)
+  })
+
+  test('notify passes numeric id to the plugin and stores nav data', async () => {
+    await notify({ title: 'T', body: 'B', taskId: 't-A', sessionId: 's-A' })
+    expect(pluginSend).toHaveBeenCalledTimes(1)
+    const call = pluginSend.mock.calls[0][0] as { id: number; title: string; body: string; autoCancel: boolean }
+    expect(typeof call.id).toBe('number')
+    expect(call.title).toBe('T')
+    expect(call.body).toBe('B')
+    expect(call.autoCancel).toBe(true)
+
+    expect(consumePendingNav(call.id)).toEqual({ taskId: 't-A', sessionId: 's-A' })
+  })
+
+  test('consumePendingNav removes the entry so a second read returns undefined', async () => {
+    await notify({ title: 'T', body: 'B', taskId: 't-B', sessionId: 's-B' })
+    const { id } = pluginSend.mock.calls[0][0] as { id: number }
+    expect(consumePendingNav(id)).toEqual({ taskId: 't-B', sessionId: 's-B' })
+    expect(consumePendingNav(id)).toBeUndefined()
+  })
+
+  test('consumePendingNav returns undefined for unknown ids', () => {
+    expect(consumePendingNav(999_999)).toBeUndefined()
+  })
+
+  test('clearDeliveredNotifications calls the plugin removeAllActive', () => {
+    clearDeliveredNotifications()
+    expect(removeAllActive).toHaveBeenCalledTimes(1)
+  })
+
+  test('clearDeliveredNotifications swallows plugin errors', () => {
+    removeAllActive.mockRejectedValueOnce(new Error('plugin unavailable'))
+    expect(() => clearDeliveredNotifications()).not.toThrow()
+  })
+
+  test('nav entry is dropped when the plugin send throws', async () => {
+    pluginSend.mockRejectedValueOnce(new Error('not bundled'))
+    const before = consumePendingNav(123_456)
+    expect(before).toBeUndefined()
+    await notify({ title: 'T', body: 'B', taskId: 't-C', sessionId: 's-C' })
+    // No successful send means no id was returned to the caller; verify the
+    // map wasn't left with a stale entry by sweeping a range of plausible ids.
+    for (let i = 1; i < 50; i++) expect(consumePendingNav(i)).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

- Clicking a notification now navigates to the source task and session (previously the app just came to foreground with no further action)
- Notifications are cleared from macOS Notification Center when the app gains focus (previously they accumulated indefinitely)
- Root cause: the `notify-rust` Cargo feature selected a fallback backend whose click listener and `removeAllActive` are no-ops — the notification id was also dropped, breaking the JS nav map lookup

## How

Switches `tauri-plugin-notifications` to the native `UNUserNotificationCenter` backend in release builds by removing the `notify-rust` feature. Since dev builds run unbundled (no `.app`), the native backend panics on init. A new local Cargo feature `dev-notifications` re-enables the fallback only for dev — `make dev`, `.verun.json` startCommand, and `CLAUDE.md` all pass `--features dev-notifications`.

## Test plan

- [ ] `pnpm test` — 6 new unit tests in `src/lib/notifications.test.ts` lock in the JS nav roundtrip (`notify` → `pendingNavMap` → `consumePendingNav`) and `clearDeliveredNotifications` calling `removeAllActive`
- [ ] `cargo check --features dev-notifications` (dev path) and `cargo check` (release path) both compile clean
- [ ] In a release build: trigger a notification, click it — app opens and navigates to the correct task/session
- [ ] In a release build: let notifications accumulate, switch to another app, return to Verun — Notification Center clears on focus
- [ ] `make dev` still launches without panicking