### PR TITLE
fix(ci): fix release builds for Linux, Windows, and macOS Intel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,7 @@ jobs:
   build-macos-intel:
     needs: check-version
     if: needs.check-version.outputs.should_release == 'true'
-    runs-on: macos-26
+    runs-on: macos-15-intel
     steps:
       - uses: actions/checkout@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix release CI: macOS Intel now builds on `macos-15-intel` (the plugin's Swift bundle doesn't cross-compile from the arm `macos-26` runner); Linux and Windows re-enable the `notify-rust` fallback in `tauri-plugin-notifications` since they have no native branch
+
 ## 0.9.0 - 2026-04-23
 
 ### Codex (OpenAI) support lands

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,7 +19,6 @@ tauri-plugin-shell = "2"
 tauri-plugin-sql = { version = "2", features = ["sqlite"] }
 tauri-plugin-fs = "2"
 tauri-plugin-dialog = "2"
-tauri-plugin-notifications = { version = "0.4", default-features = false }
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
 tokio = { version = "1", features = ["full"] }
@@ -37,6 +36,18 @@ grep-matcher = "0.1"
 notify = "7"
 notify-debouncer-mini = "0.5"
 yash-syntax = "0.19"
+
+# macOS: native UNUserNotificationCenter (click routing + Notification Center clearing).
+# The plugin's build.rs invokes `swift build` with no --arch flag, so Swift compiles for the
+# host CPU only — the Intel build therefore has to run on an actual Intel runner
+# (`macos-15-intel`) rather than cross-compiling from `macos-26` (arm).
+#
+# Linux / Windows: the plugin has no native branch without `notify-rust`, so we enable it.
+[target.'cfg(target_os = "macos")'.dependencies]
+tauri-plugin-notifications = { version = "0.4", default-features = false }
+
+[target.'cfg(not(target_os = "macos"))'.dependencies]
+tauri-plugin-notifications = { version = "0.4", default-features = false, features = ["notify-rust"] }
 
 [dev-dependencies]
 rstest = "0.18"


### PR DESCRIPTION
## Problem

After #189 (commit 565e57d) switched `tauri-plugin-notifications` to `default-features = false` for the native macOS backend, three platforms broke in the v0.9.0 release CI:

**Linux / Windows** — E0412/E0425 compile errors. The plugin only exports `Notifications` via one of three cfg gates: `notify-rust` feature (desktop), native macOS (without notify-rust), or mobile. Without `notify-rust`, Linux and Windows have no matching branch at all.

**macOS Intel** — Swift linker failure: `found architecture 'arm64', required architecture 'x86_64'`. The plugin's `build.rs` invokes `swift build` with no `--arch` flag, so the Swift bundle always compiles for the build host's CPU. The `build-macos-intel` job was running on `macos-26` (Apple Silicon), so the resulting `.a` was arm64 and couldn't link into the x86_64 binary.

## Fix

**`src-tauri/Cargo.toml`** — Split `tauri-plugin-notifications` into target-conditional sections:
- `cfg(target_os = "macos")` → `default-features = false` (native `UNUserNotificationCenter`)
- `cfg(not(target_os = "macos"))` → add `features = ["notify-rust"]` (the only available backend on Linux/Windows)

**`.github/workflows/release.yml`** — Switch `build-macos-intel` from `macos-26` to `macos-15-intel` so `swift build` runs natively on x86_64. (`macos-13` was fully deprecated Dec 2025; `macos-15-intel` is the current Intel image, available through Aug 2027 per [runner-images#13045](https://github.com/actions/runner-images/issues/13045).)

Both macOS ARM and Intel retain the native click-routing + Notification Center clearing added in 565e57d.

## Testing

- `cargo check` (arm macOS) ✓
- `cargo check --target x86_64-apple-darwin` ✓ (no Swift link step in check, but correct feature resolution confirmed)
- `cargo check -p tauri-plugin-notifications --target x86_64-pc-windows-msvc` ✓ (resolves via notify-rust)