### PR TITLE
fix: light-mode support for inputs, palettes, and breadcrumb dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Import/Export `.verun.json` now let you pick the location: the main repo or any task's worktree (previously import always read from main repo and export always wrote to the first task)
+- Fix light-mode regressions: hook textareas (Settings + Add Project dialog), Cmd+P file picker, `>` command palette, and breadcrumb dropdown no longer bake in dark-theme hex colors - they now follow the active theme palette
 - Trust level changes apply mid-run: editing the policy during an in-flight turn now takes effect on the next tool-approval check instead of waiting for the next send_message
 - Task switching stays responsive across large workspaces by virtualizing diagnostics and source-control lists, caching chat block rebuilds, and avoiding repeated full-list scans in the file tree, tabs, and sidebar
 - `+` menu now surfaces closed sessions for the task under a "Recent" section - click one to restore it as a tab with full transcript replay; `+` button sticks to the left edge while the tab bar scrolls horizontally (#100)

--- a/src/components/BreadcrumbBar.tsx
+++ b/src/components/BreadcrumbBar.tsx
@@ -68,8 +68,8 @@ function TreeNode(props: {
         data-current={isCurrent()}
         class="w-full flex items-center gap-1 py-0.5 text-[12px] text-left transition-colors"
         classList={{
-          'bg-[#2c313a] text-text-secondary': isCurrent(),
-          'text-[#abb2bf] hover:bg-[#2c313a]': !isCurrent(),
+          'bg-surface-3 text-text-primary': isCurrent(),
+          'text-text-secondary hover:bg-surface-3': !isCurrent(),
         }}
         style={{ 'padding-left': `${props.depth * 16 + 8}px`, 'padding-right': '12px' }}
         onClick={handleClick}
@@ -211,7 +211,7 @@ export const BreadcrumbBar: Component<{
               class="bc-seg shrink-0 hover:text-text-secondary cursor-pointer rounded px-0.5 transition-colors"
               classList={{
                 'text-text-secondary': i() === parts().length - 1,
-                'bg-[#2c313a]': openIdx() === i(),
+                'bg-surface-3': openIdx() === i(),
               }}
               onClick={(e) => openDropdown(i(), e.currentTarget)}
             >
@@ -224,11 +224,10 @@ export const BreadcrumbBar: Component<{
       <Show when={openIdx() >= 0}>
         <div
           ref={(el) => { dropRef = el; scrollToCurrent(el) }}
-          class="fixed z-100 bg-[#21252b] border border-[#181a1f] rounded-lg py-1 min-w-56 max-h-80 overflow-y-auto"
+          class="fixed z-100 bg-surface-2 ring-1 ring-outline/8 shadow-2xl rounded-lg py-1 min-w-56 max-h-80 overflow-y-auto"
           style={{
             left: `${dropPos().left}px`,
             top: `${dropPos().top}px`,
-            'box-shadow': '0 6px 24px rgba(0,0,0,0.5)',
           }}
         >
           <For each={entries()}>

--- a/src/components/CodeTextarea.tsx
+++ b/src/components/CodeTextarea.tsx
@@ -39,7 +39,7 @@ export const CodeTextarea: Component<Props> = (props) => {
   return (
     <textarea
       ref={textareaRef}
-      class="w-full px-3 py-2 rounded-lg bg-[#0d1117] border border-[#30363d] text-[13px] text-[#c9d1d9] placeholder:text-[#484f58] focus:outline-none focus:border-[#58a6ff] resize-none font-mono leading-5"
+      class="w-full px-3 py-2 rounded-lg bg-surface-1 ring-1 ring-outline/8 text-[13px] text-text-secondary placeholder:text-text-dim focus:outline-none focus:ring-accent/40 resize-none font-mono leading-5"
       placeholder={props.placeholder}
       value={props.value}
       onInput={(e) => {

--- a/src/components/GlobalCommandPalette.tsx
+++ b/src/components/GlobalCommandPalette.tsx
@@ -114,15 +114,12 @@ export const GlobalCommandPalette: Component = () => {
         class="fixed inset-0 z-200 bg-black/50 flex items-start justify-center pt-[15vh]"
         onClick={(e) => { if (e.target === e.currentTarget) close() }}
       >
-        <div
-          class="w-[520px] max-h-[340px] bg-[#21252b] border border-[#181a1f] rounded-lg overflow-hidden flex flex-col"
-          style={{ 'box-shadow': '0 8px 32px rgba(0,0,0,0.6)' }}
-        >
-          <div class="flex items-center gap-2 px-3 py-2.5 border-b border-[#181a1f]">
-            <span class="text-[#5c6370] text-[13px] shrink-0">&gt;</span>
+        <div class="w-[520px] max-h-[340px] bg-surface-2 ring-1 ring-outline/8 rounded-lg shadow-2xl overflow-hidden flex flex-col">
+          <div class="flex items-center gap-2 px-3 py-2.5 border-b border-border">
+            <span class="text-text-muted text-[13px] shrink-0">&gt;</span>
             <input
               ref={inputRef}
-              class="flex-1 bg-transparent text-[#abb2bf] text-[13px] outline-none placeholder-[#5c6370]"
+              class="flex-1 bg-transparent text-text-primary text-[13px] outline-none placeholder-text-dim"
               placeholder="Type a command..."
               value={query()}
               onInput={(e) => setQuery(e.currentTarget.value)}
@@ -138,7 +135,7 @@ export const GlobalCommandPalette: Component = () => {
             <Show
               when={filtered().length > 0}
               fallback={
-                <div class="px-4 py-8 text-center text-[#5c6370] text-xs">
+                <div class="px-4 py-8 text-center text-text-dim text-xs">
                   No commands match
                 </div>
               }
@@ -148,8 +145,8 @@ export const GlobalCommandPalette: Component = () => {
                   <button
                     class={`w-full flex items-center justify-between px-3 py-2 text-left transition-colors ${
                       i() === selectedIndex()
-                        ? 'bg-[#2c313a] text-[#abb2bf]'
-                        : 'text-[#7f848e] hover:bg-[#2c313a]/50'
+                        ? 'bg-surface-3 text-text-primary'
+                        : 'text-text-secondary hover:bg-surface-3/50'
                     }`}
                     onClick={() => {
                       setSelectedIndex(i())
@@ -159,7 +156,7 @@ export const GlobalCommandPalette: Component = () => {
                   >
                     <span class="text-[12px]">{cmd.label}</span>
                     <Show when={cmd.detail}>
-                      <span class="text-[11px] text-[#5c6370] ml-4 shrink-0">{cmd.detail}</span>
+                      <span class="text-[11px] text-text-dim ml-4 shrink-0">{cmd.detail}</span>
                     </Show>
                   </button>
                 )}

--- a/src/components/QuickOpen.tsx
+++ b/src/components/QuickOpen.tsx
@@ -241,16 +241,13 @@ export const QuickOpen: Component = () => {
         class="quick-open-backdrop fixed inset-0 z-200 bg-black/50 flex items-start justify-center pt-[15vh]"
         onClick={handleBackdropClick}
       >
-        <div
-          class="w-[520px] max-h-[400px] bg-[#21252b] border border-[#181a1f] rounded-lg overflow-hidden flex flex-col"
-          style={{ 'box-shadow': '0 8px 32px rgba(0,0,0,0.6)' }}
-        >
+        <div class="w-[520px] max-h-[400px] bg-surface-2 ring-1 ring-outline/8 rounded-lg shadow-2xl overflow-hidden flex flex-col">
           {/* Search input */}
-          <div class="flex items-center gap-2 px-3 py-2.5 border-b border-[#181a1f]">
-            <Search size={14} class="text-[#5c6370] shrink-0" />
+          <div class="flex items-center gap-2 px-3 py-2.5 border-b border-border">
+            <Search size={14} class="text-text-muted shrink-0" />
             <input
               ref={inputRef}
-              class="flex-1 bg-transparent text-[#abb2bf] text-[13px] outline-none placeholder-[#5c6370]"
+              class="flex-1 bg-transparent text-text-primary text-[13px] outline-none placeholder-text-dim"
               placeholder="Search files by name..."
               value={query()}
               onInput={(e) => setQuery(e.currentTarget.value)}
@@ -267,7 +264,7 @@ export const QuickOpen: Component = () => {
             <Show
               when={filtered().length > 0}
               fallback={
-                <div class="px-4 py-8 text-center text-[#5c6370] text-xs">
+                <div class="px-4 py-8 text-center text-text-dim text-xs">
                   {query() ? 'No files match your search' : 'No files found'}
                 </div>
               }
@@ -305,8 +302,8 @@ export const QuickOpen: Component = () => {
                         <div
                           class={`w-full flex items-center gap-2 px-3 py-1 transition-colors ${
                             isSelected()
-                              ? 'bg-[#2c313a] text-[#abb2bf]'
-                              : 'text-[#7f848e] hover:bg-[#2c313a]/50'
+                              ? 'bg-surface-3 text-text-primary'
+                              : 'text-text-secondary hover:bg-surface-3/50'
                           }`}
                           onMouseEnter={() => setSelectedIndex(virtualRow.index)}
                         >
@@ -319,15 +316,15 @@ export const QuickOpen: Component = () => {
                           >
                             {(() => { const I = getFileIcon(name()); return <I size={14} class="shrink-0" /> })()}
                             <span class="text-[12px] truncate">
-                              <span class={isSelected() ? 'text-[#abb2bf]' : 'text-[#abb2bf]/80'}>{name()}</span>
+                              <span class={isSelected() ? 'text-text-primary' : 'text-text-secondary'}>{name()}</span>
                               <Show when={dir()}>
-                                <span class="text-[#5c6370] ml-2">{dir()}</span>
+                                <span class="text-text-dim ml-2">{dir()}</span>
                               </Show>
                             </span>
                           </button>
                           <Show when={result()?.isRecent}>
                             <button
-                              class="shrink-0 p-1 rounded text-[#5c6370] hover:text-[#abb2bf] hover:bg-[#3a404b]"
+                              class="shrink-0 p-1 rounded text-text-dim hover:text-text-primary hover:bg-surface-3"
                               onClick={(e) => handleRemoveRecent(path(), e)}
                               aria-label={`Remove ${path()} from recent files`}
                               title="Remove from recent files"


### PR DESCRIPTION
## Summary

- Replaces hardcoded OneDark/GitHub-dark hex colors with semantic theme tokens across four components, fixing black-looking inputs and surfaces in light mode
- Import/Export `.verun.json` now let you pick the location: main repo or any active task's worktree (archived tasks excluded)

## Changes

### Light-mode fixes
- **`CodeTextarea`** — hook textareas in Settings and Add Project dialog now use `bg-surface-1 ring-outline/8 text-text-secondary` instead of hardcoded `#0d1117` / `#c9d1d9`
- **`QuickOpen`** (Cmd+P file picker) — container, input, results rows, and recent-remove button converted to surface/text tokens
- **`GlobalCommandPalette`** (`>` palette) — same treatment as QuickOpen
- **`BreadcrumbBar`** — file-tree dropdown and active-segment highlight replaced with `bg-surface-{2,3}` / `text-text-{primary,secondary}`

### Import/Export improvements
- Both buttons are now dropdowns listing **Main repo** and each active task's worktree
- Backend `export_project_config` / `import_project_config` accept an optional `task_id`; omitting it targets the repo root
- Shared `resolve_config_path` helper with 2 unit tests

## Test plan

- [ ] Light mode: hook textareas in Settings and Add Project dialog are readable (not black)
- [ ] Light mode: Cmd+P file picker background and text are correct
- [ ] Light mode: `>` command palette is correct
- [ ] Light mode: breadcrumb dropdown is correct
- [ ] Dark mode: all of the above still look correct
- [ ] Import dropdown shows Main repo + active tasks (no archived tasks)
- [ ] Export dropdown shows Main repo + active tasks (no archived tasks)
- [ ] Importing from a task worktree reads that worktree's `.verun.json`
- [ ] Exporting to main repo writes to the repo root