### PR TITLE
fix: steer (cmd+enter) no longer races the interrupt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix steer (cmd+enter while busy) silently failing: the inline abort+send raced the in-flight interrupt and hit Rust's busy guard, leaving Claude running while the UI flipped to idle; steer now queues the new message as an armed step and lets the `session-aborted` listener dispatch it after graceful shutdown
 - Import/Export `.verun.json` now let you pick the location: the main repo or any task's worktree (previously import always read from main repo and export always wrote to the first task)
 - Fix light-mode regressions: hook textareas (Settings + Add Project dialog), Cmd+P file picker, `>` command palette, and breadcrumb dropdown no longer bake in dark-theme hex colors - they now follow the active theme palette
 - Trust level changes apply mid-run: editing the policy during an in-flight turn now takes effect on the next tool-approval check instead of waiting for the next send_message

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -1,5 +1,5 @@
 import { Component, createSignal, createEffect, on, Show, For, onMount, onCleanup } from 'solid-js'
-import { sendMessage, abortMessage, createSession, clearOutputItems, pendingApprovals, approveToolUse, denyToolUse, answerQuestion, sessionCosts, sessionTokens, rateLimitInfo, outputItems, tryDrainSteps, sessionById, updateSessionModel } from '../store/sessions'
+import { sendMessage, abortMessage, steerSession, createSession, clearOutputItems, pendingApprovals, approveToolUse, denyToolUse, answerQuestion, sessionCosts, sessionTokens, rateLimitInfo, outputItems, tryDrainSteps, sessionById, updateSessionModel } from '../store/sessions'
 import { planModeForSession, setPlanModeForSession, thinkingModeForSession, setThinkingModeForSession, fastModeForSession, setFastModeForSession, planFilePathForSession, setPlanFilePathForSession } from '../store/sessionContext'
 import { setSelectedSessionId, selectedTaskId, chatPrefillRequest, setChatPrefillRequest } from '../store/ui'
 import { isSetupRunning, queueMessage, queuedMessages, clearQueuedMessage } from '../store/setup'
@@ -947,8 +947,7 @@ export const MessageInput: Component<Props> = (props) => {
     setShowPalette(false)
     setSending(true)
     try {
-      await abortMessage(sid)
-      await sendMessage(sid, msg, atts.length > 0 ? atts : undefined, currentModel(), planMode(), thinkingMode(), fastMode())
+      await steerSession(sid, msg, atts.length > 0 ? atts : undefined, currentModel(), planMode(), thinkingMode(), fastMode())
     } catch (e) {
       console.error('Failed to steer:', e)
     } finally {

--- a/src/store/sessions.steer.test.ts
+++ b/src/store/sessions.steer.test.ts
@@ -1,0 +1,125 @@
+import { describe, test, expect, beforeAll, beforeEach, vi } from 'vitest'
+import { produce } from 'solid-js/store'
+
+type Listener = (event: { payload: unknown }) => void
+const listeners = new Map<string, Listener[]>()
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn((name: string, cb: Listener) => {
+    const arr = listeners.get(name) || []
+    arr.push(cb)
+    listeners.set(name, arr)
+    return Promise.resolve(() => {})
+  }),
+  emit: vi.fn(() => Promise.resolve()),
+}))
+
+vi.mock('../lib/ipc', () => ({
+  listSteps: vi.fn().mockResolvedValue([]),
+  addStep: vi.fn().mockResolvedValue(undefined),
+  updateStep: vi.fn().mockResolvedValue(undefined),
+  deleteStep: vi.fn().mockResolvedValue(undefined),
+  reorderSteps: vi.fn().mockResolvedValue(undefined),
+  disarmAllSteps: vi.fn().mockResolvedValue(undefined),
+  abortMessage: vi.fn().mockResolvedValue(undefined),
+  sendMessage: vi.fn().mockResolvedValue(undefined),
+  getPendingApprovals: vi.fn().mockResolvedValue([]),
+}))
+
+vi.mock('../lib/notifications', () => ({ notify: vi.fn() }))
+vi.mock('../lib/binary', () => ({
+  deserializeAttachments: vi.fn(() => undefined),
+  serializeAttachments: vi.fn(() => null),
+}))
+vi.mock('./tasks', () => ({
+  setTasks: vi.fn(),
+  taskById: vi.fn(() => ({ name: 'test-task' })),
+}))
+vi.mock('./ui', () => ({
+  markTaskUnread: vi.fn(),
+  markTaskAttention: vi.fn(),
+  clearTaskAttention: vi.fn(),
+  markSessionUnread: vi.fn(),
+}))
+
+import {
+  setSessions,
+  setOutputItems,
+  setAbortingSessions,
+  steerSession,
+  initSessionListeners,
+} from './sessions'
+import { clearSteps, getSteps } from './steps'
+import * as ipc from '../lib/ipc'
+import type { Session } from '../types'
+
+const SID = 's-steer-001'
+
+const makeSession = (overrides: Partial<Session> = {}): Session => ({
+  id: SID,
+  taskId: 't-001',
+  name: null,
+  resumeSessionId: null,
+  status: 'running',
+  startedAt: 1000,
+  endedAt: null,
+  totalCost: 0,
+  parentSessionId: null,
+  forkedAtMessageUuid: null,
+  agentType: 'claude' as const,
+  model: null,
+  closedAt: null,
+  ...overrides,
+})
+
+function fire(name: string, payload: unknown) {
+  const arr = listeners.get(name) || []
+  for (const cb of arr) cb({ payload })
+}
+
+describe('steerSession', () => {
+  beforeAll(async () => {
+    await initSessionListeners()
+  })
+
+  beforeEach(() => {
+    setSessions([])
+    setOutputItems(produce(store => { delete store[SID] }))
+    setAbortingSessions(produce(store => { delete store[SID] }))
+    clearSteps(SID)
+    vi.clearAllMocks()
+  })
+
+  test('queues an armed step and then aborts — does not sendMessage directly', async () => {
+    // Regression: handleSteer used to call abortMessage then immediately
+    // sendMessage. The second call raced the in-flight interrupt and hit
+    // Rust's busy guard (task.rs "Session is already processing a message"),
+    // silently failing. Claude kept running, UI flipped to idle — classic
+    // desync. The fix: queue an armed step so the session-aborted listener
+    // drains it after graceful shutdown completes.
+    setSessions([makeSession({ status: 'running' })])
+
+    await steerSession(SID, 'new direction', undefined, 'sonnet', false, false, false)
+
+    expect(ipc.abortMessage).toHaveBeenCalledWith(SID)
+    expect(ipc.sendMessage).not.toHaveBeenCalled()
+    const steps = getSteps(SID)
+    expect(steps.length).toBe(1)
+    expect(steps[0].armed).toBe(true)
+    expect(steps[0].message).toBe('new direction')
+    expect(steps[0].model).toBe('sonnet')
+  })
+
+  test('armed step drains via session-aborted listener after graceful shutdown', async () => {
+    setSessions([makeSession({ status: 'running' })])
+
+    await steerSession(SID, 'steered message', undefined, undefined, false, false, false)
+    // Backend signals graceful shutdown finished — drain should now fire.
+    fire('session-status', { sessionId: SID, status: 'idle' })
+    fire('session-aborted', SID)
+
+    expect(getSteps(SID).length).toBe(0)
+    expect(ipc.sendMessage).toHaveBeenCalledTimes(1)
+    expect(ipc.sendMessage).toHaveBeenCalledWith(SID, 'steered message', undefined, undefined, false, false, false)
+  })
+})

