### PR TITLE
feat: import/export .verun.json from any task worktree or main repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Import/Export `.verun.json` now let you pick the location: the main repo or any task's worktree (previously import always read from main repo and export always wrote to the first task)
 - Trust level changes apply mid-run: editing the policy during an in-flight turn now takes effect on the next tool-approval check instead of waiting for the next send_message
 - Task switching stays responsive across large workspaces by virtualizing diagnostics and source-control lists, caching chat block rebuilds, and avoiding repeated full-list scans in the file tree, tabs, and sidebar
 - `+` menu now surfaces closed sessions for the task under a "Recent" section - click one to restore it as a tab with full transcript replay; `+` button sticks to the left edge while the tab bar scrolls horizontally (#100)

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -191,19 +191,26 @@ pub async fn update_project_default_agent(
         .map_err(|e| format!("DB write failed: {e}"))
 }
 
-/// Export current DB hooks to .verun.json in a task's worktree
+/// Export current DB hooks to .verun.json. Writes to `task_id`'s worktree when
+/// provided, otherwise to the project repo root.
 #[tauri::command]
 pub async fn export_project_config(
     pool: State<'_, SqlitePool>,
     project_id: String,
-    task_id: String,
+    task_id: Option<String>,
 ) -> Result<(), String> {
     let project = db::get_project(pool.inner(), &project_id)
         .await?
         .ok_or_else(|| format!("Project {project_id} not found"))?;
-    let t = db::get_task(pool.inner(), &task_id)
-        .await?
-        .ok_or_else(|| format!("Task {task_id} not found"))?;
+
+    let task = match task_id.as_deref() {
+        Some(tid) => Some(
+            db::get_task(pool.inner(), tid)
+                .await?
+                .ok_or_else(|| format!("Task {tid} not found"))?,
+        ),
+        None => None,
+    };
 
     let config = serde_json::json!({
         "hooks": {
@@ -213,23 +220,43 @@ pub async fn export_project_config(
         "startCommand": &project.start_command,
     });
     let pretty = serde_json::to_string_pretty(&config).unwrap_or_default();
-    let config_path = format!("{}/.verun.json", t.worktree_path);
+    let config_path =
+        resolve_config_path(&project.repo_path, task.as_ref().map(|t| t.worktree_path.as_str()));
     std::fs::write(&config_path, format!("{pretty}\n"))
         .map_err(|e| format!("Failed to write .verun.json: {e}"))
 }
 
-/// Import .verun.json from the repo root into DB. Returns the imported hooks.
+/// Resolve which `.verun.json` to read/write: a task's worktree when
+/// `task_worktree_path` is `Some`, otherwise the project's repo root.
+fn resolve_config_path(repo_path: &str, task_worktree_path: Option<&str>) -> String {
+    let base = task_worktree_path.unwrap_or(repo_path);
+    format!("{base}/.verun.json")
+}
+
+/// Import .verun.json into DB. Reads from `task_id`'s worktree when provided,
+/// otherwise from the project repo root. Returns the imported hooks.
 #[tauri::command]
 pub async fn import_project_config(
     pool: State<'_, SqlitePool>,
     db_tx: State<'_, DbWriteTx>,
     project_id: String,
+    task_id: Option<String>,
 ) -> Result<ImportedHooks, String> {
     let project = db::get_project(pool.inner(), &project_id)
         .await?
         .ok_or_else(|| format!("Project {project_id} not found"))?;
 
-    let config_path = format!("{}/.verun.json", project.repo_path);
+    let task = match task_id.as_deref() {
+        Some(tid) => Some(
+            db::get_task(pool.inner(), tid)
+                .await?
+                .ok_or_else(|| format!("Task {tid} not found"))?,
+        ),
+        None => None,
+    };
+
+    let config_path =
+        resolve_config_path(&project.repo_path, task.as_ref().map(|t| t.worktree_path.as_str()));
     let (setup, destroy, start) = task::parse_verun_config_file(&config_path)
         .ok_or_else(|| "No .verun.json found or file is empty".to_string())?;
 
@@ -2717,6 +2744,21 @@ mod tests {
         assert!(entry.is_symlink);
         assert!(!entry.is_dir, "broken symlink is not a directory");
         assert!(entry.size.is_none());
+    }
+
+    #[test]
+    fn resolve_config_path_uses_repo_root_when_no_task() {
+        let p = resolve_config_path("/tmp/repo", None);
+        assert_eq!(p, "/tmp/repo/.verun.json");
+    }
+
+    #[test]
+    fn resolve_config_path_uses_worktree_when_task_given() {
+        let p = resolve_config_path(
+            "/tmp/repo",
+            Some("/tmp/repo/.verun/worktrees/silly-penguin"),
+        );
+        assert_eq!(p, "/tmp/repo/.verun/worktrees/silly-penguin/.verun.json");
     }
 
     #[test]

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -10,7 +10,7 @@ import {
 import { setShowSettings, setSelectedTaskId, setSelectedSessionId, defaultWrapLines, setDefaultWrapLinesAndPersist, defaultHideWhitespace, setDefaultHideWhitespaceAndPersist, sidebarWidth } from '../store/ui'
 import { notificationsEnabled, setNotificationsEnabledAndPersist } from '../lib/notifications'
 import { projects, updateHooks, updateStoreHooks, updateBaseBranch } from '../store/projects'
-import { createTask, tasksForProject } from '../store/tasks'
+import { createTask, activeTasksForProject } from '../store/tasks'
 import { sendMessage, setSessions, setOutputItems } from '../store/sessions'
 import * as ipc from '../lib/ipc'
 import { Popover } from './Popover'
@@ -55,6 +55,8 @@ export const SettingsPage: Component = () => {
   const [codeFontDropdownOpen, setCodeFontDropdownOpen] = createSignal(false)
   const [uiFontCustom, setUiFontCustom] = createSignal('')
   const [codeFontCustom, setCodeFontCustom] = createSignal('')
+  const [importDropdownOpen, setImportDropdownOpen] = createSignal(false)
+  const [exportDropdownOpen, setExportDropdownOpen] = createSignal(false)
 
   // Populate edit fields from active project on mount
   const section = activeSection()
@@ -129,32 +131,29 @@ export const SettingsPage: Component = () => {
     }
   }
 
-  const handleExport = async () => {
+  const handleExport = async (taskId?: string) => {
     const p = selectedProject()
     if (!p) return
-    const projectTasks = tasksForProject(p.id)
-    if (projectTasks.length === 0) {
-      addToast('Create a task first to export config into its worktree', 'error')
-      return
-    }
     try {
-      await ipc.exportProjectConfig(p.id, projectTasks[0].id)
-      addToast('Exported .verun.json to worktree — commit it to share', 'success')
+      await ipc.exportProjectConfig(p.id, taskId)
+      const source = taskId ? 'task worktree' : 'main repo'
+      addToast(`Exported .verun.json (${source}) - commit it to share`, 'success')
     } catch (e) {
       addToast(String(e), 'error')
     }
   }
 
-  const handleImport = async () => {
+  const handleImport = async (taskId?: string) => {
     const p = selectedProject()
     if (!p) return
     try {
-      const hooks = await ipc.importProjectConfig(p.id)
+      const hooks = await ipc.importProjectConfig(p.id, taskId)
       updateStoreHooks(p.id, hooks.setupHook, hooks.destroyHook, hooks.startCommand)
       setEditSetupHook(hooks.setupHook)
       setEditDestroyHook(hooks.destroyHook)
       setEditStartCommand(hooks.startCommand)
-      addToast('Imported config from .verun.json', 'success')
+      const source = taskId ? 'task worktree' : 'main repo'
+      addToast(`Imported config from .verun.json (${source})`, 'success')
     } catch (e) {
       addToast(String(e), 'error')
     }
@@ -434,22 +433,96 @@ export const SettingsPage: Component = () => {
                 </button>
 
                 <div class="flex items-center gap-2">
-                  <button
-                    class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs bg-surface-2 border border-border hover:border-border-active text-text-muted hover:text-text-secondary transition-colors"
-                    onClick={handleImport}
-                    title="Import from .verun.json in repo"
-                  >
-                    <Download size={12} />
-                    Import
-                  </button>
-                  <button
-                    class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs bg-surface-2 border border-border hover:border-border-active text-text-muted hover:text-text-secondary transition-colors"
-                    onClick={handleExport}
-                    title="Export to .verun.json in a task worktree"
-                  >
-                    <Upload size={12} />
-                    Export
-                  </button>
+                  <div class="relative">
+                    <button
+                      class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs bg-surface-2 border border-border hover:border-border-active text-text-muted hover:text-text-secondary transition-colors"
+                      onClick={() => setImportDropdownOpen(!importDropdownOpen())}
+                      title="Import from .verun.json in the main repo or a task worktree"
+                    >
+                      <Download size={12} />
+                      Import
+                      <ChevronDown size={12} class="text-text-dim" />
+                    </button>
+                    <Popover
+                      open={importDropdownOpen()}
+                      onClose={() => setImportDropdownOpen(false)}
+                      class="py-1 max-h-64 overflow-y-auto w-56 absolute right-0 bottom-full mb-1 bg-surface-2 border-border-active"
+                    >
+                      <button
+                        class="w-full flex items-center gap-2.5 px-3 py-1.5 text-xs text-text-secondary hover:bg-surface-3 transition-colors"
+                        onClick={() => {
+                          setImportDropdownOpen(false)
+                          handleImport()
+                        }}
+                      >
+                        <FolderGit2 size={13} class="shrink-0" />
+                        <span class="truncate" title={selectedProject()?.repoPath}>Main repo</span>
+                      </button>
+                      <Show when={activeTasksForProject(selectedProject()?.id ?? '').length > 0}>
+                        <div class="border-t border-border-subtle my-1" />
+                        <div class="px-3 py-1 text-[10px] uppercase tracking-wider text-text-dim">Tasks</div>
+                        <For each={activeTasksForProject(selectedProject()?.id ?? '')}>
+                          {(t) => (
+                            <button
+                              class="w-full flex items-center gap-2.5 px-3 py-1.5 text-xs text-text-secondary hover:bg-surface-3 transition-colors"
+                              onClick={() => {
+                                setImportDropdownOpen(false)
+                                handleImport(t.id)
+                              }}
+                            >
+                              <GitBranch size={13} class="shrink-0" />
+                              <span class="truncate" title={t.worktreePath}>{t.name ?? t.branch}</span>
+                            </button>
+                          )}
+                        </For>
+                      </Show>
+                    </Popover>
+                  </div>
+                  <div class="relative">
+                    <button
+                      class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs bg-surface-2 border border-border hover:border-border-active text-text-muted hover:text-text-secondary transition-colors"
+                      onClick={() => setExportDropdownOpen(!exportDropdownOpen())}
+                      title="Export to .verun.json in the main repo or a task worktree"
+                    >
+                      <Upload size={12} />
+                      Export
+                      <ChevronDown size={12} class="text-text-dim" />
+                    </button>
+                    <Popover
+                      open={exportDropdownOpen()}
+                      onClose={() => setExportDropdownOpen(false)}
+                      class="py-1 max-h-64 overflow-y-auto w-56 absolute right-0 bottom-full mb-1 bg-surface-2 border-border-active"
+                    >
+                      <button
+                        class="w-full flex items-center gap-2.5 px-3 py-1.5 text-xs text-text-secondary hover:bg-surface-3 transition-colors"
+                        onClick={() => {
+                          setExportDropdownOpen(false)
+                          handleExport()
+                        }}
+                      >
+                        <FolderGit2 size={13} class="shrink-0" />
+                        <span class="truncate" title={selectedProject()?.repoPath}>Main repo</span>
+                      </button>
+                      <Show when={activeTasksForProject(selectedProject()?.id ?? '').length > 0}>
+                        <div class="border-t border-border-subtle my-1" />
+                        <div class="px-3 py-1 text-[10px] uppercase tracking-wider text-text-dim">Tasks</div>
+                        <For each={activeTasksForProject(selectedProject()?.id ?? '')}>
+                          {(t) => (
+                            <button
+                              class="w-full flex items-center gap-2.5 px-3 py-1.5 text-xs text-text-secondary hover:bg-surface-3 transition-colors"
+                              onClick={() => {
+                                setExportDropdownOpen(false)
+                                handleExport(t.id)
+                              }}
+                            >
+                              <GitBranch size={13} class="shrink-0" />
+                              <span class="truncate" title={t.worktreePath}>{t.name ?? t.branch}</span>
+                            </button>
+                          )}
+                        </For>
+                      </Show>
+                    </Popover>
+                  </div>
                 </div>
               </div>
             </div>

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -24,11 +24,11 @@ export const updateProjectHooks = (id: string, setupHook: string, destroyHook: s
 export const updateProjectDefaultAgent = (id: string, defaultAgentType: string) =>
   invoke<void>('update_project_default_agent', { id, defaultAgentType })
 
-export const exportProjectConfig = (projectId: string, taskId: string) =>
-  invoke<void>('export_project_config', { projectId, taskId })
+export const exportProjectConfig = (projectId: string, taskId?: string) =>
+  invoke<void>('export_project_config', { projectId, taskId: taskId ?? null })
 
-export const importProjectConfig = (projectId: string) =>
-  invoke<{ setupHook: string; destroyHook: string; startCommand: string }>('import_project_config', { projectId })
+export const importProjectConfig = (projectId: string, taskId?: string) =>
+  invoke<{ setupHook: string; destroyHook: string; startCommand: string }>('import_project_config', { projectId, taskId: taskId ?? null })
 
 // Tasks
 export const createTask = (projectId: string, baseBranch?: string, agentType?: AgentType) =>


### PR DESCRIPTION
## Summary

- Import and Export `.verun.json` in project settings now show a dropdown to pick the location: **Main repo** or any active task's worktree
- Previously, import always read from the project root and export always wrote to the first task with no selection
- Archived tasks are excluded from the picker

## Changes

- `export_project_config` and `import_project_config` Tauri commands accept an optional `task_id`; omitting it targets the project repo root
- Shared `resolve_config_path` helper drives both commands (tested with 2 unit tests)
- `exportProjectConfig` / `importProjectConfig` IPC wrappers updated to pass optional `taskId`
- Both buttons replaced with chevron dropdowns listing Main repo + active tasks

## Test plan

- [ ] Import with no tasks: only "Main repo" appears; imports from repo root
- [ ] Import with tasks: task list appears; selecting one imports from its worktree
- [ ] Export with no tasks: only "Main repo" appears; writes to repo root
- [ ] Export with tasks: selecting a task writes to its worktree
- [ ] Archived tasks do not appear in either picker
- [ ] `cargo test --lib ipc::tests::resolve_config_path` passes