### PR TITLE
fix: avoid EMFILE on new task creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix "Task setup failed: Too many open files" on new-task creation — raise `RLIMIT_NOFILE` at startup and only fetch sessions/git/watcher for newly-added tasks in the sidebar effect instead of re-fanning out across every existing task on each insert
 - Fix release CI: macOS Intel now builds on `macos-15-intel` (the plugin's Swift bundle doesn't cross-compile from the arm `macos-26` runner); Linux and Windows re-enable the `notify-rust` fallback in `tauri-plugin-notifications` since they have no native branch
 
 ## 0.9.0 - 2026-04-23

--- a/src-tauri/src/fd_limit.rs
+++ b/src-tauri/src/fd_limit.rs
@@ -1,0 +1,99 @@
+//! Raise the process's open-file soft limit at startup.
+//!
+//! macOS ships with a default `RLIMIT_NOFILE` soft limit of 256, which is
+//! trivially exhausted once several tasks are open: each holds an LSP child,
+//! a codex app-server child (3 piped FDs per session since the 0.9 migration),
+//! one or more PTYs, and a notify watcher. Adding a burst of `git` subprocess
+//! spawns on top of that (e.g. the sidebar's per-task git refresh fanning
+//! out when a task is added) reliably hits EMFILE. Bumping the soft limit to
+//! something well above normal usage costs nothing and removes the ceiling.
+
+use std::io;
+
+/// Raise the `RLIMIT_NOFILE` soft limit to `min(desired, hard_limit)` when it
+/// is currently below that. Returns `(previous_soft, new_soft)`.
+#[cfg(unix)]
+pub fn raise_fd_limit_to(desired: u64) -> io::Result<(u64, u64)> {
+    let mut rlim = libc::rlimit {
+        rlim_cur: 0,
+        rlim_max: 0,
+    };
+    let got = unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut rlim) };
+    if got != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let prev_soft = rlim.rlim_cur;
+    let hard = rlim.rlim_max;
+    let target = desired.min(hard);
+    if target <= prev_soft {
+        return Ok((prev_soft, prev_soft));
+    }
+    rlim.rlim_cur = target;
+    let set = unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, &rlim) };
+    if set != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok((prev_soft, target))
+}
+
+/// Default target used by `lib.rs` at startup. 8192 is well above what any
+/// realistic verun usage needs but below macOS's typical hard limit.
+pub const DEFAULT_TARGET: u64 = 8192;
+
+#[cfg(unix)]
+pub fn raise_fd_limit() -> io::Result<(u64, u64)> {
+    raise_fd_limit_to(DEFAULT_TARGET)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn current_soft() -> u64 {
+        let mut rlim = libc::rlimit {
+            rlim_cur: 0,
+            rlim_max: 0,
+        };
+        let rc = unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut rlim) };
+        assert_eq!(rc, 0);
+        rlim.rlim_cur
+    }
+
+    fn current_hard() -> u64 {
+        let mut rlim = libc::rlimit {
+            rlim_cur: 0,
+            rlim_max: 0,
+        };
+        let rc = unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut rlim) };
+        assert_eq!(rc, 0);
+        rlim.rlim_max
+    }
+
+    #[test]
+    fn raises_soft_limit_to_desired_when_below_hard() {
+        let hard = current_hard();
+        let target = 4096u64.min(hard);
+        let (_prev, new_soft) = raise_fd_limit_to(target).expect("setrlimit failed");
+        assert!(new_soft >= target, "new_soft={new_soft} < target={target}");
+        assert!(current_soft() >= target);
+    }
+
+    #[test]
+    fn caps_at_hard_limit() {
+        let hard = current_hard();
+        // Ask for more than the hard limit — result must not exceed hard.
+        let (_prev, new_soft) = raise_fd_limit_to(hard.saturating_add(1_000_000))
+            .expect("setrlimit failed");
+        assert!(new_soft <= hard, "new_soft={new_soft} > hard={hard}");
+    }
+
+    #[test]
+    fn idempotent_when_already_above_desired() {
+        // Raise once, then ask for less — should be a no-op, prev == new.
+        let hard = current_hard();
+        let high = 4096u64.min(hard);
+        let _ = raise_fd_limit_to(high).expect("first raise failed");
+        let (prev, new) = raise_fd_limit_to(256).expect("second raise failed");
+        assert_eq!(prev, new, "expected no-op when desired <= current soft");
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ pub mod agent;
 mod claude_jsonl;
 mod db;
 mod env_path;
+mod fd_limit;
 mod file_search;
 mod git_ops;
 mod github;
@@ -29,6 +30,20 @@ pub type WindowTaskMap = DashMap<String, String>;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // macOS defaults RLIMIT_NOFILE soft to 256. With multiple tasks each
+    // holding LSP + codex app-server + PTY + watcher FDs, a burst of
+    // concurrent `git` spawns (e.g. sidebar refresh when a task is added)
+    // trips EMFILE on `git check-ref-format` inside `create_task`. Raise
+    // the ceiling before any subprocess work begins.
+    #[cfg(unix)]
+    match fd_limit::raise_fd_limit() {
+        Ok((prev, new)) if new > prev => {
+            eprintln!("[verun] raised RLIMIT_NOFILE: {prev} -> {new}");
+        }
+        Ok(_) => {}
+        Err(e) => eprintln!("[verun] failed to raise RLIMIT_NOFILE: {e}"),
+    }
+
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_shell::init())

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -12,6 +12,7 @@ import {
   onCleanup,
 } from "solid-js";
 import { taskGit, refreshTaskGit } from "../store/git";
