### PR TITLE
fix: terminals survive opening a task in a detached window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - `+` menu now surfaces closed sessions for the task under a "Recent" section - click one to restore it as a tab with full transcript replay; `+` button sticks to the left edge while the tab bar scrolls horizontally (#100)
 - File tree treats symlinked directories as directories so they expand on click instead of appearing as dead entries (broken symlinks stay non-expandable)
 - Notifications: clicking a banner now navigates to the source task/session, and the Notification Center is cleared when the app regains focus - dropped the `notify-rust` fallback so the native macOS `UNUserNotificationCenter` backend is used in release builds (dev builds no longer emit notifications, which matches expectations - they previously appeared as Terminal.app and swallowed click data anyway)
+- Fix terminals vanishing when opening a task in a detached window: Rust now keeps a per-PTY 256KB ring buffer and exposes `pty_list_for_task`, so a new window discovers existing PTYs, replays scrollback into xterm (TUIs like vim and Claude Code redraw correctly), and dedupes live events against the snapshot by seq number
+- Terminal panel open/closed state now persists per task, so a detached window inherits the same visibility the main window had
+- Closing a detached task window re-syncs the main window's terminal list against Rust, so PTYs spawned or closed in the other window reappear / disappear correctly when the task comes back
 
 ## 0.8.1 — 2026-04-20
 

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -1659,6 +1659,7 @@ pub async fn pty_spawn(
     cols: u16,
     initial_command: Option<String>,
     direct_command: Option<bool>,
+    is_start_command: Option<bool>,
 ) -> Result<pty::SpawnResult, String> {
     let t = db::get_task(pool.inner(), &task_id)
         .await?
@@ -1668,6 +1669,14 @@ pub async fn pty_spawn(
     let env_vars = worktree::verun_env_vars(t.port_offset, &repo_path);
     let map = pty_map.inner().clone();
     let direct = direct_command.unwrap_or(false);
+    // Frontend sends is_start_command explicitly when spawning the project start
+    // command. Fall back to `direct` for older callers that conflated the two.
+    let start_cmd = is_start_command.unwrap_or(direct);
+    let name_override = if start_cmd {
+        Some("Dev Server".to_string())
+    } else {
+        None
+    };
     flatten_join(
         tokio::task::spawn_blocking(move || {
             pty::spawn_pty(
@@ -1680,6 +1689,9 @@ pub async fn pty_spawn(
                 initial_command,
                 env_vars,
                 direct,
+                name_override,
+                start_cmd,
+                None,
             )
         })
         .await,
@@ -1719,6 +1731,19 @@ pub async fn pty_close(
 ) -> Result<(), String> {
     let map = pty_map.inner().clone();
     flatten_join(tokio::task::spawn_blocking(move || pty::close_pty(&map, &terminal_id)).await)
+}
+
+/// Return all PTYs currently alive for a task, along with their replay buffers.
+/// Called by a freshly-opened task window to hydrate its local terminal store
+/// so the user sees existing shells (and their scrollback) instead of a new one
+/// being spawned.
+#[tauri::command]
+pub async fn pty_list_for_task(
+    pty_map: State<'_, ActivePtyMap>,
+    task_id: String,
+) -> Result<Vec<pty::PtyListEntry>, String> {
+    let map = pty_map.inner().clone();
+    flatten_join(tokio::task::spawn_blocking(move || Ok(pty::list_for_task(&map, &task_id))).await)
 }
 
 // ---------------------------------------------------------------------------

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -312,6 +312,7 @@ pub fn run() {
             ipc::pty_write,
             ipc::pty_resize,
             ipc::pty_close,
+            ipc::pty_list_for_task,
             // Clipboard
             ipc::read_clipboard,
             ipc::copy_image_to_clipboard,

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -2,20 +2,83 @@ use crate::env_path;
 use dashmap::DashMap;
 use portable_pty::{native_pty_system, CommandBuilder, PtySize};
 use serde::Serialize;
+use std::collections::VecDeque;
 use std::io::{Read, Write};
 use std::sync::{Arc, Mutex};
 use tauri::{AppHandle, Emitter};
 use uuid::Uuid;
 
+/// Maximum bytes of raw PTY output retained per terminal for scrollback replay
+/// on attach (e.g. when a task is opened in a new window). 256 KB holds ~2500
+/// lines of typical text at 100 chars/line - more than enough for a typical
+/// terminal viewport.
+pub const REPLAY_BUFFER_CAP: usize = 256 * 1024;
+
 // ---------------------------------------------------------------------------
 // PTY handle & map
 // ---------------------------------------------------------------------------
 
+/// Bounded chunk-keyed ring buffer of raw PTY output. Chunks are preserved
+/// whole (never split in the middle of a multibyte char) so `snapshot` always
+/// returns valid UTF-8. The newest chunk is never evicted, so a single chunk
+/// larger than `cap` is still surfaced on snapshot.
+pub struct PtyBuffer {
+    chunks: VecDeque<String>,
+    byte_len: usize,
+    cap: usize,
+    /// Monotonically increasing count of total bytes ever written, regardless
+    /// of what's still in the buffer. Used as a sequence number so clients can
+    /// dedupe live events against a snapshot.
+    total_written: u64,
+}
+
+impl PtyBuffer {
+    pub fn new(cap: usize) -> Self {
+        Self {
+            chunks: VecDeque::new(),
+            byte_len: 0,
+            cap,
+            total_written: 0,
+        }
+    }
+
+    pub fn append(&mut self, chunk: &str) {
+        self.total_written = self.total_written.saturating_add(chunk.len() as u64);
+        self.byte_len += chunk.len();
+        self.chunks.push_back(chunk.to_string());
+        while self.byte_len > self.cap && self.chunks.len() > 1 {
+            if let Some(front) = self.chunks.pop_front() {
+                self.byte_len -= front.len();
+            }
+        }
+    }
+
+    /// Returns (concatenated contents, total bytes ever written).
+    pub fn snapshot(&self) -> (String, u64) {
+        let mut out = String::with_capacity(self.byte_len);
+        for c in &self.chunks {
+            out.push_str(c);
+        }
+        (out, self.total_written)
+    }
+
+    pub fn total_written(&self) -> u64 {
+        self.total_written
+    }
+}
+
 pub struct PtyHandle {
     pub task_id: String,
+    /// Display name shown in terminal tab (shell name, "Dev Server", "Setup", etc.)
+    pub name: String,
+    /// True when spawned as a project start command (auto-exits on completion).
+    pub is_start_command: bool,
+    /// "setup" or "destroy" when spawned as a lifecycle hook, else None.
+    pub hook_type: Option<String>,
     pub master: Mutex<Box<dyn portable_pty::MasterPty + Send>>,
     pub writer: Mutex<Box<dyn Write + Send>>,
     pub child: Mutex<Box<dyn portable_pty::Child + Send + Sync>>,
+    pub buffer: Arc<Mutex<PtyBuffer>>,
 }
 
 /// terminal_id → active PTY handle
@@ -34,6 +97,23 @@ pub fn new_active_pty_map() -> ActivePtyMap {
 pub struct PtyOutputEvent {
     pub terminal_id: String,
     pub data: String,
+    /// Total bytes ever written to this PTY (including this chunk). Clients use
+    /// this to dedupe against an initial snapshot returned from `pty_list_for_task`.
+    pub seq: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PtyListEntry {
+    pub terminal_id: String,
+    pub task_id: String,
+    pub name: String,
+    pub is_start_command: bool,
+    pub hook_type: Option<String>,
+    /// Everything still in the replay buffer - typically the last ~256 KB of output.
+    pub buffered_output: String,
+    /// Seq (total bytes ever written) at the moment the snapshot was taken.
+    pub seq: u64,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -58,6 +138,11 @@ pub struct SpawnResult {
 /// If `initial_command` is provided, it will be written to the PTY immediately after spawn.
 /// If `direct_command` is true, the command is run directly via `sh -c` instead of inside
 /// a login shell — the PTY exits when the command exits (good for dev servers / start commands).
+///
+/// `name_override` sets the display name shown in the terminal tab. When `None`,
+/// the shell's basename is used (e.g. "zsh"). `is_start_command` and `hook_type`
+/// are persisted on the handle so `pty_list_for_task` can surface them when a
+/// new window attaches.
 #[allow(clippy::too_many_arguments)]
 pub fn spawn_pty(
     app: AppHandle,
@@ -69,6 +154,9 @@ pub fn spawn_pty(
     initial_command: Option<String>,
     env_vars: Vec<(String, String)>,
     direct_command: bool,
+    name_override: Option<String>,
+    is_start_command: bool,
+    hook_type: Option<String>,
 ) -> Result<SpawnResult, String> {
     let terminal_id = Uuid::new_v4().to_string();
     let pty_system = native_pty_system();
@@ -154,14 +242,21 @@ pub fn spawn_pty(
         .take_writer()
         .map_err(|e| format!("Failed to take PTY writer: {e}"))?;
 
+    let display_name = name_override.unwrap_or_else(|| shell_name.clone());
+    let buffer = Arc::new(Mutex::new(PtyBuffer::new(REPLAY_BUFFER_CAP)));
+
     // Store the handle (master kept for resize)
     map.insert(
         terminal_id.clone(),
         PtyHandle {
             task_id,
+            name: display_name,
+            is_start_command,
+            hook_type,
             master: Mutex::new(pair.master),
             writer: Mutex::new(writer),
             child: Mutex::new(child),
+            buffer: buffer.clone(),
         },
     );
 
@@ -182,6 +277,7 @@ pub fn spawn_pty(
     // Spawn a dedicated OS thread for blocking read
     let tid = terminal_id.clone();
     let exit_map = map.clone();
+    let reader_buffer = buffer;
     std::thread::spawn(move || {
         let mut buf = [0u8; 4096];
         loop {
@@ -190,11 +286,19 @@ pub fn spawn_pty(
                 Ok(n) => {
                     env_path::record_pty_output();
                     let data = String::from_utf8_lossy(&buf[..n]).to_string();
+                    let seq = match reader_buffer.lock() {
+                        Ok(mut b) => {
+                            b.append(&data);
+                            b.total_written()
+                        }
+                        Err(_) => 0,
+                    };
                     let _ = app.emit(
                         "pty-output",
                         PtyOutputEvent {
                             terminal_id: tid.clone(),
                             data,
+                            seq,
                         },
                     );
                 }
@@ -301,5 +405,98 @@ pub fn close_all_for_task(map: &ActivePtyMap, task_id: &str) {
         if let Some((_, handle)) = map.remove(&id) {
             kill_handle(handle);
         }
+    }
+}
+
+/// Return metadata + replay buffer for every PTY currently running for a given task.
+/// Callers on a freshly-opened window use this to rebuild their terminal list and
+/// replay scrollback into their xterm instances.
+pub fn list_for_task(map: &ActivePtyMap, task_id: &str) -> Vec<PtyListEntry> {
+    let mut entries: Vec<PtyListEntry> = map
+        .iter()
+        .filter(|e| e.value().task_id == task_id)
+        .map(|e| {
+            let handle = e.value();
+            let (buffered_output, seq) = handle
+                .buffer
+                .lock()
+                .map(|b| b.snapshot())
+                .unwrap_or_else(|_| (String::new(), 0));
+            PtyListEntry {
+                terminal_id: e.key().clone(),
+                task_id: handle.task_id.clone(),
+                name: handle.name.clone(),
+                is_start_command: handle.is_start_command,
+                hook_type: handle.hook_type.clone(),
+                buffered_output,
+                seq,
+            }
+        })
+        .collect();
+    // Stable ordering: hooks first (setup then destroy), then start command, then shells.
+    // Within each group, keep DashMap's iteration order (arbitrary but consistent per run).
+    entries.sort_by_key(|e| match (e.hook_type.as_deref(), e.is_start_command) {
+        (Some("setup"), _) => 0,
+        (Some(_), _) => 2,
+        (None, true) => 1,
+        (None, false) => 3,
+    });
+    entries
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn buffer_retains_full_content_below_cap() {
+        let mut buf = PtyBuffer::new(1024);
+        buf.append("hello ");
+        buf.append("world");
+        let (snap, seq) = buf.snapshot();
+        assert_eq!(snap, "hello world");
+        assert_eq!(seq, 11);
+    }
+
+    #[test]
+    fn buffer_evicts_oldest_chunks_when_over_cap() {
+        let mut buf = PtyBuffer::new(10);
+        buf.append("aaaa"); // 4
+        buf.append("bbbb"); // 8
+        buf.append("cccc"); // over cap -> evict "aaaa"
+        let (snap, seq) = buf.snapshot();
+        assert_eq!(snap, "bbbbcccc");
+        assert_eq!(seq, 12, "seq counts total bytes ever written");
+    }
+
+    #[test]
+    fn buffer_preserves_single_oversize_chunk() {
+        // Eviction should never drop the newest chunk, even if it alone exceeds cap,
+        // so clients always see the latest output.
+        let mut buf = PtyBuffer::new(4);
+        buf.append("ab");
+        buf.append("cdefghij");
+        let (snap, _) = buf.snapshot();
+        assert_eq!(snap, "cdefghij");
+    }
+
+    #[test]
+    fn buffer_preserves_multibyte_utf8() {
+        // Chunks are kept whole, so a multibyte char can never be split at the
+        // eviction boundary.
+        let mut buf = PtyBuffer::new(6);
+        buf.append("日本"); // 6 bytes
+        buf.append("語"); // 3 bytes -> over cap, evict 日本
+        let (snap, _) = buf.snapshot();
+        assert_eq!(snap, "語");
+    }
+
+    #[test]
+    fn total_written_advances_past_evicted_bytes() {
+        let mut buf = PtyBuffer::new(4);
+        buf.append("aa"); // 2
+        buf.append("bb"); // 4
+        buf.append("cc"); // 6 → evict "aa"
+        assert_eq!(buf.total_written(), 6);
     }
 }

--- a/src-tauri/src/task.rs
+++ b/src-tauri/src/task.rs
@@ -296,6 +296,10 @@ pub fn spawn_hook_pty(
 
     let env_vars = worktree::verun_env_vars(port_offset, repo_path);
 
+    let display_name = match hook_type {
+        HookType::Setup => "Setup",
+        HookType::Destroy => "Destroy",
+    };
     let result = crate::pty::spawn_pty(
         app.clone(),
         pty_map.clone(),
@@ -306,6 +310,9 @@ pub fn spawn_hook_pty(
         Some(hook_command.to_string()),
         env_vars,
         true, // direct_command — PTY exits when hook exits
+        Some(display_name.to_string()),
+        false,
+        Some(hook_type.as_str().to_string()),
     )?;
 
     hook_pty_map.insert(

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import { Component, Show, onMount, onCleanup, createSignal } from 'solid-js'
+import { Component, Show, onMount, onCleanup, createSignal, createEffect } from 'solid-js'
 import { listen } from '@tauri-apps/api/event'
 import { open as openDialog } from '@tauri-apps/plugin-dialog'
 import { Sidebar } from './Sidebar'
@@ -8,7 +8,7 @@ import { ArchivedPage } from './ArchivedPage'
 import { NewTaskDialog } from './NewTaskDialog'
 import { sidebarWidth, setSidebarWidth, showSettings, setShowSettings, showArchived, setShowArchived, toggleTerminal, showTerminal, setShowTerminal, setAddProjectPath, newTaskProjectId, setNewTaskProjectId, requestNewTaskForProject, focusOrSelectTask } from '../store/ui'
 import * as ipc from '../lib/ipc'
-import { spawnTerminal, focusActiveTerminal, terminalsForTask, activeTerminalId, setActiveTerminalForTask, isStartCommandRunning, spawnStartCommand, stopStartCommand } from '../store/terminals'
+import { spawnTerminal, focusActiveTerminal, terminalsForTask, activeTerminalId, setActiveTerminalForTask, isStartCommandRunning, spawnStartCommand, stopStartCommand, hydrateTerminalsForTask } from '../store/terminals'
 import { activeTasksForProject, taskById } from '../store/tasks'
 import { projects, projectById } from '../store/projects'
 import { selectedProjectId, selectedTaskId } from '../store/ui'
@@ -30,6 +30,26 @@ export const Layout: Component = () => {
   onMount(() => {
     const saved = localStorage.getItem('verun:sidebarWidth')
     if (saved) setSidebarWidth(parseInt(saved, 10))
+  })
+
+  // Hydrate terminals from the Rust ring buffer whenever a task becomes
+  // selected. Runs on every selection change (not just the first) so that
+  // switching back to a task re-syncs against the backend — picks up PTYs
+  // spawned in another window and prunes ones closed elsewhere.
+  createEffect(() => {
+    const tid = selectedTaskId()
+    if (tid) hydrateTerminalsForTask(tid)
+  })
+
+  // When a detached task window closes, the main window's terminal store for
+  // that task is potentially stale (PTYs spawned or closed while we weren't
+  // looking). Re-hydrate so the content reappears when the user views the task
+  // again in this window.
+  onMount(() => {
+    const unlisten = listen<{ taskId: string; open: boolean }>('task-window-changed', (event) => {
+      if (!event.payload.open) hydrateTerminalsForTask(event.payload.taskId)
+    })
+    onCleanup(() => { unlisten.then(fn => fn()) })
   })
 
   const startResize = (e: MouseEvent) => {

--- a/src/components/ShellTerminal.tsx
+++ b/src/components/ShellTerminal.tsx
@@ -5,7 +5,7 @@ import { SearchAddon } from '@xterm/addon-search'
 import { WebLinksAddon } from '@xterm/addon-web-links'
 import { Unicode11Addon } from '@xterm/addon-unicode11'
 import { WebglAddon } from '@xterm/addon-webgl'
-import { registerXterm, getXtermEntry } from '../store/terminals'
+import { registerXterm, getXtermEntry, consumeInitialReplay, markSeqWritten } from '../store/terminals'
 import type { XtermEntry } from '../store/terminals'
 import * as ipc from '../lib/ipc'
 import { isMac, modPressed } from '../lib/platform'
@@ -216,9 +216,18 @@ export const ShellTerminal: Component<Props> = (props) => {
       if (props.isStopped?.()) return
       ipc.ptyWrite(props.terminalId, data)
     })
-    registerXterm(props.terminalId, term, fitAddon, searchAddon)
 
     term.open(terminalRef)
+
+    // Replay any buffered scrollback BEFORE registering xterm. registerXterm
+    // flushes pending live chunks; by replaying first and marking seq, those
+    // flushed chunks are correctly deduped against the snapshot.
+    const replay = consumeInitialReplay(props.terminalId)
+    if (replay) {
+      term.write(replay.data)
+      markSeqWritten(props.terminalId, replay.seq)
+    }
+    registerXterm(props.terminalId, term, fitAddon, searchAddon)
 
     try {
       term.loadAddon(new WebglAddon())

--- a/src/components/TaskWindowShell.tsx
+++ b/src/components/TaskWindowShell.tsx
@@ -11,7 +11,7 @@ import { loadAgents } from '../store/agents'
 import { selectedTaskId, setSelectedTaskId, setSelectedProjectId } from '../store/ui'
 import { modPressed } from '../lib/platform'
 import { toggleTerminal, showTerminal, setShowTerminal } from '../store/ui'
-import { spawnTerminal, focusActiveTerminal, terminalsForTask, activeTerminalId, setActiveTerminalForTask, isStartCommandRunning, spawnStartCommand, stopStartCommand } from '../store/terminals'
+import { spawnTerminal, focusActiveTerminal, terminalsForTask, activeTerminalId, setActiveTerminalForTask, isStartCommandRunning, spawnStartCommand, stopStartCommand, hydrateTerminalsForTask } from '../store/terminals'
 import { projectById } from '../store/projects'
 import { requestCloseTab, reopenClosedTab, nextTab, prevTab, activeTabPath, mainView } from '../store/editorView'
 import { rightPanelTab, setRightPanelTab, setShowQuickOpen, setFocusSearchRequest } from '../store/ui'
@@ -41,6 +41,14 @@ export const TaskWindowShell: Component = () => {
   createEffect(on(selectedTaskId, (taskId) => {
     if (taskId) emit('task-window-changed', { taskId, open: true })
   }))
+
+  // Hydrate terminals from the Rust ring buffer whenever the selected task
+  // changes. Runs on every change (not just first mount) so re-syncing picks
+  // up PTYs spawned in the main window since we last looked.
+  createEffect(() => {
+    const taskId = selectedTaskId()
+    if (taskId) hydrateTerminalsForTask(taskId)
+  })
 
 
   // --- Initialization ---

--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -1,7 +1,7 @@
-import { Component, For, Show, createSignal } from 'solid-js'
+import { Component, For, Show, createSignal, createEffect } from 'solid-js'
 import { Plus, X, Square, Loader2, Check, AlertCircle, RotateCcw } from 'lucide-solid'
 import { clsx } from 'clsx'
-import { terminalsForTask, activeTerminalId, setActiveTerminalForTask, spawnTerminal, closeTerminal, focusActiveTerminal, terminalExitCodes, isTerminalStopped, spawnStartCommand } from '../store/terminals'
+import { terminalsForTask, activeTerminalId, setActiveTerminalForTask, spawnTerminal, closeTerminal, focusActiveTerminal, terminalExitCodes, isTerminalStopped, spawnStartCommand, isTaskHydrated } from '../store/terminals'
 import { isSetupRunning } from '../store/setup'
 import { ShellTerminal } from './ShellTerminal'
 import * as ipc from '../lib/ipc'
@@ -61,16 +61,21 @@ export const TerminalPanel: Component<Props> = (props) => {
     }
   }
 
-  // Auto-spawn first terminal if none exist
-  // If auto-start enabled and start command exists, run it; otherwise open a plain shell
-  if (taskTerminals().length === 0 && !isSetupRunning(props.taskId)) {
+  // Auto-spawn first terminal if none exist. Wait for hydration first so we
+  // don't spawn a fresh shell on top of PTYs the Rust side already has running
+  // (e.g. opened from another window or surviving a window reload).
+  createEffect(() => {
+    if (!isTaskHydrated(props.taskId)) return
+    if (taskTerminals().length > 0) return
+    if (isSetupRunning(props.taskId)) return
+    if (spawning()) return
     if (props.autoStart && props.startCommand) {
       setSpawning(true)
       spawnStartCommand(props.taskId, props.startCommand).finally(() => setSpawning(false))
     } else {
       handleNew()
     }
-  }
+  })
 
   return (
     <div class="flex flex-col h-full bg-[#0a0a0a]">

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -1,5 +1,5 @@
 import { invoke } from '@tauri-apps/api/core'
-import type { Project, Task, TaskWithSession, Session, OutputLine, RepoInfo, Attachment, AgentSkill, AgentInfo, AgentType, GitStatus, FileDiff, DiffContents, BranchCommit, GitHubRepo, PrInfo, CiCheck, ToolApprovalRequest, TrustLevel, AuditEntry, PtySpawnResult, FileEntry, Step } from '../types'
+import type { Project, Task, TaskWithSession, Session, OutputLine, RepoInfo, Attachment, AgentSkill, AgentInfo, AgentType, GitStatus, FileDiff, DiffContents, BranchCommit, GitHubRepo, PrInfo, CiCheck, ToolApprovalRequest, TrustLevel, AuditEntry, PtySpawnResult, PtyListEntry, FileEntry, Step } from '../types'
 import { bytesToBase64 } from './binary'
 
 const DEMO = import.meta.env.VITE_DEMO_MODE === 'true'
@@ -303,8 +303,11 @@ export const openInApp = (path: string, app: string) =>
   invoke<void>('open_in_app', { path, app })
 
 // PTY / Terminal
-export const ptySpawn = (taskId: string, rows: number, cols: number, initialCommand?: string, directCommand?: boolean) =>
-  invoke<PtySpawnResult>('pty_spawn', { taskId, rows, cols, initialCommand, directCommand })
+export const ptySpawn = (taskId: string, rows: number, cols: number, initialCommand?: string, directCommand?: boolean, isStartCommand?: boolean) =>
+  invoke<PtySpawnResult>('pty_spawn', { taskId, rows, cols, initialCommand, directCommand, isStartCommand })
+
+export const ptyListForTask = (taskId: string) =>
+  invoke<PtyListEntry[]>('pty_list_for_task', { taskId })
 
 export const ptyWrite = (terminalId: string, data: string) =>
   invoke<void>('pty_write', { terminalId, data })

--- a/src/store/taskContext.ts
+++ b/src/store/taskContext.ts
@@ -101,6 +101,7 @@ export function terminalOpenForTask(taskId: string): boolean {
 export function setTerminalOpenForTask(taskId: string, open: boolean) {
   ensureTaskContext(taskId)
   setTaskContexts(taskId, 'terminalOpen', open)
+  persistTaskContext(taskId, taskContexts[taskId]!)
 }
 
 export function activeTerminalForTask(taskId: string): string | null {

--- a/src/store/taskContextStorage.ts
+++ b/src/store/taskContextStorage.ts
@@ -4,6 +4,7 @@ import type { DiffSource, EditorTab } from './editorTypes'
 interface PersistedTaskContext {
   selectedSessionId?: string | null
   mainView?: string
+  terminalOpen?: boolean
   editor?: PersistedEditorState
 }
 
@@ -61,6 +62,7 @@ export function loadInitialTaskContext(taskId: string): Partial<TaskContextState
   return {
     selectedSessionId: persisted?.selectedSessionId ?? localStorage.getItem(`verun:lastSession:${taskId}`),
     mainView: persisted?.mainView ?? persisted?.editor?.mainView ?? legacyMainView ?? 'session',
+    terminalOpen: persisted?.terminalOpen ?? false,
   }
 }
 
@@ -72,6 +74,7 @@ export function persistTaskContext(taskId: string, ctx: TaskContextState) {
     ...previous,
     selectedSessionId: ctx.selectedSessionId,
     mainView: ctx.mainView,
+    terminalOpen: ctx.terminalOpen,
   }
 
   try {

--- a/src/store/terminals.test.ts
+++ b/src/store/terminals.test.ts
@@ -1,0 +1,226 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+
+const listenCallbacks = new Map<string, (e: { payload: unknown }) => void>()
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn((event: string, cb: (e: { payload: unknown }) => void) => {
+    listenCallbacks.set(event, cb)
+    return Promise.resolve(() => listenCallbacks.delete(event))
+  }),
+  emit: vi.fn(),
+}))
+
+vi.mock('../lib/ipc', () => ({
+  ptyListForTask: vi.fn().mockResolvedValue([]),
+  ptySpawn: vi.fn(),
+  ptyClose: vi.fn().mockResolvedValue(undefined),
+  ptyResize: vi.fn().mockResolvedValue(undefined),
+  ptyWrite: vi.fn().mockResolvedValue(undefined),
+}))
+
+import * as ipc from '../lib/ipc'
+import {
+  terminals,
+  terminalsForTask,
+  hydrateTerminalsForTask,
+  isTaskHydrated,
+  consumeInitialReplay,
+  markSeqWritten,
+  registerXterm,
+  initTerminalListeners,
+  closeTerminalsForTask,
+} from './terminals'
+import type { PtyListEntry, PtyOutputEvent } from '../types'
+
+function makeEntry(overrides: Partial<PtyListEntry> = {}): PtyListEntry {
+  return {
+    terminalId: 'p-1',
+    taskId: 't-1',
+    name: 'zsh',
+    isStartCommand: false,
+    hookType: null,
+    bufferedOutput: '',
+    seq: 0,
+    ...overrides,
+  }
+}
+
+function fakeXterm() {
+  return {
+    write: vi.fn(),
+    focus: vi.fn(),
+    refresh: vi.fn(),
+    dispose: vi.fn(),
+    rows: 24,
+    cols: 80,
+  }
+}
+
+beforeEach(() => {
+  closeTerminalsForTask('t-1')
+  closeTerminalsForTask('t-2')
+  vi.clearAllMocks()
+})
+
+describe('hydrateTerminalsForTask', () => {
+  test('marks the task as hydrated even when no PTYs exist', async () => {
+    vi.mocked(ipc.ptyListForTask).mockResolvedValueOnce([])
+    expect(isTaskHydrated('t-1')).toBe(false)
+    await hydrateTerminalsForTask('t-1')
+    expect(isTaskHydrated('t-1')).toBe(true)
+    expect(terminalsForTask('t-1')).toHaveLength(0)
+  })
+
+  test('populates store with entries from ipc including replay + seq', async () => {
+    vi.mocked(ipc.ptyListForTask).mockResolvedValueOnce([
+      makeEntry({ terminalId: 'p-shell', name: 'zsh', bufferedOutput: 'hello', seq: 5 }),
+    ])
+    await hydrateTerminalsForTask('t-1')
+    const list = terminalsForTask('t-1')
+    expect(list).toHaveLength(1)
+    expect(list[0].id).toBe('p-shell')
+    expect(list[0].initialReplay).toEqual({ data: 'hello', seq: 5 })
+  })
+
+  test('puts hooks and start command before regular shells', async () => {
+    vi.mocked(ipc.ptyListForTask).mockResolvedValueOnce([
+      makeEntry({ terminalId: 'shell', name: 'zsh' }),
+      makeEntry({ terminalId: 'dev', name: 'Dev Server', isStartCommand: true }),
+      makeEntry({ terminalId: 'setup', name: 'Setup', hookType: 'setup' }),
+    ])
+    await hydrateTerminalsForTask('t-1')
+    const list = terminalsForTask('t-1').map(t => t.id)
+    // hooks / start cmd get unshifted, so they end up first in insertion order
+    expect(list[0]).not.toBe('shell')
+    expect(list).toContain('shell')
+    expect(list).toContain('dev')
+    expect(list).toContain('setup')
+  })
+
+  test('is idempotent for already-known terminals', async () => {
+    vi.mocked(ipc.ptyListForTask).mockResolvedValue([
+      makeEntry({ terminalId: 'p-a' }),
+    ])
+    await hydrateTerminalsForTask('t-1')
+    await hydrateTerminalsForTask('t-1')
+    expect(terminalsForTask('t-1')).toHaveLength(1)
+  })
+
+  test('re-hydration syncs store: adds new backend PTYs and prunes missing ones', async () => {
+    vi.mocked(ipc.ptyListForTask).mockResolvedValueOnce([
+      makeEntry({ terminalId: 'p-a' }),
+      makeEntry({ terminalId: 'p-b' }),
+    ])
+    await hydrateTerminalsForTask('t-1')
+    expect(terminalsForTask('t-1').map(t => t.id).sort()).toEqual(['p-a', 'p-b'])
+
+    // Second snapshot: p-a closed in another window, p-c spawned there.
+    vi.mocked(ipc.ptyListForTask).mockResolvedValueOnce([
+      makeEntry({ terminalId: 'p-b' }),
+      makeEntry({ terminalId: 'p-c', bufferedOutput: 'hi from other window', seq: 3 }),
+    ])
+    await hydrateTerminalsForTask('t-1')
+
+    const ids = terminalsForTask('t-1').map(t => t.id).sort()
+    expect(ids).toEqual(['p-b', 'p-c'])
+    const pc = terminalsForTask('t-1').find(t => t.id === 'p-c')
+    expect(pc?.initialReplay).toEqual({ data: 'hi from other window', seq: 3 })
+  })
+
+  test('pruning during re-hydration does not auto-spawn a replacement shell', async () => {
+    vi.mocked(ipc.ptyListForTask).mockResolvedValueOnce([
+      makeEntry({ terminalId: 'p-only' }),
+    ])
+    await hydrateTerminalsForTask('t-1')
+    expect(terminalsForTask('t-1')).toHaveLength(1)
+
+    // Backend now reports zero PTYs (all closed elsewhere). Must not spawn a
+    // replacement via removeTerminal's fallback.
+    vi.mocked(ipc.ptyListForTask).mockResolvedValueOnce([])
+    await hydrateTerminalsForTask('t-1')
+
+    expect(terminalsForTask('t-1')).toHaveLength(0)
+    expect(ipc.ptySpawn).not.toHaveBeenCalled()
+  })
+
+  test('still marks hydrated when ipc throws (prevents spawn deadlock)', async () => {
+    vi.mocked(ipc.ptyListForTask).mockRejectedValueOnce(new Error('boom'))
+    await hydrateTerminalsForTask('t-1')
+    expect(isTaskHydrated('t-1')).toBe(true)
+  })
+
+  test('omits initialReplay when buffered output is empty', async () => {
+    vi.mocked(ipc.ptyListForTask).mockResolvedValueOnce([
+      makeEntry({ terminalId: 'p-empty', bufferedOutput: '', seq: 0 }),
+    ])
+    await hydrateTerminalsForTask('t-1')
+    expect(terminals.find(t => t.id === 'p-empty')?.initialReplay).toBeUndefined()
+  })
+})
+
+describe('pty-output seq dedupe', () => {
+  test('drops events with seq <= markSeqWritten boundary', async () => {
+    vi.mocked(ipc.ptyListForTask).mockResolvedValueOnce([
+      makeEntry({ terminalId: 'p-1', bufferedOutput: 'snap', seq: 10 }),
+    ])
+    await hydrateTerminalsForTask('t-1')
+    await initTerminalListeners()
+
+    // Simulate ShellTerminal.onMount: consume replay, mark seq, then register
+    const replay = consumeInitialReplay('p-1')
+    expect(replay).toEqual({ data: 'snap', seq: 10 })
+    const term = fakeXterm()
+    markSeqWritten('p-1', replay!.seq)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerXterm('p-1', term as any, { fit: vi.fn() } as any)
+
+    const cb = listenCallbacks.get('pty-output')!
+    // seq 5 is below the snapshot boundary — must be dropped
+    cb({ payload: { terminalId: 'p-1', data: 'stale', seq: 5 } satisfies PtyOutputEvent })
+    // Let the rAF-batched buffer flush
+    await new Promise(r => requestAnimationFrame(() => r(null)))
+    expect(term.write).not.toHaveBeenCalled()
+
+    // seq 11 is fresh — must be written
+    cb({ payload: { terminalId: 'p-1', data: 'fresh', seq: 11 } satisfies PtyOutputEvent })
+    await new Promise(r => requestAnimationFrame(() => r(null)))
+    expect(term.write).toHaveBeenCalledWith('fresh')
+  })
+
+  test('buffers events arriving before registerXterm and flushes on register', async () => {
+    await initTerminalListeners()
+    const cb = listenCallbacks.get('pty-output')!
+
+    // Event arrives before xterm mounts — stashed in pendingChunks
+    cb({ payload: { terminalId: 'p-pending', data: 'early', seq: 1 } satisfies PtyOutputEvent })
+
+    const term = fakeXterm()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerXterm('p-pending', term as any, { fit: vi.fn() } as any)
+    expect(term.write).toHaveBeenCalledWith('early')
+  })
+
+  test('filters pending chunks already covered by a snapshot replay', async () => {
+    await initTerminalListeners()
+    const cb = listenCallbacks.get('pty-output')!
+
+    // Live chunks arrive first
+    cb({ payload: { terminalId: 'p-race', data: 'old', seq: 3 } satisfies PtyOutputEvent })
+    cb({ payload: { terminalId: 'p-race', data: 'new', seq: 7 } satisfies PtyOutputEvent })
+
+    // Hydration snapshot at seq 5 covers 'old' but not 'new'
+    vi.mocked(ipc.ptyListForTask).mockResolvedValueOnce([
+      makeEntry({ terminalId: 'p-race', bufferedOutput: 'SNAP', seq: 5 }),
+    ])
+    await hydrateTerminalsForTask('t-1')
+
+    const term = fakeXterm()
+    const replay = consumeInitialReplay('p-race')!
+    markSeqWritten('p-race', replay.seq)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerXterm('p-race', term as any, { fit: vi.fn() } as any)
+
+    // Only seq-7 chunk should flush — seq-3 was covered by the snapshot
+    expect(term.write).toHaveBeenCalledWith('new')
+    expect(term.write).not.toHaveBeenCalledWith('old')
+  })
+})

--- a/src/store/terminals.ts
+++ b/src/store/terminals.ts
@@ -20,6 +20,10 @@ const deletingTasks = new Set<string>()
 // Terminal exit status: terminalId → exit code (undefined = still running, null = unknown)
 const [terminalExitCodes, setTerminalExitCodes] = createSignal<Record<string, number | null>>({})
 
+// Tasks that have completed hydration (fetched existing PTYs from Rust). Used by
+// TerminalPanel to suppress auto-spawn until we know whether any PTYs already exist.
+const [hydratedTaskIds, setHydratedTaskIds] = createSignal<Set<string>>(new Set())
+
 export interface XtermEntry {
   term: XTerm
   fitAddon: FitAddon
@@ -29,6 +33,16 @@ const xtermInstances = new Map<string, XtermEntry>()
 
 const ptyWriteBuffers = new Map<string, string[]>()
 const ptyRafIds = new Map<string, number>()
+
+// Highest seq already written to an xterm (either via replay or live). Events
+// with seq <= this are duplicates and dropped.
+const lastSeqWritten = new Map<string, number>()
+
+// Live events received before ShellTerminal has registered an xterm for the
+// terminal. Flushed on register. Seq-tagged so stale entries (covered by a
+// later snapshot replay) can be filtered out.
+interface PendingChunk { data: string; seq: number }
+const pendingChunks = new Map<string, PendingChunk[]>()
 
 function flushPtyBuffer(terminalId: string) {
   const buf = ptyWriteBuffers.get(terminalId)
@@ -69,8 +83,39 @@ export function setActiveTerminalForTask(taskId: string, terminalId: string | nu
 // xterm instance registry
 // ---------------------------------------------------------------------------
 
+/** Consume any replay scrollback attached to this terminal. Called exactly once
+ *  by ShellTerminal.onMount: returns the data to write into xterm and clears
+ *  the store entry so a re-mount doesn't double-replay. */
+export function consumeInitialReplay(terminalId: string): { data: string; seq: number } | null {
+  const idx = terminals.findIndex(t => t.id === terminalId)
+  if (idx < 0) return null
+  const replay = terminals[idx].initialReplay
+  if (!replay) return null
+  setTerminals(idx, 'initialReplay', undefined)
+  return replay
+}
+
+/** Record the highest seq already written to xterm for this terminal — live
+ *  events with seq <= this are dropped as duplicates of the replay. */
+export function markSeqWritten(terminalId: string, seq: number) {
+  const prev = lastSeqWritten.get(terminalId) ?? 0
+  if (seq > prev) lastSeqWritten.set(terminalId, seq)
+}
+
 export function registerXterm(terminalId: string, term: XTerm, fitAddon: FitAddon, searchAddon?: SearchAddon) {
   xtermInstances.set(terminalId, { term, fitAddon, searchAddon })
+  // Drain any live chunks that arrived after the snapshot was taken but before
+  // this xterm was mounted. Stale chunks (seq <= last written) are skipped.
+  const pending = pendingChunks.get(terminalId)
+  if (pending && pending.length > 0) {
+    const last = lastSeqWritten.get(terminalId) ?? 0
+    const fresh = pending.filter(c => c.seq > last)
+    if (fresh.length > 0) {
+      term.write(fresh.map(c => c.data).join(''))
+      lastSeqWritten.set(terminalId, fresh[fresh.length - 1].seq)
+    }
+  }
+  pendingChunks.delete(terminalId)
 }
 
 export function getXtermEntry(terminalId: string): XtermEntry | undefined {
@@ -117,7 +162,9 @@ export function seedDemoStartCommands(taskIds: string[]) {
 }
 
 export async function spawnTerminal(taskId: string, rows: number, cols: number, initialCommand?: string, isStartCommand?: boolean): Promise<TerminalInstance> {
-  const result = await ipc.ptySpawn(taskId, rows, cols, initialCommand, isStartCommand || undefined)
+  // `directCommand` controls how the shell is invoked (login vs. sh -c). For
+  // start commands we pass both so Rust can label the handle correctly.
+  const result = await ipc.ptySpawn(taskId, rows, cols, initialCommand, isStartCommand || undefined, isStartCommand || undefined)
   const name = isStartCommand ? 'Dev Server' : result.shellName
   const instance: TerminalInstance = { id: result.terminalId, taskId, name, isStartCommand }
   if (isStartCommand) {
@@ -127,6 +174,76 @@ export async function spawnTerminal(taskId: string, rows: number, cols: number, 
   }
   setActiveTerminalForTask(taskId, result.terminalId)
   return instance
+}
+
+export const isTaskHydrated = (taskId: string) => hydratedTaskIds().has(taskId)
+
+/** Fetch the Rust-side PTY snapshot for this task and reconcile the store:
+ *  add PTYs that are new to this window (carrying a replay buffer so xterm can
+ *  redraw scrollback on mount) and remove PTYs that no longer exist (e.g.
+ *  closed in another window). Idempotent; safe to call on every task switch
+ *  and whenever a sibling window closes. */
+export async function hydrateTerminalsForTask(taskId: string): Promise<void> {
+  let entries: Awaited<ReturnType<typeof ipc.ptyListForTask>> = []
+  try {
+    entries = await ipc.ptyListForTask(taskId)
+  } catch (err) {
+    console.error('hydrateTerminalsForTask failed:', err)
+    // Bail out: without a snapshot we can't tell stale from live, so leaving
+    // the store untouched is safer than pruning.
+    setHydratedTaskIds(prev => {
+      if (prev.has(taskId)) return prev
+      const next = new Set(prev)
+      next.add(taskId)
+      return next
+    })
+    return
+  }
+
+  const backendIds = new Set(entries.map(e => e.terminalId))
+  // Prune: terminals in our store for this task that the backend no longer
+  // knows about (closed in another window, or backend process ended).
+  // suppressAutoSpawn: re-hydration should never materialize a brand-new shell
+  // just because every PTY we were tracking turned out to be gone — the live
+  // entries below (or TerminalPanel's own gate) will handle that.
+  const stale = terminals.filter(t => t.taskId === taskId && !backendIds.has(t.id))
+  for (const t of stale) removeTerminal(t.id, { suppressAutoSpawn: true })
+
+  for (const e of entries) {
+    if (terminals.find(t => t.id === e.terminalId)) continue
+    const hookType = e.hookType === 'setup' || e.hookType === 'destroy' ? e.hookType : undefined
+    const instance: TerminalInstance = {
+      id: e.terminalId,
+      taskId: e.taskId,
+      name: e.name,
+      isStartCommand: e.isStartCommand || undefined,
+      hookType,
+      initialReplay: e.bufferedOutput ? { data: e.bufferedOutput, seq: e.seq } : undefined,
+    }
+    // Drop any pending chunks already covered by this snapshot so ShellTerminal
+    // doesn't double-write them after replay.
+    const pending = pendingChunks.get(e.terminalId)
+    if (pending) {
+      const fresh = pending.filter(c => c.seq > e.seq)
+      if (fresh.length > 0) pendingChunks.set(e.terminalId, fresh)
+      else pendingChunks.delete(e.terminalId)
+    }
+    if (e.isStartCommand || hookType) {
+      setTerminals(produce(t => t.unshift(instance)))
+    } else {
+      setTerminals(produce(t => t.push(instance)))
+    }
+    if (!activeTerminalForTask(taskId)) {
+      setActiveTerminalForTask(taskId, e.terminalId)
+    }
+  }
+
+  setHydratedTaskIds(prev => {
+    if (prev.has(taskId)) return prev
+    const next = new Set(prev)
+    next.add(taskId)
+    return next
+  })
 }
 
 /** Check if a start command terminal exists for this task */
@@ -187,8 +304,10 @@ export async function closeTerminal(terminalId: string) {
   removeTerminal(terminalId)
 }
 
-function removeTerminal(terminalId: string) {
+function removeTerminal(terminalId: string, opts: { suppressAutoSpawn?: boolean } = {}) {
   cleanupPtyBuffer(terminalId)
+  pendingChunks.delete(terminalId)
+  lastSeqWritten.delete(terminalId)
   const term = terminals.find(t => t.id === terminalId)
   const taskId = term?.taskId
   const isSpecial = !!term?.hookType || !!term?.isStartCommand
@@ -204,7 +323,7 @@ function removeTerminal(terminalId: string) {
     const remaining = terminals.filter(t => t.taskId === taskId && t.id !== terminalId)
     if (remaining.length > 0) {
       setActiveTerminalForTask(taskId, remaining[remaining.length - 1].id)
-    } else if (!deletingTasks.has(taskId) && !isSpecial) {
+    } else if (!deletingTasks.has(taskId) && !isSpecial && !opts.suppressAutoSpawn) {
       spawnTerminal(taskId, 24, 80)
     }
   }
@@ -216,10 +335,18 @@ export function closeTerminalsForTask(taskId: string) {
   const ids = terminals.filter(t => t.taskId === taskId).map(t => t.id)
   for (const id of ids) {
     cleanupPtyBuffer(id)
+    pendingChunks.delete(id)
+    lastSeqWritten.delete(id)
     xtermInstances.get(id)?.term.dispose()
     xtermInstances.delete(id)
   }
   setTerminals(prev => prev.filter(t => t.taskId !== taskId))
+  setHydratedTaskIds(prev => {
+    if (!prev.has(taskId)) return prev
+    const next = new Set(prev)
+    next.delete(taskId)
+    return next
+  })
   // deletingTasks cleanup delayed to let async pty-exited events arrive
   setTimeout(() => deletingTasks.delete(taskId), 2000)
 }
@@ -230,8 +357,24 @@ export function closeTerminalsForTask(taskId: string) {
 
 export async function initTerminalListeners() {
   await listen<PtyOutputEvent>('pty-output', (event) => {
-    const { terminalId, data } = event.payload
-    if (!xtermInstances.has(terminalId)) return
+    const { terminalId, data, seq } = event.payload
+    // Dedupe: a snapshot replay has already covered anything with seq <= last.
+    const last = lastSeqWritten.get(terminalId) ?? 0
+    if (seq <= last) return
+
+    const entry = xtermInstances.get(terminalId)
+    if (!entry) {
+      // xterm not mounted yet — stash until registerXterm flushes.
+      let pending = pendingChunks.get(terminalId)
+      if (!pending) {
+        pending = []
+        pendingChunks.set(terminalId, pending)
+      }
+      pending.push({ data, seq })
+      return
+    }
+
+    lastSeqWritten.set(terminalId, seq)
     let buf = ptyWriteBuffers.get(terminalId)
     if (!buf) {
       buf = []

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -285,6 +285,9 @@ export interface TerminalInstance {
   name: string
   hookType?: 'setup' | 'destroy'
   isStartCommand?: boolean
+  /** Scrollback to replay into xterm on first mount (from Rust ring buffer).
+   *  Consumed and cleared by ShellTerminal. */
+  initialReplay?: { data: string; seq: number }
 }
 
 export interface PtySpawnResult {
@@ -295,11 +298,24 @@ export interface PtySpawnResult {
 export interface PtyOutputEvent {
   terminalId: string
   data: string
+  /** Total bytes written to the PTY including this chunk. Used to dedupe live
+   *  events against the snapshot returned by pty_list_for_task. */
+  seq: number
 }
 
 export interface PtyExitedEvent {
   terminalId: string
   exitCode?: number
+}
+
+export interface PtyListEntry {
+  terminalId: string
+  taskId: string
+  name: string
+  isStartCommand: boolean
+  hookType?: string | null
+  bufferedOutput: string
+  seq: number
 }
 
 // File tree types


### PR DESCRIPTION
## Summary

- **Ring buffer in Rust**: each PTY keeps a 256 KB chunk-preserving buffer + cumulative seq counter; `pty_list_for_task` exposes a snapshot to any window
- **Hydration on task selection**: `hydrateTerminalsForTask` reconciles the store — adds PTYs spawned in other windows (with scrollback replay), prunes ones closed elsewhere; runs on every task switch and when a detached window closes via `task-window-changed`
- **TUI correctness**: xterm replays the buffered scrollback before live events attach; seq numbers on `pty-output` dedupe against the snapshot so alt-screen apps (vim, Claude Code) redraw correctly
- **Auto-spawn gating**: `TerminalPanel` waits for hydration before spawning a default shell, preventing a fresh shell racing the incoming PTY list
- **Panel visibility persisted**: `terminalOpen` now lives in `taskContextStorage`, so detached windows open with the same panel state the main window had

## Test plan

- [ ] Open a task in main window, start a terminal session, open vim / run claude
- [ ] Cmd+Shift+N to open the same task in a detached window — terminal content + scrollback should appear, vim/Claude Code should render correctly
- [ ] Close the detached window — terminal content should still be visible in the main window when you switch back
- [ ] Terminal panel open/closed state should match between windows
- [ ] `make check` passes (212 frontend + 329 Rust tests, zero clippy warnings)

Closes #139