--- a/src/store/sessions.ts
+++ b/src/store/sessions.ts
@@ -4,7 +4,7 @@ import { listen } from '@tauri-apps/api/event'
 import type { Session, SessionOutputEvent, SessionStatusEvent, OutputItem, Attachment, ToolApprovalRequest, PolicyAutoApprovedEvent, RateLimitInfo } from '../types'
 import { setTasks, taskById } from './tasks'
 import { markTaskUnread, markTaskAttention, clearTaskAttention, markSessionUnread } from './ui'
-import { dequeueArmedStep, disarmAllSteps, clearSteps } from './steps'
+import { addStep, dequeueArmedStep, disarmAllSteps, clearSteps } from './steps'
 import * as ipc from '../lib/ipc'
 import { notify } from '../lib/notifications'
 import { deserializeAttachments } from '../lib/binary'
@@ -108,6 +108,23 @@ export async function abortMessage(sessionId: string) {
     setSessions(s => s.id === sessionId, 'status', 'running')
     throw e
   }
+}
+
+/// Steer: queue the new message as an armed step, then abort the current turn.
+/// session-aborted fires once graceful shutdown is done, and its listener
+/// drains the armed step. Sending inline races the interrupt and hits Rust's
+/// busy guard, which silently fails and leaves the UI desynced.
+export async function steerSession(
+  sessionId: string,
+  message: string,
+  attachments: Attachment[] | undefined,
+  model: string | undefined,
+  planMode: boolean | undefined,
+  thinkingMode: boolean | undefined,
+  fastMode: boolean | undefined,
+) {
+  addStep({ sessionId, message, attachments, armed: true, model, planMode, thinkingMode, fastMode })
+  await abortMessage(sessionId)
 }
 
 export async function approveToolUse(requestId: string, sessionId: string) {


### PR DESCRIPTION
## Summary

- \`handleSteer\` did \`abortMessage\` then immediately \`sendMessage\`; the second call raced the in-flight interrupt and hit Rust's busy guard in \`task.rs\`, silently failing. Claude kept running while the UI flipped to idle.
- New \`steerSession\` helper queues the message as an armed step, then aborts. The \`session-aborted\` listener drains the step after graceful shutdown, which is the correct sequencing.

## Test plan

- [x] \`pnpm test\` - 239 passed (new \`sessions.steer.test.ts\` covers queue order + drain)
- [x] \`cargo clippy -- -D warnings\` clean
- [x] \`cargo test\` - 349 passed
- [ ] Manual: steer mid-turn in \`pnpm tauri dev\`, confirm UI + Claude stay in sync and the new message actually sends