+import { newTaskIds } from "../lib/taskDiff";
 import { projects } from "../store/projects";
 import {
   tasks,
@@ -248,15 +249,19 @@ export const Sidebar: Component = () => {
     ),
   );
 
-  // Load sessions + git state for all tasks on mount and when tasks change
+  // Load sessions + git state only for tasks that are newly in the list. A
+  // prior version re-fired the whole loop on any length change, which made a
+  // single task insert spawn ~10 git subprocesses per existing task in
+  // parallel — enough to exhaust the macOS 256 FD ceiling while
+  // `ipc.createTask` was trying to spawn its own `git check-ref-format`.
   createEffect(
     on(
-      () => tasks.length,
-      () => {
-        for (const t of tasks) {
-          loadSessions(t.id);
-          refreshTaskGit(t.id);
-          ipc.watchWorktree(t.id);
+      () => tasks.map(t => t.id),
+      (currIds, prevIds) => {
+        for (const id of newTaskIds(prevIds, currIds)) {
+          loadSessions(id);
+          refreshTaskGit(id);
+          ipc.watchWorktree(id);
         }
       },
     ),

--- a/src/lib/taskDiff.test.ts
+++ b/src/lib/taskDiff.test.ts
@@ -1,0 +1,32 @@
+import { describe, test, expect } from 'vitest'
+import { newTaskIds } from './taskDiff'
+
+describe('newTaskIds', () => {
+  test('first mount — processes every id when prev is undefined', () => {
+    expect(newTaskIds(undefined, ['a', 'b', 'c'])).toEqual(['a', 'b', 'c'])
+  })
+
+  test('no change — returns empty', () => {
+    expect(newTaskIds(['a', 'b'], ['a', 'b'])).toEqual([])
+  })
+
+  test('one added — returns only the added id', () => {
+    expect(newTaskIds(['a', 'b'], ['c', 'a', 'b'])).toEqual(['c'])
+  })
+
+  test('multiple added — returns all newcomers in current order', () => {
+    expect(newTaskIds(['a'], ['a', 'b', 'c'])).toEqual(['b', 'c'])
+  })
+
+  test('removal only — returns empty', () => {
+    expect(newTaskIds(['a', 'b', 'c'], ['a', 'b'])).toEqual([])
+  })
+
+  test('swap (placeholder id → real id) — returns only the real id', () => {
+    expect(newTaskIds(['placeholder'], ['real'])).toEqual(['real'])
+  })
+
+  test('reorder only — returns empty', () => {
+    expect(newTaskIds(['a', 'b', 'c'], ['c', 'a', 'b'])).toEqual([])
+  })
+})

--- a/src/lib/taskDiff.ts
+++ b/src/lib/taskDiff.ts
@@ -1,0 +1,15 @@
+/**
+ * Ids present in `curr` but not in `prev`. When `prev` is undefined (first run),
+ * every id in `curr` is returned. Used by the sidebar's "load per-task data"
+ * effect so a single task insert doesn't re-fire the effect for every existing
+ * task — that storm is what exhausts macOS's 256 FD limit when `ipc.createTask`
+ * is spawning `git check-ref-format` in parallel.
+ */
+export function newTaskIds(
+  prev: readonly string[] | undefined,
+  curr: readonly string[],
+): string[] {
+  if (!prev) return [...curr]
+  const prevSet = new Set(prev)
+  return curr.filter(id => !prevSet.has(id))
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -279,7 +279,6 @@ export interface PrInfo {
   body?: string
   mergeable: string
   isDraft: boolean
-  body?: string
 }
 
 export interface CiCheck {


### PR DESCRIPTION
## Summary

Fixes the regression where creating a new task in 0.9.0 reliably failed with:

> Task setup failed: Failed to validate branch name: Too many open files (os error 24)

Two complementary fixes:

- **Raise `RLIMIT_NOFILE` at startup** (256 -> 8192 on macOS). The 0.9.0 codex migration to a persistent app-server child added 3 piped FDs per session on top of the existing per-task LSP child, PTYs, and notify watchers. The 256 ceiling was trivial to exhaust.
- **Sidebar effect diffs task ids** instead of iterating every task on `tasks.length` change. Previously, clicking + Task spawned ~10 git subprocesses *per existing task* (status + branch commits + branch status, all in parallel) — the deterministic FD spike. Now only newly-added ids trigger `loadSessions` / `refreshTaskGit` / `watchWorktree`.

## Test plan

- [x] `cargo test fd_limit` — 3 new tests cover raise/cap/idempotent
- [x] `pnpm test src/lib/taskDiff.test.ts` — 7 tests cover first mount, add, multi-add, removal, swap, reorder
- [x] `make check` passes; clippy clean; no TS errors
- [x] Verified `[verun] raised RLIMIT_NOFILE: 256 -> 8192` log line at dev startup
- [x] Confirmed bug no longer reproduces in dev nor prod builds