### PR TITLE
Improve GitHub caching and Codex session plumbing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- File edits detected by the worktree watcher now trigger a debounced local git refresh, so status/commits/branch state update automatically as you change code without hitting GitHub
+- Local git refresh now uses non-locking read-only git commands, so viewing status no longer rewrites `.git/index` and self-triggers endless `git-local-changed` watcher loops
+- Successful in-chat `gh pr create/reopen/close/ready/merge` commands now invalidate GitHub overview immediately, so PR state updates without waiting for process exit or background refresh
+- Selected tasks now refresh GitHub overview at session end when an agent likely changed remote state, and dev builds show a live GitHub debug panel with cache/fetch activity
+- Session-created pull requests now trigger a scoped GitHub overview refresh when the task is already tracking remote state, so the PR badge/link appears without a manual refresh
 - GitHub sidebar/PR/Actions refresh now uses cached Rust-side snapshots with scope-based invalidation, so local git changes stop fan-out refreshing GitHub and Actions/PR data refresh only when their remote state actually changes
 
 ## 0.10.0 — 2026-04-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- GitHub sidebar/PR/Actions refresh now uses cached Rust-side snapshots with scope-based invalidation, so local git changes stop fan-out refreshing GitHub and Actions/PR data refresh only when their remote state actually changes
+
 ## 0.10.0 — 2026-04-28
 
 ### Bootstrap a new project without leaving Verun

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Pluggable agent backend with first-class support for Claude Code and Codex (plan
 - **TypeScript intellisense** - bundled tsgo with autocomplete, diagnostics, hover, go-to-definition, find references, and rename
 - **Problems panel** - project-wide type checking with click-to-navigate and one-click "ask agent to fix"
 - **Side-by-side diffs** - syntax-highlighted diffs for working-tree changes and individual commits
-- **Git workflow** - commit, push, create PR, and merge without leaving the app
+- **Git workflow** - commit, push, create PR, merge, and inspect branch-scoped GitHub Actions/PR state without leaving the app; remote refresh is cached and only invalidated when relevant GitHub state changes
 - **Integrated terminal** - drop into any task's worktree with a built-in shell
 - **File tree & Quick Open** - browse files, fuzzy-find with CMD+P, preview media and markdown inline
 - **Workspace search** - Cmd+Shift+F content search across the task's worktree with case/whole-word/regex toggles and include/exclude globs, powered by embedded ripgrep

--- a/src-tauri/src/agent/claude.rs
+++ b/src-tauri/src/agent/claude.rs
@@ -212,11 +212,7 @@ impl Agent for Claude {
         Ok(payload)
     }
 
-    fn discover_skills(
-        &self,
-        scan_root: Option<&Path>,
-        user_home: &Path,
-    ) -> Vec<AgentSkill> {
+    fn discover_skills(&self, scan_root: Option<&Path>, user_home: &Path) -> Vec<AgentSkill> {
         let mut seen: HashSet<String> = HashSet::new();
         let mut out: Vec<AgentSkill> = Vec::new();
 
@@ -303,10 +299,7 @@ mod tests {
                 )
             })
             .collect();
-        let json = format!(
-            r#"{{"version":2,"plugins":{{ {} }}}}"#,
-            entries.join(",")
-        );
+        let json = format!(r#"{{"version":2,"plugins":{{ {} }}}}"#, entries.join(","));
         fs::write(plugins_dir.join("installed_plugins.json"), json).unwrap();
     }
 
@@ -317,16 +310,28 @@ mod tests {
 
         let global_dir = home.path().join(".claude/skills");
         fs::create_dir_all(&global_dir).unwrap();
-        write_skill(&global_dir, "global-only", "---\nname: global-only\ndescription: g\n---\n");
+        write_skill(
+            &global_dir,
+            "global-only",
+            "---\nname: global-only\ndescription: g\n---\n",
+        );
 
         let project_dir = project.path().join(".claude/skills");
         fs::create_dir_all(&project_dir).unwrap();
-        write_skill(&project_dir, "project-only", "---\nname: project-only\ndescription: p\n---\n");
+        write_skill(
+            &project_dir,
+            "project-only",
+            "---\nname: project-only\ndescription: p\n---\n",
+        );
 
         let install_path = home.path().join(".claude/plugins/cache/mp/plugin-x/1.0.0");
         let plugin_skills = install_path.join("skills");
         fs::create_dir_all(&plugin_skills).unwrap();
-        write_skill(&plugin_skills, "plugin-only", "---\nname: plugin-only\ndescription: pl\n---\n");
+        write_skill(
+            &plugin_skills,
+            "plugin-only",
+            "---\nname: plugin-only\ndescription: pl\n---\n",
+        );
         write_installed_plugins(home.path(), &[&install_path]);
 
         let skills = Claude.discover_skills(Some(project.path()), home.path());
@@ -343,11 +348,19 @@ mod tests {
 
         let global_dir = home.path().join(".claude/skills");
         fs::create_dir_all(&global_dir).unwrap();
-        write_skill(&global_dir, "review", "---\nname: review\ndescription: global\n---\n");
+        write_skill(
+            &global_dir,
+            "review",
+            "---\nname: review\ndescription: global\n---\n",
+        );
 
         let project_dir = project.path().join(".claude/skills");
         fs::create_dir_all(&project_dir).unwrap();
-        write_skill(&project_dir, "review", "---\nname: review\ndescription: project override\n---\n");
+        write_skill(
+            &project_dir,
+            "review",
+            "---\nname: review\ndescription: project override\n---\n",
+        );
 
         let skills = Claude.discover_skills(Some(project.path()), home.path());
         let review: Vec<&AgentSkill> = skills.iter().filter(|s| s.name == "review").collect();
@@ -376,10 +389,16 @@ mod tests {
     #[test]
     fn plugin_scan_reads_installed_plugin_cache() {
         let home = TempDir::new().unwrap();
-        let install_path = home.path().join(".claude/plugins/cache/official/code-review/1.0.0");
+        let install_path = home
+            .path()
+            .join(".claude/plugins/cache/official/code-review/1.0.0");
         let skills_dir = install_path.join("skills");
         fs::create_dir_all(&skills_dir).unwrap();
-        write_skill(&skills_dir, "review", "---\nname: review\ndescription: PR review\n---\n");
+        write_skill(
+            &skills_dir,
+            "review",
+            "---\nname: review\ndescription: PR review\n---\n",
+        );
         write_installed_plugins(home.path(), &[&install_path]);
 
         let skills = Claude.discover_skills(None, home.path());
@@ -390,9 +409,15 @@ mod tests {
     #[test]
     fn plugin_scan_ignores_uninstalled_marketplace_entries() {
         let home = TempDir::new().unwrap();
-        let stray = home.path().join(".claude/plugins/marketplaces/official/plugins/example/skills");
+        let stray = home
+            .path()
+            .join(".claude/plugins/marketplaces/official/plugins/example/skills");
         fs::create_dir_all(&stray).unwrap();
-        write_skill(&stray, "example-skill", "---\nname: example-skill\ndescription: catalog only\n---\n");
+        write_skill(
+            &stray,
+            "example-skill",
+            "---\nname: example-skill\ndescription: catalog only\n---\n",
+        );
 
         let skills = Claude.discover_skills(None, home.path());
         assert!(skills.iter().all(|s| s.name != "example-skill"));
@@ -403,7 +428,11 @@ mod tests {
         let home = TempDir::new().unwrap();
         let project = TempDir::new().unwrap();
         let cmds_dir = project.path().join(".claude/commands");
-        write_command(&cmds_dir, "bump-version", "---\nname: bump-version\ndescription: Bump the version\n---\n");
+        write_command(
+            &cmds_dir,
+            "bump-version",
+            "---\nname: bump-version\ndescription: Bump the version\n---\n",
+        );
 
         let skills = Claude.discover_skills(Some(project.path()), home.path());
         let names: Vec<&str> = skills.iter().map(|s| s.name.as_str()).collect();
@@ -414,7 +443,11 @@ mod tests {
     fn discover_includes_global_commands() {
         let home = TempDir::new().unwrap();
         let cmds_dir = home.path().join(".claude/commands");
-        write_command(&cmds_dir, "my-global-cmd", "---\nname: my-global-cmd\ndescription: Global\n---\n");
+        write_command(
+            &cmds_dir,
+            "my-global-cmd",
+            "---\nname: my-global-cmd\ndescription: Global\n---\n",
+        );
 
         let skills = Claude.discover_skills(None, home.path());
         let names: Vec<&str> = skills.iter().map(|s| s.name.as_str()).collect();
@@ -425,7 +458,11 @@ mod tests {
     fn discover_includes_plugin_commands() {
         let home = TempDir::new().unwrap();
         let install_path = home.path().join(".claude/plugins/cache/mp/plugin-x/1.0.0");
-        write_command(&install_path.join("commands"), "plugin-cmd", "---\nname: plugin-cmd\ndescription: from plugin\n---\n");
+        write_command(
+            &install_path.join("commands"),
+            "plugin-cmd",
+            "---\nname: plugin-cmd\ndescription: from plugin\n---\n",
+        );
         write_installed_plugins(home.path(), &[&install_path]);
 
         let skills = Claude.discover_skills(None, home.path());
@@ -439,7 +476,11 @@ mod tests {
         let project = TempDir::new().unwrap();
         let agents_dir = project.path().join(".agents/skills");
         fs::create_dir_all(&agents_dir).unwrap();
-        write_skill(&agents_dir, "tauri-v2", "---\nname: tauri-v2\ndescription: Tauri v2 helper\n---\n");
+        write_skill(
+            &agents_dir,
+            "tauri-v2",
+            "---\nname: tauri-v2\ndescription: Tauri v2 helper\n---\n",
+        );
 
         let skills = Claude.discover_skills(Some(project.path()), home.path());
         let names: Vec<&str> = skills.iter().map(|s| s.name.as_str()).collect();
@@ -449,8 +490,12 @@ mod tests {
     #[test]
     #[ignore]
     fn sanity_real_home() {
-        let home = std::env::var_os("HOME").map(std::path::PathBuf::from).unwrap();
-        let project = std::env::current_dir().ok().and_then(|p| p.parent().map(|p| p.to_path_buf()));
+        let home = std::env::var_os("HOME")
+            .map(std::path::PathBuf::from)
+            .unwrap();
+        let project = std::env::current_dir()
+            .ok()
+            .and_then(|p| p.parent().map(|p| p.to_path_buf()));
         let skills = Claude.discover_skills(project.as_deref(), &home);
         println!("discovered {} skills", skills.len());
         let mut names: Vec<_> = skills.iter().map(|s| s.name.clone()).collect();

--- a/src-tauri/src/agent/codex.rs
+++ b/src-tauri/src/agent/codex.rs
@@ -146,10 +146,7 @@ impl Agent for Codex {
         // JSON-RPC `thread/started` notification shape:
         //   { "method": "thread/started", "params": { "thread": { "id": "..." } } }
         if v.get("method").and_then(|m| m.as_str()) == Some("thread/started") {
-            if let Some(id) = v
-                .pointer("/params/thread/id")
-                .and_then(|s| s.as_str())
-            {
+            if let Some(id) = v.pointer("/params/thread/id").and_then(|s| s.as_str()) {
                 return Some(id.to_string());
             }
         }

--- a/src-tauri/src/agent/codex_rpc.rs
+++ b/src-tauri/src/agent/codex_rpc.rs
@@ -76,8 +76,7 @@ pub enum CodexRpcEvent {
 }
 
 /// `request_id → oneshot sender waiting for the server's response`.
-pub type PendingRpcResponses =
-    Arc<DashMap<i64, oneshot::Sender<Result<Value, JsonRpcError>>>>;
+pub type PendingRpcResponses = Arc<DashMap<i64, oneshot::Sender<Result<Value, JsonRpcError>>>>;
 
 pub fn new_pending_rpc_responses() -> PendingRpcResponses {
     Arc::new(DashMap::new())
@@ -376,9 +375,7 @@ mod tests {
         let line = r#"{"id":7,"result":{"thread":{"id":"t-1"}}}"#;
         let msg = classify_line(line).unwrap().unwrap();
         match msg {
-            ClassifiedMessage::Response {
-                id, result, ..
-            } => {
+            ClassifiedMessage::Response { id, result, .. } => {
                 assert_eq!(id, Some(7));
                 let val = result.unwrap();
                 assert_eq!(val["thread"]["id"], "t-1");

--- a/src-tauri/src/agent/mod.rs
+++ b/src-tauri/src/agent/mod.rs
@@ -524,11 +524,7 @@ pub trait Agent: Send + Sync {
     /// root (typically a repo root or worktree path) and the user's home
     /// directory. Returns empty by default; each agent that supports skills
     /// overrides this.
-    fn discover_skills(
-        &self,
-        _scan_root: Option<&Path>,
-        _user_home: &Path,
-    ) -> Vec<AgentSkill> {
+    fn discover_skills(&self, _scan_root: Option<&Path>, _user_home: &Path) -> Vec<AgentSkill> {
         Vec::new()
     }
 
@@ -788,7 +784,10 @@ mod tests {
         let bytes = agent
             .encode_stream_user_message("hi there", &[])
             .expect("claude should encode");
-        assert!(bytes.ends_with(b"\n"), "stream lines must be newline-delimited");
+        assert!(
+            bytes.ends_with(b"\n"),
+            "stream lines must be newline-delimited"
+        );
         let text = std::str::from_utf8(&bytes).expect("utf8");
         let v: serde_json::Value = serde_json::from_str(text.trim_end()).expect("valid json");
         assert_eq!(v["type"], "user");
@@ -831,8 +830,7 @@ mod tests {
         let agent = Claude;
         let bytes = agent.encode_stream_interrupt("req_abc").expect("encode");
         assert!(bytes.ends_with(b"\n"));
-        let v: serde_json::Value =
-            serde_json::from_slice(&bytes[..bytes.len() - 1]).expect("json");
+        let v: serde_json::Value = serde_json::from_slice(&bytes[..bytes.len() - 1]).expect("json");
         assert_eq!(v["type"], "control_request");
         assert_eq!(v["request_id"], "req_abc");
         assert_eq!(v["request"]["subtype"], "interrupt");
@@ -845,8 +843,7 @@ mod tests {
             .encode_stream_set_permission_mode("req_1", "plan")
             .expect("encode");
         assert!(bytes.ends_with(b"\n"));
-        let v: serde_json::Value =
-            serde_json::from_slice(&bytes[..bytes.len() - 1]).expect("json");
+        let v: serde_json::Value = serde_json::from_slice(&bytes[..bytes.len() - 1]).expect("json");
         assert_eq!(v["type"], "control_request");
         assert_eq!(v["request_id"], "req_1");
         assert_eq!(v["request"]["subtype"], "set_permission_mode");
@@ -859,8 +856,7 @@ mod tests {
         let bytes = agent
             .encode_stream_set_permission_mode("req_2", "default")
             .expect("encode");
-        let v: serde_json::Value =
-            serde_json::from_slice(&bytes[..bytes.len() - 1]).expect("json");
+        let v: serde_json::Value = serde_json::from_slice(&bytes[..bytes.len() - 1]).expect("json");
         assert_eq!(v["request"]["mode"], "default");
     }
 
@@ -871,8 +867,7 @@ mod tests {
             .encode_stream_set_model("req_3", Some("claude-sonnet-4-6"))
             .expect("encode");
         assert!(bytes.ends_with(b"\n"));
-        let v: serde_json::Value =
-            serde_json::from_slice(&bytes[..bytes.len() - 1]).expect("json");
+        let v: serde_json::Value = serde_json::from_slice(&bytes[..bytes.len() - 1]).expect("json");
         assert_eq!(v["type"], "control_request");
         assert_eq!(v["request_id"], "req_3");
         assert_eq!(v["request"]["subtype"], "set_model");
@@ -885,8 +880,7 @@ mod tests {
         let bytes = agent
             .encode_stream_set_model("req_4", None)
             .expect("encode");
-        let v: serde_json::Value =
-            serde_json::from_slice(&bytes[..bytes.len() - 1]).expect("json");
+        let v: serde_json::Value = serde_json::from_slice(&bytes[..bytes.len() - 1]).expect("json");
         assert!(v["request"]["model"].is_null());
     }
 
@@ -903,9 +897,7 @@ mod tests {
             assert!(agent
                 .encode_stream_set_permission_mode("req_x", "plan")
                 .is_err());
-            assert!(agent
-                .encode_stream_set_model("req_x", Some("m"))
-                .is_err());
+            assert!(agent.encode_stream_set_model("req_x", Some("m")).is_err());
         }
     }
 
@@ -1199,7 +1191,10 @@ mod tests {
         assert_eq!(v["params"]["approvalPolicy"], "on-request");
         assert_eq!(v["params"]["sandboxPolicy"]["type"], "workspaceWrite");
         assert_eq!(v["params"]["collaborationMode"]["mode"], "default");
-        assert_eq!(v["params"]["collaborationMode"]["settings"]["model"], "gpt-5.4");
+        assert_eq!(
+            v["params"]["collaborationMode"]["settings"]["model"],
+            "gpt-5.4"
+        );
         assert_eq!(
             v["params"]["collaborationMode"]["settings"]["reasoning_effort"],
             "medium"

--- a/src-tauri/src/blob.rs
+++ b/src-tauri/src/blob.rs
@@ -64,7 +64,9 @@ pub fn blobs_dir(app_data_dir: &Path) -> PathBuf {
 
 pub fn blob_path(app_data_dir: &Path, hash: &str) -> PathBuf {
     let shard = hash.get(..2).unwrap_or("00");
-    blobs_dir(app_data_dir).join(shard).join(format!("{hash}.bin"))
+    blobs_dir(app_data_dir)
+        .join(shard)
+        .join(format!("{hash}.bin"))
 }
 
 pub fn hash_bytes(bytes: &[u8]) -> String {
@@ -159,14 +161,12 @@ pub async fn get_blob_info(pool: &SqlitePool, hash: &str) -> Result<Option<BlobI
 }
 
 pub async fn incr_ref(pool: &SqlitePool, hash: &str) -> Result<(), String> {
-    sqlx::query(
-        "UPDATE blobs SET ref_count = ref_count + 1, last_used_at = ? WHERE hash = ?",
-    )
-    .bind(epoch_ms())
-    .bind(hash)
-    .execute(pool)
-    .await
-    .map_err(|e| e.to_string())?;
+    sqlx::query("UPDATE blobs SET ref_count = ref_count + 1, last_used_at = ? WHERE hash = ?")
+        .bind(epoch_ms())
+        .bind(hash)
+        .execute(pool)
+        .await
+        .map_err(|e| e.to_string())?;
     Ok(())
 }
 
@@ -193,7 +193,9 @@ pub fn extract_hashes_from_attachments_json(json: Option<&str>) -> Vec<String> {
     let Ok(value) = serde_json::from_str::<serde_json::Value>(s) else {
         return Vec::new();
     };
-    let Some(arr) = value.as_array() else { return Vec::new() };
+    let Some(arr) = value.as_array() else {
+        return Vec::new();
+    };
     arr.iter()
         .filter_map(|item| item.get("hash").and_then(|h| h.as_str()).map(String::from))
         .collect()
@@ -238,11 +240,7 @@ pub async fn decr_refs(pool: &SqlitePool, hashes: &[String]) -> Result<(), Strin
 /// Delete a single blob: file first, then the DB row. File-first ordering
 /// makes a crash mid-delete leave a dangling row (recoverable on next sweep)
 /// rather than a dangling file (which would leak forever).
-pub async fn delete_blob(
-    pool: &SqlitePool,
-    app_data_dir: &Path,
-    hash: &str,
-) -> Result<(), String> {
+pub async fn delete_blob(pool: &SqlitePool, app_data_dir: &Path, hash: &str) -> Result<(), String> {
     let path = blob_path(app_data_dir, hash);
     match tokio::fs::remove_file(&path).await {
         Ok(()) => {}
@@ -270,13 +268,12 @@ pub async fn gc_unreferenced(
         return Ok(0);
     }
     let cutoff = epoch_ms() - ttl_ms;
-    let rows: Vec<(String,)> = sqlx::query_as(
-        "SELECT hash FROM blobs WHERE ref_count = 0 AND last_used_at < ?",
-    )
-    .bind(cutoff)
-    .fetch_all(pool)
-    .await
-    .map_err(|e| e.to_string())?;
+    let rows: Vec<(String,)> =
+        sqlx::query_as("SELECT hash FROM blobs WHERE ref_count = 0 AND last_used_at < ?")
+            .bind(cutoff)
+            .fetch_all(pool)
+            .await
+            .map_err(|e| e.to_string())?;
 
     let mut reclaimed = 0u64;
     for (hash,) in rows {
@@ -491,7 +488,10 @@ async fn migrate_legacy_user_message_line(
         return Ok(None);
     }
     if let Some(obj) = value.as_object_mut() {
-        obj.insert("attachments".to_string(), serde_json::Value::Array(rewritten));
+        obj.insert(
+            "attachments".to_string(),
+            serde_json::Value::Array(rewritten),
+        );
     }
     let new_line = serde_json::to_string(&value).map_err(|e| e.to_string())?;
     Ok(Some((new_line, hashes, created)))
@@ -523,9 +523,17 @@ async fn rewrite_array(
             out.push(item.clone());
             continue;
         };
-        let mime = obj.get("mimeType").and_then(|v| v.as_str()).unwrap_or("application/octet-stream");
-        let name = obj.get("name").and_then(|v| v.as_str()).unwrap_or("attachment");
-        let bytes = STANDARD.decode(b64).map_err(|e| format!("base64 decode failed: {e}"))?;
+        let mime = obj
+            .get("mimeType")
+            .and_then(|v| v.as_str())
+            .unwrap_or("application/octet-stream");
+        let name = obj
+            .get("name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("attachment");
+        let bytes = STANDARD
+            .decode(b64)
+            .map_err(|e| format!("base64 decode failed: {e}"))?;
 
         let pre: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM blobs")
             .fetch_one(pool)
@@ -615,13 +623,17 @@ mod tests {
         let (pool, tmp) = test_setup().await;
         let bytes = b"hello world";
 
-        let r = write_blob(&pool, tmp.path(), "text/plain", bytes).await.unwrap();
+        let r = write_blob(&pool, tmp.path(), "text/plain", bytes)
+            .await
+            .unwrap();
 
         assert_eq!(r.hash, hash_bytes(bytes));
         assert_eq!(r.mime, "text/plain");
         assert_eq!(r.size, 11);
 
-        let on_disk = tokio::fs::read(blob_path(tmp.path(), &r.hash)).await.unwrap();
+        let on_disk = tokio::fs::read(blob_path(tmp.path(), &r.hash))
+            .await
+            .unwrap();
         assert_eq!(on_disk, bytes);
 
         let info = get_blob_info(&pool, &r.hash).await.unwrap().unwrap();
@@ -634,8 +646,12 @@ mod tests {
         let (pool, tmp) = test_setup().await;
         let bytes = b"same bytes";
 
-        let r1 = write_blob(&pool, tmp.path(), "image/png", bytes).await.unwrap();
-        let r2 = write_blob(&pool, tmp.path(), "image/png", bytes).await.unwrap();
+        let r1 = write_blob(&pool, tmp.path(), "image/png", bytes)
+            .await
+            .unwrap();
+        let r2 = write_blob(&pool, tmp.path(), "image/png", bytes)
+            .await
+            .unwrap();
 
         assert_eq!(r1.hash, r2.hash);
 
@@ -670,7 +686,9 @@ mod tests {
     async fn read_blob_bytes_round_trips() {
         let (pool, tmp) = test_setup().await;
         let bytes: Vec<u8> = (0u8..=255).collect();
-        let r = write_blob(&pool, tmp.path(), "image/png", &bytes).await.unwrap();
+        let r = write_blob(&pool, tmp.path(), "image/png", &bytes)
+            .await
+            .unwrap();
 
         let read = read_blob_bytes(tmp.path(), &r.hash).await.unwrap();
         assert_eq!(read, bytes);
@@ -679,7 +697,9 @@ mod tests {
     #[tokio::test]
     async fn incr_decr_ref_track_count() {
         let (pool, tmp) = test_setup().await;
-        let r = write_blob(&pool, tmp.path(), "image/png", b"x").await.unwrap();
+        let r = write_blob(&pool, tmp.path(), "image/png", b"x")
+            .await
+            .unwrap();
 
         incr_ref(&pool, &r.hash).await.unwrap();
         incr_ref(&pool, &r.hash).await.unwrap();
@@ -694,7 +714,9 @@ mod tests {
     #[tokio::test]
     async fn decr_ref_floors_at_zero() {
         let (pool, tmp) = test_setup().await;
-        let r = write_blob(&pool, tmp.path(), "image/png", b"x").await.unwrap();
+        let r = write_blob(&pool, tmp.path(), "image/png", b"x")
+            .await
+            .unwrap();
 
         // No incr — refcount is 0. Decrement must not go negative.
         decr_ref(&pool, &r.hash).await.unwrap();
@@ -705,8 +727,12 @@ mod tests {
     #[tokio::test]
     async fn get_storage_stats_partitions_referenced_vs_unreferenced() {
         let (pool, tmp) = test_setup().await;
-        let a = write_blob(&pool, tmp.path(), "image/png", b"aaaa").await.unwrap();
-        let _b = write_blob(&pool, tmp.path(), "image/png", b"bbbbbb").await.unwrap();
+        let a = write_blob(&pool, tmp.path(), "image/png", b"aaaa")
+            .await
+            .unwrap();
+        let _b = write_blob(&pool, tmp.path(), "image/png", b"bbbbbb")
+            .await
+            .unwrap();
         incr_ref(&pool, &a.hash).await.unwrap();
 
         let stats = get_storage_stats(&pool).await.unwrap();
@@ -797,7 +823,9 @@ mod tests {
     #[tokio::test]
     async fn delete_blob_removes_file_and_row() {
         let (pool, tmp) = test_setup().await;
-        let r = write_blob(&pool, tmp.path(), "image/png", b"bye").await.unwrap();
+        let r = write_blob(&pool, tmp.path(), "image/png", b"bye")
+            .await
+            .unwrap();
         let path = blob_path(tmp.path(), &r.hash);
         assert!(path.exists());
 
@@ -810,9 +838,13 @@ mod tests {
     #[tokio::test]
     async fn delete_blob_tolerates_missing_file() {
         let (pool, tmp) = test_setup().await;
-        let r = write_blob(&pool, tmp.path(), "image/png", b"x").await.unwrap();
+        let r = write_blob(&pool, tmp.path(), "image/png", b"x")
+            .await
+            .unwrap();
         // Pre-delete the file out from under the row — DB row should still go.
-        tokio::fs::remove_file(blob_path(tmp.path(), &r.hash)).await.unwrap();
+        tokio::fs::remove_file(blob_path(tmp.path(), &r.hash))
+            .await
+            .unwrap();
 
         delete_blob(&pool, tmp.path(), &r.hash).await.unwrap();
         assert!(get_blob_info(&pool, &r.hash).await.unwrap().is_none());
@@ -882,15 +914,30 @@ mod tests {
     async fn enforce_storage_cap_evicts_oldest_unreferenced_until_under_cap() {
         let (pool, tmp) = test_setup().await;
         let a = write_blob(&pool, tmp.path(), "image/png", b"aaaaa") // 5
-            .await.unwrap();
+            .await
+            .unwrap();
         let b = write_blob(&pool, tmp.path(), "image/png", b"bbbbbb") // 6
-            .await.unwrap();
+            .await
+            .unwrap();
         let c = write_blob(&pool, tmp.path(), "image/png", b"ccccccc") // 7
-            .await.unwrap();
+            .await
+            .unwrap();
         // a is oldest, b mid, c newest — set last_used_at explicitly.
-        sqlx::query("UPDATE blobs SET last_used_at = 100 WHERE hash = ?").bind(&a.hash).execute(&pool).await.unwrap();
-        sqlx::query("UPDATE blobs SET last_used_at = 200 WHERE hash = ?").bind(&b.hash).execute(&pool).await.unwrap();
-        sqlx::query("UPDATE blobs SET last_used_at = 300 WHERE hash = ?").bind(&c.hash).execute(&pool).await.unwrap();
+        sqlx::query("UPDATE blobs SET last_used_at = 100 WHERE hash = ?")
+            .bind(&a.hash)
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("UPDATE blobs SET last_used_at = 200 WHERE hash = ?")
+            .bind(&b.hash)
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("UPDATE blobs SET last_used_at = 300 WHERE hash = ?")
+            .bind(&c.hash)
+            .execute(&pool)
+            .await
+            .unwrap();
 
         // Cap at 10 bytes — total is 18, must reclaim ≥ 8 bytes by evicting
         // a (5) then b (6) for 11 bytes freed, leaving c (7) under the cap.
@@ -904,8 +951,14 @@ mod tests {
     #[tokio::test]
     async fn enforce_storage_cap_keeps_referenced_blobs() {
         let (pool, tmp) = test_setup().await;
-        let pinned = write_blob(&pool, tmp.path(), "image/png", b"pinned-large-blob-xxxxxxxxxxxxxxxxxxxxxxxxxx")
-            .await.unwrap();
+        let pinned = write_blob(
+            &pool,
+            tmp.path(),
+            "image/png",
+            b"pinned-large-blob-xxxxxxxxxxxxxxxxxxxxxxxxxx",
+        )
+        .await
+        .unwrap();
         incr_ref(&pool, &pinned.hash).await.unwrap();
 
         // Cap is well under the pinned blob — but it must NOT be evicted
@@ -918,7 +971,9 @@ mod tests {
     #[tokio::test]
     async fn enforce_storage_cap_disabled_when_max_non_positive() {
         let (pool, tmp) = test_setup().await;
-        let r = write_blob(&pool, tmp.path(), "image/png", b"x").await.unwrap();
+        let r = write_blob(&pool, tmp.path(), "image/png", b"x")
+            .await
+            .unwrap();
         assert_eq!(enforce_storage_cap(&pool, tmp.path(), 0).await.unwrap(), 0);
         assert_eq!(enforce_storage_cap(&pool, tmp.path(), -1).await.unwrap(), 0);
         assert!(get_blob_info(&pool, &r.hash).await.unwrap().is_some());
@@ -967,13 +1022,11 @@ mod tests {
 
     async fn seed_output_line(pool: &SqlitePool, line: &str) -> i64 {
         ensure_session(pool).await;
-        sqlx::query(
-            "INSERT INTO output_lines (session_id, line, emitted_at) VALUES ('s', ?, 0)",
-        )
-        .bind(line)
-        .execute(pool)
-        .await
-        .unwrap();
+        sqlx::query("INSERT INTO output_lines (session_id, line, emitted_at) VALUES ('s', ?, 0)")
+            .bind(line)
+            .execute(pool)
+            .await
+            .unwrap();
         let row: (i64,) = sqlx::query_as("SELECT last_insert_rowid()")
             .fetch_one(pool)
             .await
@@ -1015,7 +1068,10 @@ mod tests {
         assert_eq!(entry["size"], bytes.len());
         assert!(entry.get("dataBase64").is_none());
 
-        let info = get_blob_info(&pool, &hash_bytes(bytes)).await.unwrap().unwrap();
+        let info = get_blob_info(&pool, &hash_bytes(bytes))
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(info.ref_count, 1);
         assert_eq!(info.size, bytes.len() as i64);
     }
@@ -1034,12 +1090,11 @@ mod tests {
         assert_eq!(report.output_lines_migrated, 1);
         assert_eq!(report.blobs_created, 1);
 
-        let (new_line,): (String,) =
-            sqlx::query_as("SELECT line FROM output_lines WHERE id = ?")
-                .bind(id)
-                .fetch_one(&pool)
-                .await
-                .unwrap();
+        let (new_line,): (String,) = sqlx::query_as("SELECT line FROM output_lines WHERE id = ?")
+            .bind(id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
         let v: serde_json::Value = serde_json::from_str(&new_line).unwrap();
         let arr = v["attachments"].as_array().unwrap();
         assert_eq!(arr.len(), 1);
@@ -1049,7 +1104,10 @@ mod tests {
         assert_eq!(v["text"], "hi");
         assert_eq!(v["type"], "verun_user_message");
 
-        let info = get_blob_info(&pool, &hash_bytes(bytes)).await.unwrap().unwrap();
+        let info = get_blob_info(&pool, &hash_bytes(bytes))
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(info.ref_count, 1);
     }
 
@@ -1068,7 +1126,10 @@ mod tests {
         assert_eq!(first.blobs_created, 1);
         assert!(!first.already_done);
 
-        let info_after_first = get_blob_info(&pool, &hash_bytes(bytes)).await.unwrap().unwrap();
+        let info_after_first = get_blob_info(&pool, &hash_bytes(bytes))
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(info_after_first.ref_count, 1);
 
         // Second run: sentinel is set → no-op, no double-incr.
@@ -1077,8 +1138,14 @@ mod tests {
         assert_eq!(second.blobs_created, 0);
         assert!(second.already_done);
 
-        let info_after_second = get_blob_info(&pool, &hash_bytes(bytes)).await.unwrap().unwrap();
-        assert_eq!(info_after_second.ref_count, 1, "sentinel must prevent re-incrementing");
+        let info_after_second = get_blob_info(&pool, &hash_bytes(bytes))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            info_after_second.ref_count, 1,
+            "sentinel must prevent re-incrementing"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/bts_scaffold.rs
+++ b/src-tauri/src/bts_scaffold.rs
@@ -71,11 +71,7 @@ pub async fn write_verun_config(
 
 /// Spawn a reader thread that pumps PTY master bytes into `bts-scaffold-output`
 /// events. Uses a dedicated OS thread because portable-pty's reader is blocking.
-fn spawn_reader_thread(
-    app: AppHandle,
-    scaffold_id: String,
-    mut reader: Box<dyn Read + Send>,
-) {
+fn spawn_reader_thread(app: AppHandle, scaffold_id: String, mut reader: Box<dyn Read + Send>) {
     std::thread::spawn(move || {
         let mut buf = [0u8; 4096];
         loop {
@@ -336,7 +332,10 @@ pub async fn create_subdir(parent: String, name: String) -> Result<String, Strin
     }
     let parent_path = expand_tilde(&parent)?;
     if !parent_path.is_dir() {
-        return Err(format!("Parent directory does not exist: {}", parent_path.display()));
+        return Err(format!(
+            "Parent directory does not exist: {}",
+            parent_path.display()
+        ));
     }
     let target = parent_path.join(trimmed);
     if target.exists() {
@@ -403,10 +402,18 @@ mod tests {
     #[tokio::test]
     async fn list_subdirs_returns_sorted_visible_dirs() {
         let dir = tempdir().unwrap();
-        tokio::fs::create_dir(dir.path().join("zeta")).await.unwrap();
-        tokio::fs::create_dir(dir.path().join("alpha")).await.unwrap();
-        tokio::fs::create_dir(dir.path().join(".hidden")).await.unwrap();
-        tokio::fs::write(dir.path().join("notadir.txt"), "x").await.unwrap();
+        tokio::fs::create_dir(dir.path().join("zeta"))
+            .await
+            .unwrap();
+        tokio::fs::create_dir(dir.path().join("alpha"))
+            .await
+            .unwrap();
+        tokio::fs::create_dir(dir.path().join(".hidden"))
+            .await
+            .unwrap();
+        tokio::fs::write(dir.path().join("notadir.txt"), "x")
+            .await
+            .unwrap();
         let out = list_subdirs(dir.path().to_string_lossy().into_owned())
             .await
             .unwrap();
@@ -432,7 +439,9 @@ mod tests {
         {
             perms.set_readonly(true);
         }
-        tokio::fs::set_permissions(dir.path(), perms.clone()).await.unwrap();
+        tokio::fs::set_permissions(dir.path(), perms.clone())
+            .await
+            .unwrap();
         let result = check_writable(dir.path()).await;
         // restore perms so tempdir can be cleaned up
         #[cfg(unix)]
@@ -455,7 +464,9 @@ mod tests {
     async fn create_subdir_creates_a_new_directory() {
         let parent = tempdir().unwrap();
         let parent_path = parent.path().to_string_lossy().into_owned();
-        create_subdir(parent_path.clone(), "newproj".to_string()).await.unwrap();
+        create_subdir(parent_path.clone(), "newproj".to_string())
+            .await
+            .unwrap();
         assert!(parent.path().join("newproj").is_dir());
     }
 
@@ -463,8 +474,12 @@ mod tests {
     async fn create_subdir_rejects_invalid_names() {
         let parent = tempdir().unwrap();
         let parent_path = parent.path().to_string_lossy().into_owned();
-        assert!(create_subdir(parent_path.clone(), "".to_string()).await.is_err());
-        assert!(create_subdir(parent_path.clone(), "a/b".to_string()).await.is_err());
+        assert!(create_subdir(parent_path.clone(), "".to_string())
+            .await
+            .is_err());
+        assert!(create_subdir(parent_path.clone(), "a/b".to_string())
+            .await
+            .is_err());
         assert!(create_subdir(parent_path, "..".to_string()).await.is_err());
     }
 
@@ -472,7 +487,9 @@ mod tests {
     async fn create_subdir_errors_if_already_exists() {
         let parent = tempdir().unwrap();
         let parent_path = parent.path().to_string_lossy().into_owned();
-        tokio::fs::create_dir(parent.path().join("dup")).await.unwrap();
+        tokio::fs::create_dir(parent.path().join("dup"))
+            .await
+            .unwrap();
         let res = create_subdir(parent_path, "dup".to_string()).await;
         assert!(res.is_err());
     }
@@ -481,10 +498,17 @@ mod tests {
     async fn create_subdir_expands_tilde() {
         // sanity: tilde expansion path is wired up. We can't write to $HOME in tests,
         // so just confirm a non-existent-parent error surfaces, not a tilde-literal path.
-        let res = create_subdir("~/__verun_definitely_missing_parent__".to_string(), "x".to_string()).await;
+        let res = create_subdir(
+            "~/__verun_definitely_missing_parent__".to_string(),
+            "x".to_string(),
+        )
+        .await;
         assert!(res.is_err());
         let err = res.unwrap_err();
-        assert!(!err.contains('~'), "tilde should be expanded before error: {err}");
+        assert!(
+            !err.contains('~'),
+            "tilde should be expanded before error: {err}"
+        );
     }
 
     #[tokio::test]
@@ -501,6 +525,9 @@ mod tests {
         assert!(written.contains("\"startCommand\""));
         assert!(written.contains("\"pnpm dev\""));
         assert!(written.contains("\"setup\""));
-        assert!(written.contains('\n'), "expected pretty-printed (multi-line) JSON");
+        assert!(
+            written.contains('\n'),
+            "expected pretty-printed (multi-line) JSON"
+        );
     }
 }

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -3107,6 +3107,61 @@ mod tests {
         assert_eq!(steps.len(), 0);
     }
 
+    #[tokio::test]
+    async fn invalidate_github_cache_removes_only_requested_scopes() {
+        let pool = test_pool().await;
+        process_write(&pool, DbWrite::InsertProject(make_project()))
+            .await
+            .unwrap();
+        process_write(&pool, DbWrite::InsertTask(make_task("p-001")))
+            .await
+            .unwrap();
+
+        upsert_github_cache_entry(
+            &pool,
+            &GitHubCacheEntry {
+                cache_key: "t-001:overview".into(),
+                task_id: "t-001".into(),
+                scope: "overview".into(),
+                entity_id: None,
+                payload_json: "{}".into(),
+                fetched_at: 1,
+                stale_at: 2,
+                expires_at: 3,
+            },
+        )
+        .await
+        .unwrap();
+        upsert_github_cache_entry(
+            &pool,
+            &GitHubCacheEntry {
+                cache_key: "t-001:actions".into(),
+                task_id: "t-001".into(),
+                scope: "actions".into(),
+                entity_id: None,
+                payload_json: "{}".into(),
+                fetched_at: 1,
+                stale_at: 2,
+                expires_at: 3,
+            },
+        )
+        .await
+        .unwrap();
+
+        invalidate_github_cache(&pool, "t-001", &["overview"])
+            .await
+            .unwrap();
+
+        assert!(get_github_cache_entry(&pool, "t-001:overview")
+            .await
+            .unwrap()
+            .is_none());
+        assert!(get_github_cache_entry(&pool, "t-001:actions")
+            .await
+            .unwrap()
+            .is_some());
+    }
+
     #[test]
     fn step_serializes_as_camel_case() {
         let step = Step {

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -254,6 +254,29 @@ pub fn migrations() -> Vec<Migration> {
             ALTER TABLE sessions ADD COLUMN cache_write_tokens INTEGER NOT NULL DEFAULT 0;
         "#,
         kind: MigrationKind::Up,
+    },
+    Migration {
+        version: 23,
+        description: "create github cache entries table",
+        sql: r#"
+            CREATE TABLE IF NOT EXISTS github_cache_entries (
+                cache_key TEXT PRIMARY KEY,
+                task_id TEXT NOT NULL REFERENCES tasks(id),
+                scope TEXT NOT NULL,
+                entity_id TEXT,
+                etag TEXT,
+                payload_json TEXT NOT NULL,
+                fetched_at INTEGER NOT NULL,
+                stale_at INTEGER NOT NULL,
+                expires_at INTEGER NOT NULL,
+                last_error TEXT,
+                rate_limit_reset_at INTEGER
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_github_cache_task_scope
+              ON github_cache_entries(task_id, scope);
+        "#,
+        kind: MigrationKind::Up,
     }]
 }
 
@@ -406,6 +429,19 @@ pub struct Step {
     pub fast_mode: Option<bool>,
     pub sort_order: i64,
     pub created_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+#[serde(rename_all = "camelCase")]
+pub struct GitHubCacheEntry {
+    pub cache_key: String,
+    pub task_id: String,
+    pub scope: String,
+    pub entity_id: Option<String>,
+    pub payload_json: String,
+    pub fetched_at: i64,
+    pub stale_at: i64,
+    pub expires_at: i64,
 }
 
 // ---------------------------------------------------------------------------
@@ -599,8 +635,14 @@ pub(crate) fn usage_delta_from_output_line(line: &str) -> SessionUsageDelta {
             continue;
         }
         delta.total_cost += item.get("cost").and_then(|x| x.as_f64()).unwrap_or(0.0);
-        delta.input_tokens += item.get("inputTokens").and_then(|x| x.as_i64()).unwrap_or(0);
-        delta.output_tokens += item.get("outputTokens").and_then(|x| x.as_i64()).unwrap_or(0);
+        delta.input_tokens += item
+            .get("inputTokens")
+            .and_then(|x| x.as_i64())
+            .unwrap_or(0);
+        delta.output_tokens += item
+            .get("outputTokens")
+            .and_then(|x| x.as_i64())
+            .unwrap_or(0);
         delta.cache_read_tokens += item
             .get("cacheReadTokens")
             .and_then(|x| x.as_i64())
@@ -642,14 +684,15 @@ async fn drain_refs_for_sessions(
 ) -> Result<Vec<String>, sqlx::Error> {
     let mut hashes = Vec::new();
     for sid in session_ids {
-        let step_rows: Vec<(Option<String>,)> = sqlx::query_as(
-            "SELECT attachments_json FROM steps WHERE session_id = ?",
-        )
-        .bind(sid)
-        .fetch_all(pool)
-        .await?;
+        let step_rows: Vec<(Option<String>,)> =
+            sqlx::query_as("SELECT attachments_json FROM steps WHERE session_id = ?")
+                .bind(sid)
+                .fetch_all(pool)
+                .await?;
         for (json,) in step_rows {
-            hashes.extend(crate::blob::extract_hashes_from_attachments_json(json.as_deref()));
+            hashes.extend(crate::blob::extract_hashes_from_attachments_json(
+                json.as_deref(),
+            ));
         }
     }
     hashes.extend(collect_hashes_from_output_lines(pool, session_ids).await?);
@@ -748,7 +791,10 @@ async fn process_write(pool: &SqlitePool, write: DbWrite) -> Result<(), sqlx::Er
                  (SELECT s.id FROM sessions s JOIN tasks t ON s.task_id = t.id WHERE t.project_id = ?)",
             )
             .bind(&id).execute(pool).await?;
-            log_refcount_err("decr DeleteProject", crate::blob::decr_refs(pool, &drained).await);
+            log_refcount_err(
+                "decr DeleteProject",
+                crate::blob::decr_refs(pool, &drained).await,
+            );
             sqlx::query(
                 "DELETE FROM turn_snapshots WHERE session_id IN \
                  (SELECT s.id FROM sessions s JOIN tasks t ON s.task_id = t.id WHERE t.project_id = ?)",
@@ -805,15 +851,14 @@ async fn process_write(pool: &SqlitePool, write: DbWrite) -> Result<(), sqlx::Er
         }
         DbWrite::DeleteTask { id } => {
             // Drain blob refcounts for sessions of this task before cascade.
-            let session_ids: Vec<String> = sqlx::query_as::<_, (String,)>(
-                "SELECT id FROM sessions WHERE task_id = ?",
-            )
-            .bind(&id)
-            .fetch_all(pool)
-            .await?
-            .into_iter()
-            .map(|(s,)| s)
-            .collect();
+            let session_ids: Vec<String> =
+                sqlx::query_as::<_, (String,)>("SELECT id FROM sessions WHERE task_id = ?")
+                    .bind(&id)
+                    .fetch_all(pool)
+                    .await?
+                    .into_iter()
+                    .map(|(s,)| s)
+                    .collect();
             let drained = drain_refs_for_sessions(pool, &session_ids).await?;
 
             sqlx::query("DELETE FROM policy_audit_log WHERE task_id = ?")
@@ -838,7 +883,10 @@ async fn process_write(pool: &SqlitePool, write: DbWrite) -> Result<(), sqlx::Er
             .bind(&id)
             .execute(pool)
             .await?;
-            log_refcount_err("decr DeleteTask", crate::blob::decr_refs(pool, &drained).await);
+            log_refcount_err(
+                "decr DeleteTask",
+                crate::blob::decr_refs(pool, &drained).await,
+            );
             sqlx::query(
                 "DELETE FROM turn_snapshots WHERE session_id IN \
                  (SELECT id FROM sessions WHERE task_id = ?)",
@@ -881,7 +929,10 @@ async fn process_write(pool: &SqlitePool, write: DbWrite) -> Result<(), sqlx::Er
         }
         DbWrite::SetLastPushedSha { id, sha } => {
             sqlx::query("UPDATE tasks SET last_pushed_sha = ? WHERE id = ?")
-                .bind(&sha).bind(&id).execute(pool).await?;
+                .bind(&sha)
+                .bind(&id)
+                .execute(pool)
+                .await?;
         }
 
         // -- Sessions --
@@ -1022,7 +1073,10 @@ async fn process_write(pool: &SqlitePool, write: DbWrite) -> Result<(), sqlx::Er
             .bind(&session_id)
             .execute(pool)
             .await?;
-            log_refcount_err("decr DeleteOutputLines", crate::blob::decr_refs(pool, &hashes).await);
+            log_refcount_err(
+                "decr DeleteOutputLines",
+                crate::blob::decr_refs(pool, &hashes).await,
+            );
         }
 
         DbWrite::InsertTurnSnapshot {
@@ -1092,7 +1146,8 @@ async fn process_write(pool: &SqlitePool, write: DbWrite) -> Result<(), sqlx::Er
 
         // -- Steps --
         DbWrite::InsertStep(s) => {
-            let new_hashes = crate::blob::extract_hashes_from_attachments_json(s.attachments_json.as_deref());
+            let new_hashes =
+                crate::blob::extract_hashes_from_attachments_json(s.attachments_json.as_deref());
             sqlx::query(
                 "INSERT INTO steps (id, session_id, message, attachments_json, armed, model, plan_mode, thinking_mode, fast_mode, sort_order, created_at) \
                  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
@@ -1110,7 +1165,10 @@ async fn process_write(pool: &SqlitePool, write: DbWrite) -> Result<(), sqlx::Er
             .bind(s.created_at)
             .execute(pool)
             .await?;
-            log_refcount_err("incr InsertStep", crate::blob::incr_refs(pool, &new_hashes).await);
+            log_refcount_err(
+                "incr InsertStep",
+                crate::blob::incr_refs(pool, &new_hashes).await,
+            );
         }
         DbWrite::UpdateStep {
             id,
@@ -1132,7 +1190,8 @@ async fn process_write(pool: &SqlitePool, write: DbWrite) -> Result<(), sqlx::Er
                 .and_then(|(j,)| j.as_deref())
                 .map(|s| crate::blob::extract_hashes_from_attachments_json(Some(s)))
                 .unwrap_or_default();
-            let new_hashes = crate::blob::extract_hashes_from_attachments_json(attachments_json.as_deref());
+            let new_hashes =
+                crate::blob::extract_hashes_from_attachments_json(attachments_json.as_deref());
             sqlx::query("UPDATE steps SET message = ?, armed = ?, model = ?, plan_mode = ?, thinking_mode = ?, fast_mode = ?, attachments_json = ? WHERE id = ?")
                 .bind(&message)
                 .bind(armed)
@@ -1146,8 +1205,14 @@ async fn process_write(pool: &SqlitePool, write: DbWrite) -> Result<(), sqlx::Er
                 .await?;
             // Drop old refs first, then add new — temporary undercounting is
             // safe because GC never runs concurrently with the write queue.
-            log_refcount_err("decr UpdateStep old", crate::blob::decr_refs(pool, &old_hashes).await);
-            log_refcount_err("incr UpdateStep new", crate::blob::incr_refs(pool, &new_hashes).await);
+            log_refcount_err(
+                "decr UpdateStep old",
+                crate::blob::decr_refs(pool, &old_hashes).await,
+            );
+            log_refcount_err(
+                "incr UpdateStep new",
+                crate::blob::incr_refs(pool, &new_hashes).await,
+            );
         }
         DbWrite::DeleteStep { id } => {
             let old_json: Option<(Option<String>,)> =
@@ -1164,7 +1229,10 @@ async fn process_write(pool: &SqlitePool, write: DbWrite) -> Result<(), sqlx::Er
                 .bind(&id)
                 .execute(pool)
                 .await?;
-            log_refcount_err("decr DeleteStep", crate::blob::decr_refs(pool, &old_hashes).await);
+            log_refcount_err(
+                "decr DeleteStep",
+                crate::blob::decr_refs(pool, &old_hashes).await,
+            );
         }
         DbWrite::ReorderSteps { session_id, ids } => {
             for (i, id) in ids.iter().enumerate() {
@@ -1313,33 +1381,29 @@ pub async fn get_output_lines(
             // oldest-first. Implemented in SQL to avoid loading the full row
             // set into memory for long-lived sessions.
             let mut rows = match before_id {
-                Some(cursor) => {
-                    sqlx::query_as::<_, OutputLine>(
-                        "SELECT * FROM output_lines \
+                Some(cursor) => sqlx::query_as::<_, OutputLine>(
+                    "SELECT * FROM output_lines \
                          WHERE session_id = ? AND id < ? \
                          ORDER BY id DESC \
                          LIMIT ?",
-                    )
-                    .bind(session_id)
-                    .bind(cursor)
-                    .bind(n)
-                    .fetch_all(pool)
-                    .await
-                    .map_err(|e| e.to_string())?
-                }
-                None => {
-                    sqlx::query_as::<_, OutputLine>(
-                        "SELECT * FROM output_lines \
+                )
+                .bind(session_id)
+                .bind(cursor)
+                .bind(n)
+                .fetch_all(pool)
+                .await
+                .map_err(|e| e.to_string())?,
+                None => sqlx::query_as::<_, OutputLine>(
+                    "SELECT * FROM output_lines \
                          WHERE session_id = ? \
                          ORDER BY id DESC \
                          LIMIT ?",
-                    )
-                    .bind(session_id)
-                    .bind(n)
-                    .fetch_all(pool)
-                    .await
-                    .map_err(|e| e.to_string())?
-                }
+                )
+                .bind(session_id)
+                .bind(n)
+                .fetch_all(pool)
+                .await
+                .map_err(|e| e.to_string())?,
             };
             rows.reverse();
             Ok(rows)
@@ -1366,12 +1430,11 @@ pub async fn get_session_token_totals(
     pool: &SqlitePool,
     session_id: &str,
 ) -> Result<SessionTokenTotals, String> {
-    let rows: Vec<(String,)> =
-        sqlx::query_as("SELECT line FROM output_lines WHERE session_id = ?")
-            .bind(session_id)
-            .fetch_all(pool)
-            .await
-            .map_err(|e| e.to_string())?;
+    let rows: Vec<(String,)> = sqlx::query_as("SELECT line FROM output_lines WHERE session_id = ?")
+        .bind(session_id)
+        .fetch_all(pool)
+        .await
+        .map_err(|e| e.to_string())?;
 
     let mut totals = SessionTokenTotals::default();
     for (line,) in rows {
@@ -1433,6 +1496,77 @@ pub async fn backfill_session_usage_aggregates(pool: &SqlitePool) -> Result<(), 
     }
 
     write_meta(pool, SENTINEL, "done").await
+}
+
+pub async fn get_github_cache_entry(
+    pool: &SqlitePool,
+    cache_key: &str,
+) -> Result<Option<GitHubCacheEntry>, String> {
+    sqlx::query_as::<_, GitHubCacheEntry>(
+        "SELECT
+            cache_key, task_id, scope, entity_id, payload_json,
+            fetched_at, stale_at, expires_at
+         FROM github_cache_entries
+         WHERE cache_key = ?",
+    )
+    .bind(cache_key)
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| e.to_string())
+}
+
+pub async fn upsert_github_cache_entry(
+    pool: &SqlitePool,
+    entry: &GitHubCacheEntry,
+) -> Result<(), String> {
+    sqlx::query(
+        "INSERT INTO github_cache_entries (
+            cache_key, task_id, scope, entity_id, payload_json,
+            fetched_at, stale_at, expires_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(cache_key) DO UPDATE SET
+            task_id = excluded.task_id,
+            scope = excluded.scope,
+            entity_id = excluded.entity_id,
+            payload_json = excluded.payload_json,
+            fetched_at = excluded.fetched_at,
+            stale_at = excluded.stale_at,
+            expires_at = excluded.expires_at",
+    )
+    .bind(&entry.cache_key)
+    .bind(&entry.task_id)
+    .bind(&entry.scope)
+    .bind(&entry.entity_id)
+    .bind(&entry.payload_json)
+    .bind(entry.fetched_at)
+    .bind(entry.stale_at)
+    .bind(entry.expires_at)
+    .execute(pool)
+    .await
+    .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+pub async fn invalidate_github_cache(
+    pool: &SqlitePool,
+    task_id: &str,
+    scopes: &[&str],
+) -> Result<(), String> {
+    if scopes.is_empty() {
+        return Ok(());
+    }
+
+    let placeholders = std::iter::repeat_n("?", scopes.len())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let sql =
+        format!("DELETE FROM github_cache_entries WHERE task_id = ? AND scope IN ({placeholders})");
+    let mut query = sqlx::query(&sql).bind(task_id);
+    for scope in scopes {
+        query = query.bind(scope);
+    }
+    query.execute(pool).await.map_err(|e| e.to_string())?;
+    Ok(())
 }
 
 // Turn snapshots
@@ -1543,9 +1677,14 @@ mod tests {
     #[test]
     fn migration_versions_are_sequential() {
         let m = migrations();
-        assert_eq!(m.len(), 22);
+        assert_eq!(m.len(), 23);
         for (i, mig) in m.iter().enumerate() {
-            assert_eq!(mig.version, (i + 1) as i64, "migration index {} version mismatch", i);
+            assert_eq!(
+                mig.version,
+                (i + 1) as i64,
+                "migration index {} version mismatch",
+                i
+            );
         }
     }
 
@@ -1686,7 +1825,10 @@ mod tests {
         assert!(get_project(&pool, "p-001").await.unwrap().is_none());
         assert!(get_task(&pool, "t-001").await.unwrap().is_none());
         assert!(get_session(&pool, "s-001").await.unwrap().is_none());
-        assert!(get_output_lines(&pool, "s-001", None, None).await.unwrap().is_empty());
+        assert!(get_output_lines(&pool, "s-001", None, None)
+            .await
+            .unwrap()
+            .is_empty());
     }
 
     // -- Task tests --
@@ -1786,7 +1928,10 @@ mod tests {
 
         assert!(get_task(&pool, "t-001").await.unwrap().is_none());
         assert!(get_session(&pool, "s-001").await.unwrap().is_none());
-        assert!(get_output_lines(&pool, "s-001", None, None).await.unwrap().is_empty());
+        assert!(get_output_lines(&pool, "s-001", None, None)
+            .await
+            .unwrap()
+            .is_empty());
         // Project still exists
         assert!(get_project(&pool, "p-001").await.unwrap().is_some());
     }
@@ -1830,7 +1975,10 @@ mod tests {
 
         // Sessions and output preserved
         assert!(get_session(&pool, "s-001").await.unwrap().is_some());
-        assert!(!get_output_lines(&pool, "s-001", None, None).await.unwrap().is_empty());
+        assert!(!get_output_lines(&pool, "s-001", None, None)
+            .await
+            .unwrap()
+            .is_empty());
     }
 
     // Issue #138 — archive_task now flips the archived flag with
@@ -2184,14 +2332,9 @@ mod tests {
         assert_eq!(closed.status, "closed");
         assert_eq!(closed.closed_at, Some(7_000));
 
-        process_write(
-            &pool,
-            DbWrite::ReopenSession {
-                id: "s-001".into(),
-            },
-        )
-        .await
-        .unwrap();
+        process_write(&pool, DbWrite::ReopenSession { id: "s-001".into() })
+            .await
+            .unwrap();
 
         let reopened = get_session(&pool, "s-001").await.unwrap().unwrap();
         assert_eq!(reopened.status, "idle");
@@ -2220,14 +2363,9 @@ mod tests {
             .await
             .unwrap();
 
-        process_write(
-            &pool,
-            DbWrite::ReopenSession {
-                id: "s-001".into(),
-            },
-        )
-        .await
-        .unwrap();
+        process_write(&pool, DbWrite::ReopenSession { id: "s-001".into() })
+            .await
+            .unwrap();
 
         let after = get_session(&pool, "s-001").await.unwrap().unwrap();
         assert_eq!(after.status, "running");
@@ -2440,7 +2578,9 @@ mod tests {
             .unwrap();
         let mut s2 = make_session("t-001");
         s2.id = "s-002".into();
-        process_write(&pool, DbWrite::CreateSession(s2)).await.unwrap();
+        process_write(&pool, DbWrite::CreateSession(s2))
+            .await
+            .unwrap();
 
         process_write(
             &pool,
@@ -2484,7 +2624,8 @@ mod tests {
             .unwrap();
 
         let l1 = r#"{"type":"verun_items","items":[{"kind":"text","text":"hi"},{"kind":"turnEnd","status":"completed","cost":0.01,"inputTokens":100,"outputTokens":50,"cacheReadTokens":10,"cacheWriteTokens":5}]}"#;
-        let l2 = r#"{"type":"verun_items","items":[{"kind":"toolStart","tool":"Read","input":"{}"}]}"#;
+        let l2 =
+            r#"{"type":"verun_items","items":[{"kind":"toolStart","tool":"Read","input":"{}"}]}"#;
         let l3 = r#"{"type":"verun_user_message","text":"another"}"#;
         let l4 = r#"{"type":"verun_items","items":[{"kind":"turnEnd","status":"completed","cost":0.02,"inputTokens":200,"outputTokens":80,"cacheReadTokens":20,"cacheWriteTokens":7}]}"#;
         process_write(
@@ -2543,7 +2684,9 @@ mod tests {
             .unwrap();
         let mut s2 = make_session("t-001");
         s2.id = "s-other".into();
-        process_write(&pool, DbWrite::CreateSession(s2)).await.unwrap();
+        process_write(&pool, DbWrite::CreateSession(s2))
+            .await
+            .unwrap();
 
         let valid = r#"{"type":"verun_items","items":[{"kind":"turnEnd","status":"completed","inputTokens":42,"outputTokens":7,"cacheReadTokens":0,"cacheWriteTokens":0}]}"#;
         let garbage = "this is not json";
@@ -3022,9 +3165,15 @@ mod tests {
     }
 
     async fn project_task_session(pool: &SqlitePool) {
-        process_write(pool, DbWrite::InsertProject(make_project())).await.unwrap();
-        process_write(pool, DbWrite::InsertTask(make_task("p-001"))).await.unwrap();
-        process_write(pool, DbWrite::CreateSession(make_session("t-001"))).await.unwrap();
+        process_write(pool, DbWrite::InsertProject(make_project()))
+            .await
+            .unwrap();
+        process_write(pool, DbWrite::InsertTask(make_task("p-001")))
+            .await
+            .unwrap();
+        process_write(pool, DbWrite::CreateSession(make_session("t-001")))
+            .await
+            .unwrap();
     }
 
     #[tokio::test]
@@ -3034,7 +3183,9 @@ mod tests {
 
         let mut step = make_step("s-001", 0);
         step.attachments_json = Some(refs_json(&[&h1, &h2]));
-        process_write(&pool, DbWrite::InsertStep(step)).await.unwrap();
+        process_write(&pool, DbWrite::InsertStep(step))
+            .await
+            .unwrap();
 
         assert_eq!(ref_count(&pool, &h1).await, 1);
         assert_eq!(ref_count(&pool, &h2).await, 1);
@@ -3048,10 +3199,14 @@ mod tests {
         let mut step = make_step("s-001", 0);
         step.attachments_json = Some(refs_json(&[&h1]));
         let step_id = step.id.clone();
-        process_write(&pool, DbWrite::InsertStep(step)).await.unwrap();
+        process_write(&pool, DbWrite::InsertStep(step))
+            .await
+            .unwrap();
         assert_eq!(ref_count(&pool, &h1).await, 1);
 
-        process_write(&pool, DbWrite::DeleteStep { id: step_id }).await.unwrap();
+        process_write(&pool, DbWrite::DeleteStep { id: step_id })
+            .await
+            .unwrap();
         assert_eq!(ref_count(&pool, &h1).await, 0);
     }
 
@@ -3063,7 +3218,9 @@ mod tests {
         let mut step = make_step("s-001", 0);
         step.attachments_json = Some(refs_json(&[&h1]));
         let step_id = step.id.clone();
-        process_write(&pool, DbWrite::InsertStep(step)).await.unwrap();
+        process_write(&pool, DbWrite::InsertStep(step))
+            .await
+            .unwrap();
         assert_eq!(ref_count(&pool, &h1).await, 1);
         assert_eq!(ref_count(&pool, &h2).await, 0);
 
@@ -3094,7 +3251,9 @@ mod tests {
         let mut step = make_step("s-001", 0);
         step.attachments_json = Some(refs_json(&[&h1, &h2]));
         let step_id = step.id.clone();
-        process_write(&pool, DbWrite::InsertStep(step)).await.unwrap();
+        process_write(&pool, DbWrite::InsertStep(step))
+            .await
+            .unwrap();
 
         process_write(
             &pool,
@@ -3179,7 +3338,9 @@ mod tests {
         // step references h1, output_line references h2
         let mut step = make_step("s-001", 0);
         step.attachments_json = Some(refs_json(&[&h1]));
-        process_write(&pool, DbWrite::InsertStep(step)).await.unwrap();
+        process_write(&pool, DbWrite::InsertStep(step))
+            .await
+            .unwrap();
         let line = serde_json::json!({
             "type": "verun_user_message",
             "text": "hi",
@@ -3198,7 +3359,9 @@ mod tests {
         assert_eq!(ref_count(&pool, &h1).await, 1);
         assert_eq!(ref_count(&pool, &h2).await, 1);
 
-        process_write(&pool, DbWrite::DeleteTask { id: "t-001".into() }).await.unwrap();
+        process_write(&pool, DbWrite::DeleteTask { id: "t-001".into() })
+            .await
+            .unwrap();
 
         assert_eq!(ref_count(&pool, &h1).await, 0);
         assert_eq!(ref_count(&pool, &h2).await, 0);
@@ -3211,7 +3374,9 @@ mod tests {
 
         let mut step = make_step("s-001", 0);
         step.attachments_json = Some(refs_json(&[&h1]));
-        process_write(&pool, DbWrite::InsertStep(step)).await.unwrap();
+        process_write(&pool, DbWrite::InsertStep(step))
+            .await
+            .unwrap();
         let line = serde_json::json!({
             "type": "verun_user_message",
             "text": "hi",
@@ -3228,7 +3393,9 @@ mod tests {
         .await
         .unwrap();
 
-        process_write(&pool, DbWrite::DeleteProject { id: "p-001".into() }).await.unwrap();
+        process_write(&pool, DbWrite::DeleteProject { id: "p-001".into() })
+            .await
+            .unwrap();
         assert_eq!(ref_count(&pool, &h1).await, 0);
         assert_eq!(ref_count(&pool, &h2).await, 0);
     }

--- a/src-tauri/src/fd_limit.rs
+++ b/src-tauri/src/fd_limit.rs
@@ -82,8 +82,8 @@ mod tests {
     fn caps_at_hard_limit() {
         let hard = current_hard();
         // Ask for more than the hard limit — result must not exceed hard.
-        let (_prev, new_soft) = raise_fd_limit_to(hard.saturating_add(1_000_000))
-            .expect("setrlimit failed");
+        let (_prev, new_soft) =
+            raise_fd_limit_to(hard.saturating_add(1_000_000)).expect("setrlimit failed");
         assert!(new_soft <= hard, "new_soft={new_soft} > hard={hard}");
     }
 

--- a/src-tauri/src/git_ops.rs
+++ b/src-tauri/src/git_ops.rs
@@ -11,6 +11,13 @@ fn git(cwd: &str) -> Command {
     cmd
 }
 
+/// Create a read-only git Command that avoids optional index writes.
+fn git_read_only(cwd: &str) -> Command {
+    let mut cmd = git(cwd);
+    cmd.arg("--no-optional-locks");
+    cmd
+}
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -102,7 +109,7 @@ pub fn get_git_status(worktree_path: &str) -> Result<GitStatus, String> {
 }
 
 fn parse_porcelain_status(worktree_path: &str) -> Result<Vec<FileStatus>, String> {
-    let output = git(worktree_path)
+    let output = git_read_only(worktree_path)
         .args(["status", "--porcelain"])
         .output()
         .map_err(|e| format!("Failed to run git status: {e}"))?;
@@ -171,14 +178,14 @@ fn parse_porcelain_status(worktree_path: &str) -> Result<Vec<FileStatus>, String
 
 fn parse_numstat(worktree_path: &str) -> Result<Vec<FileDiffStats>, String> {
     // Get stats for both staged and unstaged changes
-    let output = git(worktree_path)
+    let output = git_read_only(worktree_path)
         .args(["diff", "HEAD", "--numstat"])
         .output()
         .map_err(|e| format!("Failed to run git diff --numstat: {e}"))?;
 
     // HEAD might not exist yet (no commits) — fall back to diff of staged
     let stdout = if !output.status.success() {
-        let fallback = git(worktree_path)
+        let fallback = git_read_only(worktree_path)
             .args(["diff", "--cached", "--numstat"])
             .output()
             .map_err(|e| format!("Failed to run git diff --cached --numstat: {e}"))?;
@@ -230,7 +237,7 @@ pub fn get_file_diff(
     }
     args.extend(["HEAD", "--", file_path]);
 
-    let output = git(worktree_path)
+    let output = git_read_only(worktree_path)
         .args(&args)
         .output()
         .map_err(|e| format!("Failed to get file diff: {e}"))?;
@@ -243,7 +250,7 @@ pub fn get_file_diff(
         }
         fallback_args.extend(["--cached", "--", file_path]);
 
-        let fallback = git(worktree_path)
+        let fallback = git_read_only(worktree_path)
             .args(&fallback_args)
             .output()
             .map_err(|e| format!("Failed to get file diff: {e}"))?;
@@ -317,7 +324,7 @@ pub fn get_file_context(
 ) -> Result<Vec<String>, String> {
     let content = if version == "old" {
         // Read from HEAD
-        let output = git(worktree_path)
+        let output = git_read_only(worktree_path)
             .args(["show", &format!("HEAD:{file_path}")])
             .output()
             .map_err(|e| format!("Failed to read file from HEAD: {e}"))?;
@@ -491,7 +498,7 @@ pub struct BranchCommit {
 /// Returns `None` if no merge-base can be found.
 pub fn find_merge_base(worktree_path: &str, base_branch: &str) -> Option<String> {
     let remote = format!("origin/{base_branch}");
-    let remote_out = git(worktree_path)
+    let remote_out = git_read_only(worktree_path)
         .args(["merge-base", &remote, "HEAD"])
         .output()
         .ok()?;
@@ -504,7 +511,7 @@ pub fn find_merge_base(worktree_path: &str, base_branch: &str) -> Option<String>
         );
     }
 
-    let local = git(worktree_path)
+    let local = git_read_only(worktree_path)
         .args(["merge-base", base_branch, "HEAD"])
         .output()
         .ok()?;
@@ -532,7 +539,7 @@ pub fn get_branch_commits(
         },
     };
 
-    let output = git(worktree_path)
+    let output = git_read_only(worktree_path)
         .args([
             "log",
             &format!("{merge_base}..HEAD"),
@@ -552,7 +559,7 @@ pub fn get_branch_commits(
 /// Get files changed in a specific commit (as a GitStatus-like structure).
 pub fn get_commit_files(worktree_path: &str, commit_hash: &str) -> Result<GitStatus, String> {
     // Get file list with status
-    let output = git(worktree_path)
+    let output = git_read_only(worktree_path)
         .args([
             "diff-tree",
             "--no-commit-id",
@@ -587,7 +594,7 @@ pub fn get_commit_files(worktree_path: &str, commit_hash: &str) -> Result<GitSta
     }
 
     // Get stats
-    let stat_output = git(worktree_path)
+    let stat_output = git_read_only(worktree_path)
         .args([
             "diff-tree",
             "--no-commit-id",
@@ -643,7 +650,7 @@ pub fn get_commit_file_diff(
     }
     args.extend([commit_hash, "--", file_path]);
 
-    let output = git(worktree_path)
+    let output = git_read_only(worktree_path)
         .args(&args)
         .output()
         .map_err(|e| format!("Failed to get commit file diff: {e}"))?;
@@ -701,7 +708,7 @@ pub fn get_commit_file_diff(
 /// Read a file from a git revision via `git show <rev>:<path>`.
 /// Returns `(text, exists)`. Missing files are returned as empty + false.
 fn read_at_rev(worktree_path: &str, rev: &str, file_path: &str) -> (String, bool) {
-    let output = match git(worktree_path)
+    let output = match git_read_only(worktree_path)
         .args(["show", &format!("{rev}:{file_path}")])
         .output()
     {
@@ -716,7 +723,7 @@ fn read_at_rev(worktree_path: &str, rev: &str, file_path: &str) -> (String, bool
 
 /// Quick binary check — git's own --numstat marker is "-\t-".
 fn is_binary_diff(worktree_path: &str, args: &[&str]) -> bool {
-    let output = match git(worktree_path).args(args).output() {
+    let output = match git_read_only(worktree_path).args(args).output() {
         Ok(o) => o,
         Err(_) => return false,
     };
@@ -816,7 +823,7 @@ pub fn get_commit_file_contents(
 }
 
 fn get_all_commits(worktree_path: &str) -> Result<Vec<BranchCommit>, String> {
-    let output = git(worktree_path)
+    let output = git_read_only(worktree_path)
         .args(["log", "--format=%H%n%h%n%s%n%an%n%at", "--shortstat"])
         .output()
         .map_err(|e| format!("Failed to get commits: {e}"))?;
@@ -968,7 +975,7 @@ pub fn commit(worktree_path: &str, message: &str) -> Result<String, String> {
     }
 
     // Get the commit hash
-    let hash_output = git(worktree_path)
+    let hash_output = git_read_only(worktree_path)
         .args(["rev-parse", "HEAD"])
         .output()
         .map_err(|e| format!("Failed to get commit hash: {e}"))?;
@@ -981,7 +988,7 @@ pub fn commit(worktree_path: &str, message: &str) -> Result<String, String> {
 /// Push branch to remote. Uses -u to set upstream on first push.
 pub fn push_branch(worktree_path: &str) -> Result<(), String> {
     // Get current branch name
-    let output = git(worktree_path)
+    let output = git_read_only(worktree_path)
         .args(["rev-parse", "--abbrev-ref", "HEAD"])
         .output()
         .map_err(|e| format!("Failed to get branch: {e}"))?;
@@ -1023,6 +1030,7 @@ pub fn pull_branch(worktree_path: &str) -> Result<String, String> {
 mod tests {
     use super::*;
     use std::fs;
+    use std::time::{Duration, SystemTime};
 
     fn init_test_repo() -> (tempfile::TempDir, String) {
         let dir = tempfile::tempdir().unwrap();
@@ -1045,6 +1053,13 @@ mod tests {
         git(rp).args(["commit", "-m", "init"]).output().unwrap();
 
         (dir, rp.to_string())
+    }
+
+    fn index_mtime(repo_path: &str) -> SystemTime {
+        fs::metadata(format!("{repo_path}/.git/index"))
+            .unwrap()
+            .modified()
+            .unwrap()
     }
 
     #[test]
@@ -1085,6 +1100,20 @@ mod tests {
             .unwrap();
         assert_eq!(staged.staging, "staged");
         assert_eq!(staged.status, "A");
+    }
+
+    #[test]
+    fn get_git_status_does_not_touch_git_index() {
+        let (_dir, rp) = init_test_repo();
+
+        fs::write(format!("{rp}/README.md"), "# updated\n").unwrap();
+        let before = index_mtime(&rp);
+
+        std::thread::sleep(Duration::from_secs(1));
+        get_git_status(&rp).unwrap();
+        let after = index_mtime(&rp);
+
+        assert_eq!(after, before);
     }
 
     #[test]

--- a/src-tauri/src/github.rs
+++ b/src-tauri/src/github.rs
@@ -1,11 +1,11 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::process::Command;
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GitHubRepo {
     pub owner: String,
@@ -13,7 +13,7 @@ pub struct GitHubRepo {
     pub url: String,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PrInfo {
     pub number: u32,
@@ -293,7 +293,7 @@ fn capitalize(s: &str) -> String {
 // CI checks
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CiCheck {
     pub name: String,
@@ -305,7 +305,7 @@ pub struct CiCheck {
 // Workflow runs (GitHub Actions)
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct WorkflowRun {
     pub database_id: u64,
@@ -319,7 +319,7 @@ pub struct WorkflowRun {
     pub event: String,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct WorkflowJob {
     pub database_id: u64,
@@ -342,7 +342,11 @@ pub fn derive_run_state(status: &str, conclusion: Option<&str>) -> String {
     match s.as_str() {
         "queued" | "waiting" | "requested" | "pending" => "queued",
         "in_progress" => "running",
-        "completed" => match conclusion.map(str::trim).map(str::to_ascii_lowercase).as_deref() {
+        "completed" => match conclusion
+            .map(str::trim)
+            .map(str::to_ascii_lowercase)
+            .as_deref()
+        {
             Some("success") | Some("neutral") => "success",
             Some("failure") | Some("timed_out") | Some("action_required") => "failure",
             Some("cancelled") => "cancelled",
@@ -482,8 +486,7 @@ pub fn list_workflow_runs_for_branch(
 
 /// List jobs for a workflow run.
 pub fn list_jobs_for_run(worktree_path: &str, run_id: u64) -> Result<Vec<WorkflowJob>, String> {
-    let repo = detect_github_repo(worktree_path)?
-        .ok_or_else(|| "not a GitHub repo".to_string())?;
+    let repo = detect_github_repo(worktree_path)?.ok_or_else(|| "not a GitHub repo".to_string())?;
     let endpoint = format!(
         "repos/{}/{}/actions/runs/{}/jobs",
         repo.owner, repo.name, run_id
@@ -509,7 +512,6 @@ pub fn list_jobs_for_run(worktree_path: &str, run_id: u64) -> Result<Vec<Workflo
 /// so no individual step is marked failed).
 pub fn get_failed_step_logs(
     worktree_path: &str,
-    _run_id: u64,
     job_id: u64,
     max_bytes: usize,
 ) -> Result<String, String> {
@@ -540,7 +542,11 @@ pub fn get_failed_step_logs(
 }
 
 fn maybe_tail(s: &str, max_bytes: usize) -> String {
-    if max_bytes == 0 { s.to_string() } else { tail_bytes(s, max_bytes) }
+    if max_bytes == 0 {
+        s.to_string()
+    } else {
+        tail_bytes(s, max_bytes)
+    }
 }
 
 /// Re-run a workflow run. When `failed_only` is true, passes `--failed` to re-run only failed jobs.
@@ -552,9 +558,7 @@ pub fn rerun_workflow(worktree_path: &str, run_id: u64, failed_only: bool) -> Re
     if failed_only {
         cmd.arg("--failed");
     }
-    let output = cmd
-        .output()
-        .map_err(|e| format!("Failed to rerun: {e}"))?;
+    let output = cmd.output().map_err(|e| format!("Failed to rerun: {e}"))?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(format!("gh run rerun failed: {stderr}"));
@@ -762,7 +766,10 @@ mod tests {
 
     #[test]
     fn derive_state_completed_cancelled_and_skipped() {
-        assert_eq!(derive_run_state("completed", Some("cancelled")), "cancelled");
+        assert_eq!(
+            derive_run_state("completed", Some("cancelled")),
+            "cancelled"
+        );
         assert_eq!(derive_run_state("completed", Some("skipped")), "skipped");
         assert_eq!(derive_run_state("completed", Some("stale")), "skipped");
     }

--- a/src-tauri/src/github_remote.rs
+++ b/src-tauri/src/github_remote.rs
@@ -155,6 +155,30 @@ async fn singleflight_gate(cache_key: &str) -> Arc<TokioMutex<()>> {
         .clone()
 }
 
+async fn cleanup_singleflight_gate(cache_key: &str, gate: &Arc<TokioMutex<()>>) {
+    let mut gates = singleflight_gates().lock().await;
+    let should_remove = gates
+        .get(cache_key)
+        .map(|existing| Arc::ptr_eq(existing, gate) && Arc::strong_count(existing) == 2)
+        .unwrap_or(false);
+    if should_remove {
+        gates.remove(cache_key);
+    }
+}
+
+async fn with_singleflight<T, F, Fut>(cache_key: &str, work: F) -> Result<T, String>
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = Result<T, String>>,
+{
+    let gate = singleflight_gate(cache_key).await;
+    let guard = gate.lock().await;
+    let result = work().await;
+    drop(guard);
+    cleanup_singleflight_gate(cache_key, &gate).await;
+    result
+}
+
 fn schedule_revalidate<F, Fut>(
     pool: SqlitePool,
     task_id: String,
@@ -167,12 +191,15 @@ fn schedule_revalidate<F, Fut>(
     Fut: Future<Output = Result<bool, String>> + Send + 'static,
 {
     tokio::spawn(async move {
-        let gate = singleflight_gate(&cache_key).await;
-        let _guard = gate.lock().await;
-        let refreshed = work(pool).await.unwrap_or(false);
-        if refreshed {
-            if let Some(notify) = notifier {
-                notify(task_id, vec![scope.to_string()]);
+        match with_singleflight(&cache_key, move || work(pool)).await {
+            Ok(true) => {
+                if let Some(notify) = notifier {
+                    notify(task_id, vec![scope.to_string()]);
+                }
+            }
+            Ok(false) => {}
+            Err(err) => {
+                eprintln!("[verun][github-remote] revalidate {cache_key} failed: {err}");
             }
         }
     });
@@ -477,17 +504,18 @@ pub async fn get_overview(
         _ => {}
     }
 
-    let gate = singleflight_gate(&cache_key).await;
-    let _guard = gate.lock().await;
-    if mode != RemoteFetchMode::NetworkOnly {
-        if let CacheState::Fresh(payload, entry) =
-            cached_payload::<OverviewPayload>(pool, &cache_key, RemoteFetchMode::CacheFirst)
-                .await?
-        {
-            return Ok(overview_snapshot(payload, &entry, true));
+    with_singleflight(&cache_key, || async {
+        if mode != RemoteFetchMode::NetworkOnly {
+            if let CacheState::Fresh(payload, entry) =
+                cached_payload::<OverviewPayload>(pool, &cache_key, RemoteFetchMode::CacheFirst)
+                    .await?
+            {
+                return Ok(overview_snapshot(payload, &entry, true));
+            }
         }
-    }
-    fetch_overview_and_store(pool, task_id, worktree_path).await
+        fetch_overview_and_store(pool, task_id, worktree_path).await
+    })
+    .await
 }
 
 pub async fn get_actions(
@@ -537,12 +565,13 @@ pub async fn get_actions(
                             Ok(false)
                         }
                         CacheState::Miss | CacheState::Fresh(_, _) | CacheState::Stale(_, _) => {
+                            // Re-fetch enough rows to preserve the largest cached window we have seen.
                             fetch_actions_and_store(
                                 &pool,
                                 &fetch_task_id,
                                 &worktree_path,
-                                limit,
-                                Some(keep_limit),
+                                keep_limit,
+                                None,
                             )
                             .await?;
                             Ok(true)
@@ -555,22 +584,25 @@ pub async fn get_actions(
         _ => {}
     }
 
-    let gate = singleflight_gate(&cache_key).await;
-    let _guard = gate.lock().await;
-    let existing_limit = if mode != RemoteFetchMode::NetworkOnly {
-        match cached_payload::<ActionsPayload>(pool, &cache_key, RemoteFetchMode::CacheFirst)
-            .await?
-        {
-            CacheState::Fresh(payload, entry) if payload.cached_limit >= limit => {
-                return Ok(actions_snapshot(payload, &entry, limit, true));
+    with_singleflight(&cache_key, || async {
+        let existing_limit = if mode != RemoteFetchMode::NetworkOnly {
+            match cached_payload::<ActionsPayload>(pool, &cache_key, RemoteFetchMode::CacheFirst)
+                .await?
+            {
+                CacheState::Fresh(payload, entry) if payload.cached_limit >= limit => {
+                    return Ok(actions_snapshot(payload, &entry, limit, true));
+                }
+                CacheState::Fresh(payload, _) | CacheState::Stale(payload, _) => {
+                    Some(payload.cached_limit)
+                }
+                CacheState::Miss => None,
             }
-            CacheState::Fresh(payload, _) | CacheState::Stale(payload, _) => Some(payload.cached_limit),
-            CacheState::Miss => None,
-        }
-    } else {
-        None
-    };
-    fetch_actions_and_store(pool, task_id, worktree_path, limit, existing_limit).await
+        } else {
+            None
+        };
+        fetch_actions_and_store(pool, task_id, worktree_path, limit, existing_limit).await
+    })
+    .await
 }
 
 pub async fn get_workflow_jobs(
@@ -623,16 +655,17 @@ pub async fn get_workflow_jobs(
         _ => {}
     }
 
-    let gate = singleflight_gate(&cache_key).await;
-    let _guard = gate.lock().await;
-    if mode != RemoteFetchMode::NetworkOnly {
-        if let CacheState::Fresh(payload, entry) =
-            cached_payload::<JobsPayload>(pool, &cache_key, RemoteFetchMode::CacheFirst).await?
-        {
-            return Ok(jobs_snapshot(payload, &entry, true));
+    with_singleflight(&cache_key, || async {
+        if mode != RemoteFetchMode::NetworkOnly {
+            if let CacheState::Fresh(payload, entry) =
+                cached_payload::<JobsPayload>(pool, &cache_key, RemoteFetchMode::CacheFirst).await?
+            {
+                return Ok(jobs_snapshot(payload, &entry, true));
+            }
         }
-    }
-    fetch_jobs_and_store(pool, task_id, worktree_path, run_id).await
+        fetch_jobs_and_store(pool, task_id, worktree_path, run_id).await
+    })
+    .await
 }
 
 pub async fn get_workflow_log(
@@ -688,16 +721,17 @@ pub async fn get_workflow_log(
         _ => {}
     }
 
-    let gate = singleflight_gate(&cache_key).await;
-    let _guard = gate.lock().await;
-    if mode != RemoteFetchMode::NetworkOnly {
-        if let CacheState::Fresh(payload, entry) =
-            cached_payload::<LogPayload>(pool, &cache_key, RemoteFetchMode::CacheFirst).await?
-        {
-            return Ok(log_snapshot(payload, &entry, max_bytes, true));
+    with_singleflight(&cache_key, || async {
+        if mode != RemoteFetchMode::NetworkOnly {
+            if let CacheState::Fresh(payload, entry) =
+                cached_payload::<LogPayload>(pool, &cache_key, RemoteFetchMode::CacheFirst).await?
+            {
+                return Ok(log_snapshot(payload, &entry, max_bytes, true));
+            }
         }
-    }
-    fetch_log_and_store(pool, task_id, worktree_path, job_id, max_bytes).await
+        fetch_log_and_store(pool, task_id, worktree_path, job_id, max_bytes).await
+    })
+    .await
 }
 
 #[cfg(test)]
@@ -862,6 +896,10 @@ mod tests {
             .unwrap_or(0)
     }
 
+    async fn gate_count() -> usize {
+        singleflight_gates().lock().await.len()
+    }
+
     #[tokio::test]
     async fn smaller_actions_limit_reuses_larger_cached_result() {
         let _lock = test_env_lock().lock().unwrap_or_else(|poison| poison.into_inner());
@@ -902,6 +940,7 @@ mod tests {
         assert_eq!(second.runs.len(), 1);
         assert!(second.from_cache);
         assert_eq!(read_count(&count_file), 1);
+        assert_eq!(gate_count().await, 0);
     }
 
     #[tokio::test]
@@ -985,6 +1024,7 @@ mod tests {
         assert_eq!(refreshed.runs[0].database_id, 2);
         assert!(!refreshed.is_stale);
         assert_eq!(read_count(&count_file), 2);
+        assert_eq!(gate_count().await, 0);
     }
 
     #[tokio::test]
@@ -1021,5 +1061,98 @@ mod tests {
         assert_eq!(first.unwrap().runs.len(), 2);
         assert_eq!(second.unwrap().runs.len(), 2);
         assert_eq!(read_count(&count_file), 1);
+        assert_eq!(gate_count().await, 0);
+    }
+
+    #[tokio::test]
+    async fn network_only_bypasses_fresh_actions_cache() {
+        let _lock = test_env_lock().lock().unwrap_or_else(|poison| poison.into_inner());
+        let pool = test_pool().await;
+        let (_temp, repo) = setup_git_repo();
+        let bin_dir = repo.join("bin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        seed_task(&pool, "task-4", &repo).await;
+        let output_file = repo.join("runs.json");
+        let count_file = repo.join("gh-count.txt");
+        std::fs::write(&output_file, actions_json(&[11])).unwrap();
+        write_fake_gh(&bin_dir, &output_file, &count_file, 0);
+        let _path_guard = PathGuard::install(&bin_dir);
+
+        get_actions(
+            &pool,
+            "task-4",
+            repo.to_str().unwrap(),
+            1,
+            RemoteFetchMode::CacheFirst,
+            None,
+        )
+        .await
+        .unwrap();
+        std::fs::write(&output_file, actions_json(&[12])).unwrap();
+
+        let refreshed = get_actions(
+            &pool,
+            "task-4",
+            repo.to_str().unwrap(),
+            1,
+            RemoteFetchMode::NetworkOnly,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(refreshed.runs[0].database_id, 12);
+        assert_eq!(read_count(&count_file), 2);
+        assert_eq!(gate_count().await, 0);
+    }
+
+    #[tokio::test]
+    async fn expired_actions_cache_falls_back_to_miss() {
+        let _lock = test_env_lock().lock().unwrap_or_else(|poison| poison.into_inner());
+        let pool = test_pool().await;
+        let (_temp, repo) = setup_git_repo();
+        let bin_dir = repo.join("bin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        seed_task(&pool, "task-5", &repo).await;
+        let output_file = repo.join("runs.json");
+        let count_file = repo.join("gh-count.txt");
+        std::fs::write(&output_file, actions_json(&[21])).unwrap();
+        write_fake_gh(&bin_dir, &output_file, &count_file, 0);
+        let _path_guard = PathGuard::install(&bin_dir);
+
+        get_actions(
+            &pool,
+            "task-5",
+            repo.to_str().unwrap(),
+            1,
+            RemoteFetchMode::CacheFirst,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let mut entry = db::get_github_cache_entry(&pool, "task-5:actions")
+            .await
+            .unwrap()
+            .unwrap();
+        entry.stale_at = now_ms() - 10_000;
+        entry.expires_at = now_ms() - 1;
+        db::upsert_github_cache_entry(&pool, &entry).await.unwrap();
+        std::fs::write(&output_file, actions_json(&[22])).unwrap();
+
+        let refreshed = get_actions(
+            &pool,
+            "task-5",
+            repo.to_str().unwrap(),
+            1,
+            RemoteFetchMode::CacheFirst,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(refreshed.runs[0].database_id, 22);
+        assert_eq!(read_count(&count_file), 2);
+        assert_eq!(gate_count().await, 0);
     }
 }

--- a/src-tauri/src/github_remote.rs
+++ b/src-tauri/src/github_remote.rs
@@ -1,0 +1,1025 @@
+use crate::db;
+use crate::github::{self, CiCheck, GitHubRepo, PrInfo, WorkflowJob, WorkflowRun};
+use serde::{Deserialize, Serialize};
+use sqlx::sqlite::SqlitePool;
+use std::collections::HashMap;
+use std::future::Future;
+use std::sync::{Arc, OnceLock};
+use tokio::sync::Mutex as TokioMutex;
+use tokio::task::JoinError;
+
+const OVERVIEW_STALE_MS: i64 = 15_000;
+const OVERVIEW_EXPIRE_MS: i64 = 10 * 60_000;
+const ACTIONS_STALE_MS: i64 = 30_000;
+const ACTIONS_EXPIRE_MS: i64 = 10 * 60_000;
+const JOBS_STALE_MS: i64 = 30_000;
+const JOBS_EXPIRE_MS: i64 = 24 * 60 * 60_000;
+const LOGS_STALE_MS: i64 = 24 * 60 * 60_000;
+const LOGS_EXPIRE_MS: i64 = 7 * 24 * 60 * 60_000;
+
+pub type InvalidateFn = Arc<dyn Fn(String, Vec<String>) + Send + Sync + 'static>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RemoteFetchMode {
+    CacheFirst,
+    StaleWhileRevalidate,
+    NetworkOnly,
+}
+
+impl RemoteFetchMode {
+    pub fn parse(value: Option<&str>) -> Self {
+        match value.unwrap_or("cache-first") {
+            "network-only" => Self::NetworkOnly,
+            "stale-while-revalidate" => Self::StaleWhileRevalidate,
+            _ => Self::CacheFirst,
+        }
+    }
+
+    fn allows_cache(self) -> bool {
+        !matches!(self, Self::NetworkOnly)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GitHubOverviewSnapshot {
+    pub github: Option<GitHubRepo>,
+    pub branch_url: Option<String>,
+    pub pr: Option<PrInfo>,
+    pub checks: Vec<CiCheck>,
+    pub fetched_at: i64,
+    pub stale_at: i64,
+    pub expires_at: i64,
+    pub is_stale: bool,
+    pub from_cache: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GitHubActionsSnapshot {
+    pub runs: Vec<WorkflowRun>,
+    pub fetched_at: i64,
+    pub stale_at: i64,
+    pub expires_at: i64,
+    pub is_stale: bool,
+    pub from_cache: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowJobsSnapshot {
+    pub run_id: u64,
+    pub jobs: Vec<WorkflowJob>,
+    pub fetched_at: i64,
+    pub stale_at: i64,
+    pub expires_at: i64,
+    pub is_stale: bool,
+    pub from_cache: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowLogSnapshot {
+    pub job_id: u64,
+    pub text: String,
+    pub fetched_at: i64,
+    pub stale_at: i64,
+    pub expires_at: i64,
+    pub is_stale: bool,
+    pub from_cache: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OverviewPayload {
+    github: Option<GitHubRepo>,
+    branch_url: Option<String>,
+    pr: Option<PrInfo>,
+    checks: Vec<CiCheck>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ActionsPayload {
+    cached_limit: u32,
+    runs: Vec<WorkflowRun>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct JobsPayload {
+    run_id: u64,
+    jobs: Vec<WorkflowJob>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LogPayload {
+    job_id: u64,
+    text: String,
+}
+
+enum CacheState<T> {
+    Miss,
+    Fresh(T, db::GitHubCacheEntry),
+    Stale(T, db::GitHubCacheEntry),
+}
+
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64
+}
+
+fn make_cache_key(task_id: &str, scope: &str, entity_id: Option<&str>) -> String {
+    match entity_id {
+        Some(id) => format!("{task_id}:{scope}:{id}"),
+        None => format!("{task_id}:{scope}"),
+    }
+}
+
+fn flatten_join<T>(result: Result<Result<T, String>, JoinError>) -> Result<T, String> {
+    result.map_err(|e| format!("Task join error: {e}"))?
+}
+
+fn singleflight_gates() -> &'static TokioMutex<HashMap<String, Arc<TokioMutex<()>>>> {
+    static GATES: OnceLock<TokioMutex<HashMap<String, Arc<TokioMutex<()>>>>> = OnceLock::new();
+    GATES.get_or_init(|| TokioMutex::new(HashMap::new()))
+}
+
+async fn singleflight_gate(cache_key: &str) -> Arc<TokioMutex<()>> {
+    let mut gates = singleflight_gates().lock().await;
+    gates.entry(cache_key.to_string())
+        .or_insert_with(|| Arc::new(TokioMutex::new(())))
+        .clone()
+}
+
+fn schedule_revalidate<F, Fut>(
+    pool: SqlitePool,
+    task_id: String,
+    cache_key: String,
+    scope: &'static str,
+    notifier: Option<InvalidateFn>,
+    work: F,
+) where
+    F: FnOnce(SqlitePool) -> Fut + Send + 'static,
+    Fut: Future<Output = Result<bool, String>> + Send + 'static,
+{
+    tokio::spawn(async move {
+        let gate = singleflight_gate(&cache_key).await;
+        let _guard = gate.lock().await;
+        let refreshed = work(pool).await.unwrap_or(false);
+        if refreshed {
+            if let Some(notify) = notifier {
+                notify(task_id, vec![scope.to_string()]);
+            }
+        }
+    });
+}
+
+async fn cached_payload<T: for<'de> Deserialize<'de>>(
+    pool: &SqlitePool,
+    cache_key: &str,
+    mode: RemoteFetchMode,
+) -> Result<CacheState<T>, String> {
+    if !mode.allows_cache() {
+        return Ok(CacheState::Miss);
+    }
+    let Some(entry) = db::get_github_cache_entry(pool, cache_key).await? else {
+        return Ok(CacheState::Miss);
+    };
+    let now = now_ms();
+    if now >= entry.expires_at {
+        return Ok(CacheState::Miss);
+    }
+    let payload = serde_json::from_str::<T>(&entry.payload_json)
+        .map_err(|e| format!("parse cached github payload: {e}"))?;
+    if now >= entry.stale_at {
+        Ok(CacheState::Stale(payload, entry))
+    } else {
+        Ok(CacheState::Fresh(payload, entry))
+    }
+}
+
+async fn write_payload<T: Serialize>(
+    pool: &SqlitePool,
+    task_id: &str,
+    scope: &str,
+    entity_id: Option<String>,
+    stale_ms: i64,
+    expire_ms: i64,
+    payload: &T,
+) -> Result<db::GitHubCacheEntry, String> {
+    let fetched_at = now_ms();
+    let entry = db::GitHubCacheEntry {
+        cache_key: make_cache_key(task_id, scope, entity_id.as_deref()),
+        task_id: task_id.to_string(),
+        scope: scope.to_string(),
+        entity_id,
+        payload_json: serde_json::to_string(payload)
+            .map_err(|e| format!("serialize github payload: {e}"))?,
+        fetched_at,
+        stale_at: fetched_at + stale_ms,
+        expires_at: fetched_at + expire_ms,
+    };
+    db::upsert_github_cache_entry(pool, &entry).await?;
+    Ok(entry)
+}
+
+fn overview_snapshot(
+    payload: OverviewPayload,
+    entry: &db::GitHubCacheEntry,
+    from_cache: bool,
+) -> GitHubOverviewSnapshot {
+    GitHubOverviewSnapshot {
+        github: payload.github,
+        branch_url: payload.branch_url,
+        pr: payload.pr,
+        checks: payload.checks,
+        fetched_at: entry.fetched_at,
+        stale_at: entry.stale_at,
+        expires_at: entry.expires_at,
+        is_stale: now_ms() >= entry.stale_at,
+        from_cache,
+    }
+}
+
+fn actions_snapshot(
+    payload: ActionsPayload,
+    entry: &db::GitHubCacheEntry,
+    limit: u32,
+    from_cache: bool,
+) -> GitHubActionsSnapshot {
+    GitHubActionsSnapshot {
+        runs: payload.runs.into_iter().take(limit as usize).collect(),
+        fetched_at: entry.fetched_at,
+        stale_at: entry.stale_at,
+        expires_at: entry.expires_at,
+        is_stale: now_ms() >= entry.stale_at,
+        from_cache,
+    }
+}
+
+fn jobs_snapshot(
+    payload: JobsPayload,
+    entry: &db::GitHubCacheEntry,
+    from_cache: bool,
+) -> WorkflowJobsSnapshot {
+    WorkflowJobsSnapshot {
+        run_id: payload.run_id,
+        jobs: payload.jobs,
+        fetched_at: entry.fetched_at,
+        stale_at: entry.stale_at,
+        expires_at: entry.expires_at,
+        is_stale: now_ms() >= entry.stale_at,
+        from_cache,
+    }
+}
+
+fn log_snapshot(
+    payload: LogPayload,
+    entry: &db::GitHubCacheEntry,
+    max_bytes: usize,
+    from_cache: bool,
+) -> WorkflowLogSnapshot {
+    let text = if max_bytes == 0 {
+        payload.text
+    } else {
+        github::tail_bytes(&payload.text, max_bytes)
+    };
+    WorkflowLogSnapshot {
+        job_id: payload.job_id,
+        text,
+        fetched_at: entry.fetched_at,
+        stale_at: entry.stale_at,
+        expires_at: entry.expires_at,
+        is_stale: now_ms() >= entry.stale_at,
+        from_cache,
+    }
+}
+
+fn fetch_overview_blocking(worktree_path: String) -> Result<OverviewPayload, String> {
+    let github = github::detect_github_repo(&worktree_path)?;
+    let (pr, checks, branch_url) = if github.is_some() {
+        let pr = github::get_pr_for_branch(&worktree_path)?;
+        let checks = if pr.is_some() {
+            github::get_ci_checks(&worktree_path)?
+        } else {
+            Vec::new()
+        };
+        let branch_url = github::get_branch_url(&worktree_path)?;
+        (pr, checks, branch_url)
+    } else {
+        (None, Vec::new(), None)
+    };
+
+    Ok(OverviewPayload {
+        github,
+        branch_url,
+        pr,
+        checks,
+    })
+}
+
+async fn fetch_overview_and_store(
+    pool: &SqlitePool,
+    task_id: &str,
+    worktree_path: &str,
+) -> Result<GitHubOverviewSnapshot, String> {
+    let worktree_path = worktree_path.to_string();
+    let payload = flatten_join(
+        tokio::task::spawn_blocking(move || fetch_overview_blocking(worktree_path)).await,
+    )?;
+    let entry = write_payload(
+        pool,
+        task_id,
+        "overview",
+        None,
+        OVERVIEW_STALE_MS,
+        OVERVIEW_EXPIRE_MS,
+        &payload,
+    )
+    .await?;
+    Ok(overview_snapshot(payload, &entry, false))
+}
+
+async fn fetch_actions_and_store(
+    pool: &SqlitePool,
+    task_id: &str,
+    worktree_path: &str,
+    limit: u32,
+    existing_limit: Option<u32>,
+) -> Result<GitHubActionsSnapshot, String> {
+    let requested_limit = limit.max(existing_limit.unwrap_or(0));
+    let worktree_path = worktree_path.to_string();
+    let runs = flatten_join(
+        tokio::task::spawn_blocking(move || {
+            github::list_workflow_runs_for_branch(&worktree_path, requested_limit)
+        })
+        .await,
+    )?;
+    let payload = ActionsPayload {
+        cached_limit: requested_limit,
+        runs,
+    };
+    let entry = write_payload(
+        pool,
+        task_id,
+        "actions",
+        None,
+        ACTIONS_STALE_MS,
+        ACTIONS_EXPIRE_MS,
+        &payload,
+    )
+    .await?;
+    Ok(actions_snapshot(payload, &entry, limit, false))
+}
+
+async fn fetch_jobs_and_store(
+    pool: &SqlitePool,
+    task_id: &str,
+    worktree_path: &str,
+    run_id: u64,
+) -> Result<WorkflowJobsSnapshot, String> {
+    let worktree_path = worktree_path.to_string();
+    let jobs = flatten_join(
+        tokio::task::spawn_blocking(move || github::list_jobs_for_run(&worktree_path, run_id))
+            .await,
+    )?;
+    let payload = JobsPayload { run_id, jobs };
+    let entry = write_payload(
+        pool,
+        task_id,
+        "jobs",
+        Some(run_id.to_string()),
+        JOBS_STALE_MS,
+        JOBS_EXPIRE_MS,
+        &payload,
+    )
+    .await?;
+    Ok(jobs_snapshot(payload, &entry, false))
+}
+
+async fn fetch_log_and_store(
+    pool: &SqlitePool,
+    task_id: &str,
+    worktree_path: &str,
+    job_id: u64,
+    max_bytes: usize,
+) -> Result<WorkflowLogSnapshot, String> {
+    let worktree_path = worktree_path.to_string();
+    let full_text = flatten_join(
+        tokio::task::spawn_blocking(move || github::get_failed_step_logs(&worktree_path, job_id, 0))
+            .await,
+    )?;
+    let payload = LogPayload {
+        job_id,
+        text: full_text,
+    };
+    let entry = write_payload(
+        pool,
+        task_id,
+        "logs",
+        Some(job_id.to_string()),
+        LOGS_STALE_MS,
+        LOGS_EXPIRE_MS,
+        &payload,
+    )
+    .await?;
+    Ok(log_snapshot(payload, &entry, max_bytes, false))
+}
+
+pub async fn get_overview(
+    pool: &SqlitePool,
+    task_id: &str,
+    worktree_path: &str,
+    mode: RemoteFetchMode,
+    on_invalidate: Option<InvalidateFn>,
+) -> Result<GitHubOverviewSnapshot, String> {
+    let cache_key = make_cache_key(task_id, "overview", None);
+    match cached_payload::<OverviewPayload>(pool, &cache_key, mode).await? {
+        CacheState::Fresh(payload, entry) => return Ok(overview_snapshot(payload, &entry, true)),
+        CacheState::Stale(payload, entry) if mode == RemoteFetchMode::CacheFirst => {
+            return Ok(overview_snapshot(payload, &entry, true));
+        }
+        CacheState::Stale(payload, entry) if mode == RemoteFetchMode::StaleWhileRevalidate => {
+            let pool = pool.clone();
+            let fetch_task_id = task_id.to_string();
+            let notify_task_id = task_id.to_string();
+            let worktree_path = worktree_path.to_string();
+            let refresh_key = cache_key.clone();
+            let notifier = on_invalidate.clone();
+            schedule_revalidate(
+                pool,
+                notify_task_id,
+                refresh_key.clone(),
+                "overview",
+                notifier,
+                move |pool| async move {
+                    match cached_payload::<OverviewPayload>(
+                        &pool,
+                        &refresh_key,
+                        RemoteFetchMode::CacheFirst,
+                    )
+                    .await?
+                    {
+                        CacheState::Fresh(_, _) => Ok(false),
+                        CacheState::Miss | CacheState::Stale(_, _) => {
+                            fetch_overview_and_store(&pool, &fetch_task_id, &worktree_path).await?;
+                            Ok(true)
+                        }
+                    }
+                },
+            );
+            return Ok(overview_snapshot(payload, &entry, true));
+        }
+        _ => {}
+    }
+
+    let gate = singleflight_gate(&cache_key).await;
+    let _guard = gate.lock().await;
+    if mode != RemoteFetchMode::NetworkOnly {
+        if let CacheState::Fresh(payload, entry) =
+            cached_payload::<OverviewPayload>(pool, &cache_key, RemoteFetchMode::CacheFirst)
+                .await?
+        {
+            return Ok(overview_snapshot(payload, &entry, true));
+        }
+    }
+    fetch_overview_and_store(pool, task_id, worktree_path).await
+}
+
+pub async fn get_actions(
+    pool: &SqlitePool,
+    task_id: &str,
+    worktree_path: &str,
+    limit: u32,
+    mode: RemoteFetchMode,
+    on_invalidate: Option<InvalidateFn>,
+) -> Result<GitHubActionsSnapshot, String> {
+    let cache_key = make_cache_key(task_id, "actions", None);
+    match cached_payload::<ActionsPayload>(pool, &cache_key, mode).await? {
+        CacheState::Fresh(payload, entry) if payload.cached_limit >= limit => {
+            return Ok(actions_snapshot(payload, &entry, limit, true));
+        }
+        CacheState::Stale(payload, entry)
+            if payload.cached_limit >= limit && mode == RemoteFetchMode::CacheFirst =>
+        {
+            return Ok(actions_snapshot(payload, &entry, limit, true));
+        }
+        CacheState::Stale(payload, entry)
+            if payload.cached_limit >= limit
+                && mode == RemoteFetchMode::StaleWhileRevalidate =>
+        {
+            let pool = pool.clone();
+            let fetch_task_id = task_id.to_string();
+            let notify_task_id = task_id.to_string();
+            let worktree_path = worktree_path.to_string();
+            let refresh_key = cache_key.clone();
+            let notifier = on_invalidate.clone();
+            let keep_limit = payload.cached_limit.max(limit);
+            schedule_revalidate(
+                pool,
+                notify_task_id,
+                refresh_key.clone(),
+                "actions",
+                notifier,
+                move |pool| async move {
+                    match cached_payload::<ActionsPayload>(
+                        &pool,
+                        &refresh_key,
+                        RemoteFetchMode::CacheFirst,
+                    )
+                    .await?
+                    {
+                        CacheState::Fresh(existing, _) if existing.cached_limit >= keep_limit => {
+                            Ok(false)
+                        }
+                        CacheState::Miss | CacheState::Fresh(_, _) | CacheState::Stale(_, _) => {
+                            fetch_actions_and_store(
+                                &pool,
+                                &fetch_task_id,
+                                &worktree_path,
+                                limit,
+                                Some(keep_limit),
+                            )
+                            .await?;
+                            Ok(true)
+                        }
+                    }
+                },
+            );
+            return Ok(actions_snapshot(payload, &entry, limit, true));
+        }
+        _ => {}
+    }
+
+    let gate = singleflight_gate(&cache_key).await;
+    let _guard = gate.lock().await;
+    let existing_limit = if mode != RemoteFetchMode::NetworkOnly {
+        match cached_payload::<ActionsPayload>(pool, &cache_key, RemoteFetchMode::CacheFirst)
+            .await?
+        {
+            CacheState::Fresh(payload, entry) if payload.cached_limit >= limit => {
+                return Ok(actions_snapshot(payload, &entry, limit, true));
+            }
+            CacheState::Fresh(payload, _) | CacheState::Stale(payload, _) => Some(payload.cached_limit),
+            CacheState::Miss => None,
+        }
+    } else {
+        None
+    };
+    fetch_actions_and_store(pool, task_id, worktree_path, limit, existing_limit).await
+}
+
+pub async fn get_workflow_jobs(
+    pool: &SqlitePool,
+    task_id: &str,
+    worktree_path: &str,
+    run_id: u64,
+    mode: RemoteFetchMode,
+    on_invalidate: Option<InvalidateFn>,
+) -> Result<WorkflowJobsSnapshot, String> {
+    let run_key = run_id.to_string();
+    let cache_key = make_cache_key(task_id, "jobs", Some(&run_key));
+    match cached_payload::<JobsPayload>(pool, &cache_key, mode).await? {
+        CacheState::Fresh(payload, entry) => return Ok(jobs_snapshot(payload, &entry, true)),
+        CacheState::Stale(payload, entry) if mode == RemoteFetchMode::CacheFirst => {
+            return Ok(jobs_snapshot(payload, &entry, true));
+        }
+        CacheState::Stale(payload, entry) if mode == RemoteFetchMode::StaleWhileRevalidate => {
+            let pool = pool.clone();
+            let fetch_task_id = task_id.to_string();
+            let notify_task_id = task_id.to_string();
+            let worktree_path = worktree_path.to_string();
+            let refresh_key = cache_key.clone();
+            let notifier = on_invalidate.clone();
+            schedule_revalidate(
+                pool,
+                notify_task_id,
+                refresh_key.clone(),
+                "jobs",
+                notifier,
+                move |pool| async move {
+                    match cached_payload::<JobsPayload>(
+                        &pool,
+                        &refresh_key,
+                        RemoteFetchMode::CacheFirst,
+                    )
+                    .await?
+                    {
+                        CacheState::Fresh(_, _) => Ok(false),
+                        CacheState::Miss | CacheState::Stale(_, _) => {
+                            fetch_jobs_and_store(&pool, &fetch_task_id, &worktree_path, run_id)
+                                .await?;
+                            Ok(true)
+                        }
+                    }
+                },
+            );
+            return Ok(jobs_snapshot(payload, &entry, true));
+        }
+        _ => {}
+    }
+
+    let gate = singleflight_gate(&cache_key).await;
+    let _guard = gate.lock().await;
+    if mode != RemoteFetchMode::NetworkOnly {
+        if let CacheState::Fresh(payload, entry) =
+            cached_payload::<JobsPayload>(pool, &cache_key, RemoteFetchMode::CacheFirst).await?
+        {
+            return Ok(jobs_snapshot(payload, &entry, true));
+        }
+    }
+    fetch_jobs_and_store(pool, task_id, worktree_path, run_id).await
+}
+
+pub async fn get_workflow_log(
+    pool: &SqlitePool,
+    task_id: &str,
+    worktree_path: &str,
+    job_id: u64,
+    max_bytes: usize,
+    mode: RemoteFetchMode,
+    on_invalidate: Option<InvalidateFn>,
+) -> Result<WorkflowLogSnapshot, String> {
+    let job_key = job_id.to_string();
+    let cache_key = make_cache_key(task_id, "logs", Some(&job_key));
+    match cached_payload::<LogPayload>(pool, &cache_key, mode).await? {
+        CacheState::Fresh(payload, entry) => {
+            return Ok(log_snapshot(payload, &entry, max_bytes, true));
+        }
+        CacheState::Stale(payload, entry) if mode == RemoteFetchMode::CacheFirst => {
+            return Ok(log_snapshot(payload, &entry, max_bytes, true));
+        }
+        CacheState::Stale(payload, entry) if mode == RemoteFetchMode::StaleWhileRevalidate => {
+            let pool = pool.clone();
+            let fetch_task_id = task_id.to_string();
+            let notify_task_id = task_id.to_string();
+            let worktree_path = worktree_path.to_string();
+            let refresh_key = cache_key.clone();
+            let notifier = on_invalidate.clone();
+            schedule_revalidate(
+                pool,
+                notify_task_id,
+                refresh_key.clone(),
+                "logs",
+                notifier,
+                move |pool| async move {
+                    match cached_payload::<LogPayload>(
+                        &pool,
+                        &refresh_key,
+                        RemoteFetchMode::CacheFirst,
+                    )
+                    .await?
+                    {
+                        CacheState::Fresh(_, _) => Ok(false),
+                        CacheState::Miss | CacheState::Stale(_, _) => {
+                            fetch_log_and_store(&pool, &fetch_task_id, &worktree_path, job_id, 0)
+                                .await?;
+                            Ok(true)
+                        }
+                    }
+                },
+            );
+            return Ok(log_snapshot(payload, &entry, max_bytes, true));
+        }
+        _ => {}
+    }
+
+    let gate = singleflight_gate(&cache_key).await;
+    let _guard = gate.lock().await;
+    if mode != RemoteFetchMode::NetworkOnly {
+        if let CacheState::Fresh(payload, entry) =
+            cached_payload::<LogPayload>(pool, &cache_key, RemoteFetchMode::CacheFirst).await?
+        {
+            return Ok(log_snapshot(payload, &entry, max_bytes, true));
+        }
+    }
+    fetch_log_and_store(pool, task_id, worktree_path, job_id, max_bytes).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db;
+    use sqlx::sqlite::SqlitePool;
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tempfile::TempDir;
+    use tokio::time::{sleep, timeout, Duration};
+
+    fn test_env_lock() -> &'static std::sync::Mutex<()> {
+        static LOCK: OnceLock<std::sync::Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| std::sync::Mutex::new(()))
+    }
+
+    struct PathGuard {
+        original: Option<String>,
+    }
+
+    impl PathGuard {
+        fn install(bin_dir: &Path) -> Self {
+            let original = std::env::var("PATH").ok();
+            let mut parts = vec![bin_dir.display().to_string()];
+            if let Some(path) = &original {
+                parts.push(path.clone());
+            }
+            let joined = parts.join(":");
+            unsafe { std::env::set_var("PATH", joined) };
+            Self { original }
+        }
+    }
+
+    impl Drop for PathGuard {
+        fn drop(&mut self) {
+            match &self.original {
+                Some(path) => unsafe { std::env::set_var("PATH", path) },
+                None => unsafe { std::env::remove_var("PATH") },
+            }
+        }
+    }
+
+    async fn test_pool() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        for m in db::migrations() {
+            sqlx::query(m.sql).execute(&pool).await.unwrap();
+        }
+        pool
+    }
+
+    async fn seed_task(pool: &SqlitePool, task_id: &str, repo: &Path) {
+        sqlx::query(
+            "INSERT INTO projects (id, name, repo_path, base_branch, setup_hook, destroy_hook, start_command, auto_start, created_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind("p-test")
+        .bind("Test Project")
+        .bind(repo.display().to_string())
+        .bind("main")
+        .bind("")
+        .bind("")
+        .bind("")
+        .bind(false)
+        .bind(1_i64)
+        .execute(pool)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "INSERT INTO tasks (id, project_id, name, worktree_path, branch, created_at, port_offset, parent_task_id, agent_type)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(task_id)
+        .bind("p-test")
+        .bind(Option::<String>::None)
+        .bind(repo.display().to_string())
+        .bind("feat/test")
+        .bind(2_i64)
+        .bind(0_i64)
+        .bind(Option::<String>::None)
+        .bind("claude")
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    fn setup_git_repo() -> (TempDir, PathBuf) {
+        let temp = tempfile::tempdir().unwrap();
+        let repo = temp.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let status = Command::new("git")
+            .args(["init", "-b", "feat/test"])
+            .current_dir(&repo)
+            .status()
+            .unwrap();
+        assert!(status.success());
+        let status = Command::new("git")
+            .args(["config", "user.email", "tests@example.com"])
+            .current_dir(&repo)
+            .status()
+            .unwrap();
+        assert!(status.success());
+        let status = Command::new("git")
+            .args(["config", "user.name", "Verun Tests"])
+            .current_dir(&repo)
+            .status()
+            .unwrap();
+        assert!(status.success());
+        std::fs::write(repo.join("README.md"), "test\n").unwrap();
+        let status = Command::new("git")
+            .args(["add", "README.md"])
+            .current_dir(&repo)
+            .status()
+            .unwrap();
+        assert!(status.success());
+        let status = Command::new("git")
+            .args(["commit", "-m", "init"])
+            .current_dir(&repo)
+            .status()
+            .unwrap();
+        assert!(status.success());
+        (temp, repo)
+    }
+
+    fn write_fake_gh(bin_dir: &Path, output_file: &Path, count_file: &Path, sleep_ms: u64) {
+        let script = format!(
+            "#!/bin/sh\ncount=$(cat \"{count}\" 2>/dev/null || echo 0)\necho $((count + 1)) > \"{count}\"\nif [ \"{sleep_ms}\" -gt 0 ]; then\n  sleep \"0.$(printf '%03d' {sleep_ms})\"\nfi\ncat \"{output}\"\n",
+            count = count_file.display(),
+            output = output_file.display(),
+            sleep_ms = sleep_ms,
+        );
+        let path = bin_dir.join("gh");
+        std::fs::write(&path, script).unwrap();
+        let mut perms = std::fs::metadata(&path).unwrap().permissions();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&path, perms).unwrap();
+        }
+    }
+
+    fn actions_json(ids: &[u64]) -> String {
+        let runs = ids
+            .iter()
+            .map(|id| {
+                format!(
+                    "{{\"databaseId\":{id},\"number\":{id},\"workflowName\":\"CI\",\"status\":\"completed\",\"conclusion\":\"success\",\"url\":\"https://example.com/{id}\",\"createdAt\":\"2026-04-20T10:00:00Z\",\"headSha\":\"abc{id}\",\"headBranch\":\"feat/test\",\"event\":\"push\"}}"
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(",");
+        format!("[{runs}]")
+    }
+
+    fn read_count(path: &Path) -> usize {
+        std::fs::read_to_string(path)
+            .ok()
+            .and_then(|s| s.trim().parse().ok())
+            .unwrap_or(0)
+    }
+
+    #[tokio::test]
+    async fn smaller_actions_limit_reuses_larger_cached_result() {
+        let _lock = test_env_lock().lock().unwrap_or_else(|poison| poison.into_inner());
+        let pool = test_pool().await;
+        let (_temp, repo) = setup_git_repo();
+        let bin_dir = repo.join("bin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        seed_task(&pool, "task-1", &repo).await;
+        let output_file = repo.join("runs.json");
+        let count_file = repo.join("gh-count.txt");
+        std::fs::write(&output_file, actions_json(&[1, 2, 3])).unwrap();
+        write_fake_gh(&bin_dir, &output_file, &count_file, 0);
+        let _path_guard = PathGuard::install(&bin_dir);
+
+        let first = get_actions(
+            &pool,
+            "task-1",
+            repo.to_str().unwrap(),
+            3,
+            RemoteFetchMode::CacheFirst,
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(first.runs.len(), 3);
+        assert_eq!(read_count(&count_file), 1);
+
+        let second = get_actions(
+            &pool,
+            "task-1",
+            repo.to_str().unwrap(),
+            1,
+            RemoteFetchMode::CacheFirst,
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(second.runs.len(), 1);
+        assert!(second.from_cache);
+        assert_eq!(read_count(&count_file), 1);
+    }
+
+    #[tokio::test]
+    async fn stale_while_revalidate_refreshes_actions_and_notifies() {
+        let _lock = test_env_lock().lock().unwrap_or_else(|poison| poison.into_inner());
+        let pool = test_pool().await;
+        let (_temp, repo) = setup_git_repo();
+        let bin_dir = repo.join("bin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        seed_task(&pool, "task-2", &repo).await;
+        let output_file = repo.join("runs.json");
+        let count_file = repo.join("gh-count.txt");
+        std::fs::write(&output_file, actions_json(&[1])).unwrap();
+        write_fake_gh(&bin_dir, &output_file, &count_file, 0);
+        let _path_guard = PathGuard::install(&bin_dir);
+
+        let first = get_actions(
+            &pool,
+            "task-2",
+            repo.to_str().unwrap(),
+            1,
+            RemoteFetchMode::CacheFirst,
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(first.runs[0].database_id, 1);
+
+        let mut entry = db::get_github_cache_entry(&pool, "task-2:actions")
+            .await
+            .unwrap()
+            .unwrap();
+        entry.stale_at = now_ms() - 1;
+        entry.expires_at = now_ms() + 60_000;
+        db::upsert_github_cache_entry(&pool, &entry).await.unwrap();
+        std::fs::write(&output_file, actions_json(&[2])).unwrap();
+
+        let notifications = Arc::new(AtomicUsize::new(0));
+        let notify_count = notifications.clone();
+        let notify: InvalidateFn = Arc::new(move |_task_id, scopes| {
+            if scopes.iter().any(|scope| scope == "actions") {
+                notify_count.fetch_add(1, Ordering::SeqCst);
+            }
+        });
+
+        let stale = get_actions(
+            &pool,
+            "task-2",
+            repo.to_str().unwrap(),
+            1,
+            RemoteFetchMode::StaleWhileRevalidate,
+            Some(notify),
+        )
+        .await
+        .unwrap();
+        assert!(stale.from_cache);
+        assert!(stale.is_stale);
+        assert_eq!(stale.runs[0].database_id, 1);
+
+        timeout(Duration::from_secs(2), async {
+            loop {
+                if notifications.load(Ordering::SeqCst) > 0 {
+                    break;
+                }
+                sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .unwrap();
+
+        let refreshed = get_actions(
+            &pool,
+            "task-2",
+            repo.to_str().unwrap(),
+            1,
+            RemoteFetchMode::CacheFirst,
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(refreshed.runs[0].database_id, 2);
+        assert!(!refreshed.is_stale);
+        assert_eq!(read_count(&count_file), 2);
+    }
+
+    #[tokio::test]
+    async fn concurrent_actions_fetches_singleflight_on_cold_cache() {
+        let _lock = test_env_lock().lock().unwrap_or_else(|poison| poison.into_inner());
+        let pool = test_pool().await;
+        let (_temp, repo) = setup_git_repo();
+        let bin_dir = repo.join("bin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        seed_task(&pool, "task-3", &repo).await;
+        let output_file = repo.join("runs.json");
+        let count_file = repo.join("gh-count.txt");
+        std::fs::write(&output_file, actions_json(&[7, 8])).unwrap();
+        write_fake_gh(&bin_dir, &output_file, &count_file, 200);
+        let _path_guard = PathGuard::install(&bin_dir);
+
+        let first = get_actions(
+            &pool,
+            "task-3",
+            repo.to_str().unwrap(),
+            2,
+            RemoteFetchMode::CacheFirst,
+            None,
+        );
+        let second = get_actions(
+            &pool,
+            "task-3",
+            repo.to_str().unwrap(),
+            2,
+            RemoteFetchMode::CacheFirst,
+            None,
+        );
+        let (first, second) = tokio::join!(first, second);
+        assert_eq!(first.unwrap().runs.len(), 2);
+        assert_eq!(second.unwrap().runs.len(), 2);
+        assert_eq!(read_count(&count_file), 1);
+    }
+}

--- a/src-tauri/src/github_remote.rs
+++ b/src-tauri/src/github_remote.rs
@@ -1,10 +1,12 @@
 use crate::db;
 use crate::github::{self, CiCheck, GitHubRepo, PrInfo, WorkflowJob, WorkflowRun};
+use crate::stream::GitHubRemoteDebugEvent;
 use serde::{Deserialize, Serialize};
 use sqlx::sqlite::SqlitePool;
 use std::collections::HashMap;
 use std::future::Future;
 use std::sync::{Arc, OnceLock};
+use std::time::Instant;
 use tokio::sync::Mutex as TokioMutex;
 use tokio::task::JoinError;
 
@@ -18,6 +20,7 @@ const LOGS_STALE_MS: i64 = 24 * 60 * 60_000;
 const LOGS_EXPIRE_MS: i64 = 7 * 24 * 60 * 60_000;
 
 pub type InvalidateFn = Arc<dyn Fn(String, Vec<String>) + Send + Sync + 'static>;
+pub type DebugFn = Arc<dyn Fn(GitHubRemoteDebugEvent) + Send + Sync + 'static>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RemoteFetchMode {
@@ -143,6 +146,41 @@ fn flatten_join<T>(result: Result<Result<T, String>, JoinError>) -> Result<T, St
     result.map_err(|e| format!("Task join error: {e}"))?
 }
 
+fn mode_label(mode: RemoteFetchMode) -> String {
+    match mode {
+        RemoteFetchMode::CacheFirst => "cache-first",
+        RemoteFetchMode::StaleWhileRevalidate => "stale-while-revalidate",
+        RemoteFetchMode::NetworkOnly => "network-only",
+    }
+    .to_string()
+}
+
+#[allow(clippy::too_many_arguments)]
+fn emit_debug(
+    debug: Option<&DebugFn>,
+    task_id: &str,
+    scope: &str,
+    stage: &str,
+    mode: Option<RemoteFetchMode>,
+    cache_state: Option<&str>,
+    from_cache: Option<bool>,
+    duration_ms: Option<u64>,
+    detail: Option<String>,
+) {
+    let Some(debug) = debug else { return };
+    debug(GitHubRemoteDebugEvent {
+        task_id: task_id.to_string(),
+        scope: scope.to_string(),
+        stage: stage.to_string(),
+        mode: mode.map(mode_label),
+        cache_state: cache_state.map(|value| value.to_string()),
+        from_cache,
+        duration_ms,
+        detail,
+        emitted_at: now_ms(),
+    });
+}
+
 fn singleflight_gates() -> &'static TokioMutex<HashMap<String, Arc<TokioMutex<()>>>> {
     static GATES: OnceLock<TokioMutex<HashMap<String, Arc<TokioMutex<()>>>>> = OnceLock::new();
     GATES.get_or_init(|| TokioMutex::new(HashMap::new()))
@@ -185,21 +223,67 @@ fn schedule_revalidate<F, Fut>(
     cache_key: String,
     scope: &'static str,
     notifier: Option<InvalidateFn>,
+    debug: Option<DebugFn>,
     work: F,
 ) where
     F: FnOnce(SqlitePool) -> Fut + Send + 'static,
     Fut: Future<Output = Result<bool, String>> + Send + 'static,
 {
     tokio::spawn(async move {
+        emit_debug(
+            debug.as_ref(),
+            &task_id,
+            scope,
+            "revalidate-start",
+            Some(RemoteFetchMode::StaleWhileRevalidate),
+            Some("stale"),
+            Some(true),
+            None,
+            Some(cache_key.clone()),
+        );
         match with_singleflight(&cache_key, move || work(pool)).await {
             Ok(true) => {
+                emit_debug(
+                    debug.as_ref(),
+                    &task_id,
+                    scope,
+                    "revalidate-success",
+                    Some(RemoteFetchMode::StaleWhileRevalidate),
+                    Some("stale"),
+                    Some(false),
+                    None,
+                    Some(cache_key.clone()),
+                );
                 if let Some(notify) = notifier {
                     notify(task_id, vec![scope.to_string()]);
                 }
             }
-            Ok(false) => {}
+            Ok(false) => {
+                emit_debug(
+                    debug.as_ref(),
+                    &task_id,
+                    scope,
+                    "revalidate-skip",
+                    Some(RemoteFetchMode::StaleWhileRevalidate),
+                    Some("fresh"),
+                    Some(true),
+                    None,
+                    Some(cache_key.clone()),
+                );
+            }
             Err(err) => {
                 eprintln!("[verun][github-remote] revalidate {cache_key} failed: {err}");
+                emit_debug(
+                    debug.as_ref(),
+                    &task_id,
+                    scope,
+                    "revalidate-error",
+                    Some(RemoteFetchMode::StaleWhileRevalidate),
+                    Some("stale"),
+                    Some(true),
+                    None,
+                    Some(err),
+                );
             }
         }
     });
@@ -463,26 +547,64 @@ pub async fn get_overview(
     worktree_path: &str,
     mode: RemoteFetchMode,
     on_invalidate: Option<InvalidateFn>,
+    on_debug: Option<DebugFn>,
 ) -> Result<GitHubOverviewSnapshot, String> {
     let cache_key = make_cache_key(task_id, "overview", None);
     match cached_payload::<OverviewPayload>(pool, &cache_key, mode).await? {
-        CacheState::Fresh(payload, entry) => return Ok(overview_snapshot(payload, &entry, true)),
+        CacheState::Fresh(payload, entry) => {
+            emit_debug(
+                on_debug.as_ref(),
+                task_id,
+                "overview",
+                "cache-hit",
+                Some(mode),
+                Some("fresh"),
+                Some(true),
+                None,
+                Some(cache_key.clone()),
+            );
+            return Ok(overview_snapshot(payload, &entry, true));
+        }
         CacheState::Stale(payload, entry) if mode == RemoteFetchMode::CacheFirst => {
+            emit_debug(
+                on_debug.as_ref(),
+                task_id,
+                "overview",
+                "cache-hit",
+                Some(mode),
+                Some("stale"),
+                Some(true),
+                None,
+                Some(cache_key.clone()),
+            );
             return Ok(overview_snapshot(payload, &entry, true));
         }
         CacheState::Stale(payload, entry) if mode == RemoteFetchMode::StaleWhileRevalidate => {
+            emit_debug(
+                on_debug.as_ref(),
+                task_id,
+                "overview",
+                "cache-hit",
+                Some(mode),
+                Some("stale"),
+                Some(true),
+                None,
+                Some(cache_key.clone()),
+            );
             let pool = pool.clone();
             let fetch_task_id = task_id.to_string();
             let notify_task_id = task_id.to_string();
             let worktree_path = worktree_path.to_string();
             let refresh_key = cache_key.clone();
             let notifier = on_invalidate.clone();
+            let debug = on_debug.clone();
             schedule_revalidate(
                 pool,
                 notify_task_id,
                 refresh_key.clone(),
                 "overview",
                 notifier,
+                debug,
                 move |pool| async move {
                     match cached_payload::<OverviewPayload>(
                         &pool,
@@ -501,6 +623,19 @@ pub async fn get_overview(
             );
             return Ok(overview_snapshot(payload, &entry, true));
         }
+        CacheState::Miss => {
+            emit_debug(
+                on_debug.as_ref(),
+                task_id,
+                "overview",
+                "cache-miss",
+                Some(mode),
+                Some("miss"),
+                Some(false),
+                None,
+                Some(cache_key.clone()),
+            );
+        }
         _ => {}
     }
 
@@ -510,10 +645,62 @@ pub async fn get_overview(
                 cached_payload::<OverviewPayload>(pool, &cache_key, RemoteFetchMode::CacheFirst)
                     .await?
             {
+                emit_debug(
+                    on_debug.as_ref(),
+                    task_id,
+                    "overview",
+                    "cache-hit",
+                    Some(mode),
+                    Some("fresh"),
+                    Some(true),
+                    None,
+                    Some(cache_key.clone()),
+                );
                 return Ok(overview_snapshot(payload, &entry, true));
             }
         }
-        fetch_overview_and_store(pool, task_id, worktree_path).await
+        emit_debug(
+            on_debug.as_ref(),
+            task_id,
+            "overview",
+            "fetch-start",
+            Some(mode),
+            None,
+            Some(false),
+            None,
+            Some(cache_key.clone()),
+        );
+        let started = Instant::now();
+        match fetch_overview_and_store(pool, task_id, worktree_path).await {
+            Ok(snapshot) => {
+                emit_debug(
+                    on_debug.as_ref(),
+                    task_id,
+                    "overview",
+                    "fetch-success",
+                    Some(mode),
+                    Some("miss"),
+                    Some(false),
+                    Some(started.elapsed().as_millis() as u64),
+                    Some(cache_key.clone()),
+                );
+                Ok(snapshot)
+            }
+            Err(err) => {
+                emit_debug(
+                    on_debug.as_ref(),
+                    task_id,
+                    "overview",
+                    "fetch-error",
+                    Some(mode),
+                    None,
+                    Some(false),
+                    Some(started.elapsed().as_millis() as u64),
+                    Some(err.clone()),
+                );
+                Err(err)
+            }
+        }
     })
     .await
 }
@@ -525,27 +712,62 @@ pub async fn get_actions(
     limit: u32,
     mode: RemoteFetchMode,
     on_invalidate: Option<InvalidateFn>,
+    on_debug: Option<DebugFn>,
 ) -> Result<GitHubActionsSnapshot, String> {
     let cache_key = make_cache_key(task_id, "actions", None);
     match cached_payload::<ActionsPayload>(pool, &cache_key, mode).await? {
         CacheState::Fresh(payload, entry) if payload.cached_limit >= limit => {
+            emit_debug(
+                on_debug.as_ref(),
+                task_id,
+                "actions",
+                "cache-hit",
+                Some(mode),
+                Some("fresh"),
+                Some(true),
+                None,
+                Some(format!("{cache_key} limit={limit}")),
+            );
             return Ok(actions_snapshot(payload, &entry, limit, true));
         }
         CacheState::Stale(payload, entry)
             if payload.cached_limit >= limit && mode == RemoteFetchMode::CacheFirst =>
         {
+            emit_debug(
+                on_debug.as_ref(),
+                task_id,
+                "actions",
+                "cache-hit",
+                Some(mode),
+                Some("stale"),
+                Some(true),
+                None,
+                Some(format!("{cache_key} limit={limit}")),
+            );
             return Ok(actions_snapshot(payload, &entry, limit, true));
         }
         CacheState::Stale(payload, entry)
             if payload.cached_limit >= limit
                 && mode == RemoteFetchMode::StaleWhileRevalidate =>
         {
+            emit_debug(
+                on_debug.as_ref(),
+                task_id,
+                "actions",
+                "cache-hit",
+                Some(mode),
+                Some("stale"),
+                Some(true),
+                None,
+                Some(format!("{cache_key} limit={limit}")),
+            );
             let pool = pool.clone();
             let fetch_task_id = task_id.to_string();
             let notify_task_id = task_id.to_string();
             let worktree_path = worktree_path.to_string();
             let refresh_key = cache_key.clone();
             let notifier = on_invalidate.clone();
+            let debug = on_debug.clone();
             let keep_limit = payload.cached_limit.max(limit);
             schedule_revalidate(
                 pool,
@@ -553,6 +775,7 @@ pub async fn get_actions(
                 refresh_key.clone(),
                 "actions",
                 notifier,
+                debug,
                 move |pool| async move {
                     match cached_payload::<ActionsPayload>(
                         &pool,
@@ -581,6 +804,19 @@ pub async fn get_actions(
             );
             return Ok(actions_snapshot(payload, &entry, limit, true));
         }
+        CacheState::Miss => {
+            emit_debug(
+                on_debug.as_ref(),
+                task_id,
+                "actions",
+                "cache-miss",
+                Some(mode),
+                Some("miss"),
+                Some(false),
+                None,
+                Some(format!("{cache_key} limit={limit}")),
+            );
+        }
         _ => {}
     }
 
@@ -590,6 +826,17 @@ pub async fn get_actions(
                 .await?
             {
                 CacheState::Fresh(payload, entry) if payload.cached_limit >= limit => {
+                    emit_debug(
+                        on_debug.as_ref(),
+                        task_id,
+                        "actions",
+                        "cache-hit",
+                        Some(mode),
+                        Some("fresh"),
+                        Some(true),
+                        None,
+                        Some(format!("{cache_key} limit={limit}")),
+                    );
                     return Ok(actions_snapshot(payload, &entry, limit, true));
                 }
                 CacheState::Fresh(payload, _) | CacheState::Stale(payload, _) => {
@@ -600,7 +847,48 @@ pub async fn get_actions(
         } else {
             None
         };
-        fetch_actions_and_store(pool, task_id, worktree_path, limit, existing_limit).await
+        emit_debug(
+            on_debug.as_ref(),
+            task_id,
+            "actions",
+            "fetch-start",
+            Some(mode),
+            None,
+            Some(false),
+            None,
+            Some(format!("{cache_key} limit={limit}")),
+        );
+        let started = Instant::now();
+        match fetch_actions_and_store(pool, task_id, worktree_path, limit, existing_limit).await {
+            Ok(snapshot) => {
+                emit_debug(
+                    on_debug.as_ref(),
+                    task_id,
+                    "actions",
+                    "fetch-success",
+                    Some(mode),
+                    Some("miss"),
+                    Some(false),
+                    Some(started.elapsed().as_millis() as u64),
+                    Some(format!("{cache_key} limit={limit}")),
+                );
+                Ok(snapshot)
+            }
+            Err(err) => {
+                emit_debug(
+                    on_debug.as_ref(),
+                    task_id,
+                    "actions",
+                    "fetch-error",
+                    Some(mode),
+                    None,
+                    Some(false),
+                    Some(started.elapsed().as_millis() as u64),
+                    Some(err.clone()),
+                );
+                Err(err)
+            }
+        }
     })
     .await
 }
@@ -612,27 +900,65 @@ pub async fn get_workflow_jobs(
     run_id: u64,
     mode: RemoteFetchMode,
     on_invalidate: Option<InvalidateFn>,
+    on_debug: Option<DebugFn>,
 ) -> Result<WorkflowJobsSnapshot, String> {
     let run_key = run_id.to_string();
     let cache_key = make_cache_key(task_id, "jobs", Some(&run_key));
     match cached_payload::<JobsPayload>(pool, &cache_key, mode).await? {
-        CacheState::Fresh(payload, entry) => return Ok(jobs_snapshot(payload, &entry, true)),
+        CacheState::Fresh(payload, entry) => {
+            emit_debug(
+                on_debug.as_ref(),
+                task_id,
+                "jobs",
+                "cache-hit",
+                Some(mode),
+                Some("fresh"),
+                Some(true),
+                None,
+                Some(format!("{cache_key} runId={run_id}")),
+            );
+            return Ok(jobs_snapshot(payload, &entry, true));
+        }
         CacheState::Stale(payload, entry) if mode == RemoteFetchMode::CacheFirst => {
+            emit_debug(
+                on_debug.as_ref(),
+                task_id,
+                "jobs",
+                "cache-hit",
+                Some(mode),
+                Some("stale"),
+                Some(true),
+                None,
+                Some(format!("{cache_key} runId={run_id}")),
+            );
             return Ok(jobs_snapshot(payload, &entry, true));
         }
         CacheState::Stale(payload, entry) if mode == RemoteFetchMode::StaleWhileRevalidate => {
+            emit_debug(
+                on_debug.as_ref(),
+                task_id,
+                "jobs",
+                "cache-hit",
+                Some(mode),
+                Some("stale"),
+                Some(true),
+                None,
+                Some(format!("{cache_key} runId={run_id}")),
+            );
             let pool = pool.clone();
             let fetch_task_id = task_id.to_string();
             let notify_task_id = task_id.to_string();
             let worktree_path = worktree_path.to_string();
             let refresh_key = cache_key.clone();
             let notifier = on_invalidate.clone();
+            let debug = on_debug.clone();
             schedule_revalidate(
                 pool,
                 notify_task_id,
                 refresh_key.clone(),
                 "jobs",
                 notifier,
+                debug,
                 move |pool| async move {
                     match cached_payload::<JobsPayload>(
                         &pool,
@@ -652,6 +978,19 @@ pub async fn get_workflow_jobs(
             );
             return Ok(jobs_snapshot(payload, &entry, true));
         }
+        CacheState::Miss => {
+            emit_debug(
+                on_debug.as_ref(),
+                task_id,
+                "jobs",
+                "cache-miss",
+                Some(mode),
+                Some("miss"),
+                Some(false),
+                None,
+                Some(format!("{cache_key} runId={run_id}")),
+            );
+        }
         _ => {}
     }
 
@@ -660,14 +999,67 @@ pub async fn get_workflow_jobs(
             if let CacheState::Fresh(payload, entry) =
                 cached_payload::<JobsPayload>(pool, &cache_key, RemoteFetchMode::CacheFirst).await?
             {
+                emit_debug(
+                    on_debug.as_ref(),
+                    task_id,
+                    "jobs",
+                    "cache-hit",
+                    Some(mode),
+                    Some("fresh"),
+                    Some(true),
+                    None,
+                    Some(format!("{cache_key} runId={run_id}")),
+                );
                 return Ok(jobs_snapshot(payload, &entry, true));
             }
         }
-        fetch_jobs_and_store(pool, task_id, worktree_path, run_id).await
+        emit_debug(
+            on_debug.as_ref(),
+            task_id,
+            "jobs",
+            "fetch-start",
+            Some(mode),
+            None,
+            Some(false),
+            None,
+            Some(format!("{cache_key} runId={run_id}")),
+        );
+        let started = Instant::now();
+        match fetch_jobs_and_store(pool, task_id, worktree_path, run_id).await {
+            Ok(snapshot) => {
+                emit_debug(
+                    on_debug.as_ref(),
+                    task_id,
+                    "jobs",
+                    "fetch-success",
+                    Some(mode),
+                    Some("miss"),
+                    Some(false),
+                    Some(started.elapsed().as_millis() as u64),
+                    Some(format!("{cache_key} runId={run_id}")),
+                );
+                Ok(snapshot)
+            }
+            Err(err) => {
+                emit_debug(
+                    on_debug.as_ref(),
+                    task_id,
+                    "jobs",
+                    "fetch-error",
+                    Some(mode),
+                    None,
+                    Some(false),
+                    Some(started.elapsed().as_millis() as u64),
+                    Some(err.clone()),
+                );
+                Err(err)
+            }
+        }
     })
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn get_workflow_log(
     pool: &SqlitePool,
     task_id: &str,
@@ -676,29 +1068,65 @@ pub async fn get_workflow_log(
     max_bytes: usize,
     mode: RemoteFetchMode,
     on_invalidate: Option<InvalidateFn>,
+    on_debug: Option<DebugFn>,
 ) -> Result<WorkflowLogSnapshot, String> {
     let job_key = job_id.to_string();
     let cache_key = make_cache_key(task_id, "logs", Some(&job_key));
     match cached_payload::<LogPayload>(pool, &cache_key, mode).await? {
         CacheState::Fresh(payload, entry) => {
+            emit_debug(
+                on_debug.as_ref(),
+                task_id,
+                "logs",
+                "cache-hit",
+                Some(mode),
+                Some("fresh"),
+                Some(true),
+                None,
+                Some(format!("{cache_key} jobId={job_id}")),
+            );
             return Ok(log_snapshot(payload, &entry, max_bytes, true));
         }
         CacheState::Stale(payload, entry) if mode == RemoteFetchMode::CacheFirst => {
+            emit_debug(
+                on_debug.as_ref(),
+                task_id,
+                "logs",
+                "cache-hit",
+                Some(mode),
+                Some("stale"),
+                Some(true),
+                None,
+                Some(format!("{cache_key} jobId={job_id}")),
+            );
             return Ok(log_snapshot(payload, &entry, max_bytes, true));
         }
         CacheState::Stale(payload, entry) if mode == RemoteFetchMode::StaleWhileRevalidate => {
+            emit_debug(
+                on_debug.as_ref(),
+                task_id,
+                "logs",
+                "cache-hit",
+                Some(mode),
+                Some("stale"),
+                Some(true),
+                None,
+                Some(format!("{cache_key} jobId={job_id}")),
+            );
             let pool = pool.clone();
             let fetch_task_id = task_id.to_string();
             let notify_task_id = task_id.to_string();
             let worktree_path = worktree_path.to_string();
             let refresh_key = cache_key.clone();
             let notifier = on_invalidate.clone();
+            let debug = on_debug.clone();
             schedule_revalidate(
                 pool,
                 notify_task_id,
                 refresh_key.clone(),
                 "logs",
                 notifier,
+                debug,
                 move |pool| async move {
                     match cached_payload::<LogPayload>(
                         &pool,
@@ -718,6 +1146,19 @@ pub async fn get_workflow_log(
             );
             return Ok(log_snapshot(payload, &entry, max_bytes, true));
         }
+        CacheState::Miss => {
+            emit_debug(
+                on_debug.as_ref(),
+                task_id,
+                "logs",
+                "cache-miss",
+                Some(mode),
+                Some("miss"),
+                Some(false),
+                None,
+                Some(format!("{cache_key} jobId={job_id}")),
+            );
+        }
         _ => {}
     }
 
@@ -726,10 +1167,62 @@ pub async fn get_workflow_log(
             if let CacheState::Fresh(payload, entry) =
                 cached_payload::<LogPayload>(pool, &cache_key, RemoteFetchMode::CacheFirst).await?
             {
+                emit_debug(
+                    on_debug.as_ref(),
+                    task_id,
+                    "logs",
+                    "cache-hit",
+                    Some(mode),
+                    Some("fresh"),
+                    Some(true),
+                    None,
+                    Some(format!("{cache_key} jobId={job_id}")),
+                );
                 return Ok(log_snapshot(payload, &entry, max_bytes, true));
             }
         }
-        fetch_log_and_store(pool, task_id, worktree_path, job_id, max_bytes).await
+        emit_debug(
+            on_debug.as_ref(),
+            task_id,
+            "logs",
+            "fetch-start",
+            Some(mode),
+            None,
+            Some(false),
+            None,
+            Some(format!("{cache_key} jobId={job_id}")),
+        );
+        let started = Instant::now();
+        match fetch_log_and_store(pool, task_id, worktree_path, job_id, max_bytes).await {
+            Ok(snapshot) => {
+                emit_debug(
+                    on_debug.as_ref(),
+                    task_id,
+                    "logs",
+                    "fetch-success",
+                    Some(mode),
+                    Some("miss"),
+                    Some(false),
+                    Some(started.elapsed().as_millis() as u64),
+                    Some(format!("{cache_key} jobId={job_id}")),
+                );
+                Ok(snapshot)
+            }
+            Err(err) => {
+                emit_debug(
+                    on_debug.as_ref(),
+                    task_id,
+                    "logs",
+                    "fetch-error",
+                    Some(mode),
+                    None,
+                    Some(false),
+                    Some(started.elapsed().as_millis() as u64),
+                    Some(err.clone()),
+                );
+                Err(err)
+            }
+        }
     })
     .await
 }
@@ -921,6 +1414,7 @@ mod tests {
             3,
             RemoteFetchMode::CacheFirst,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -933,6 +1427,7 @@ mod tests {
             repo.to_str().unwrap(),
             1,
             RemoteFetchMode::CacheFirst,
+            None,
             None,
         )
         .await
@@ -964,6 +1459,7 @@ mod tests {
             1,
             RemoteFetchMode::CacheFirst,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -993,6 +1489,7 @@ mod tests {
             1,
             RemoteFetchMode::StaleWhileRevalidate,
             Some(notify),
+            None,
         )
         .await
         .unwrap();
@@ -1017,6 +1514,7 @@ mod tests {
             repo.to_str().unwrap(),
             1,
             RemoteFetchMode::CacheFirst,
+            None,
             None,
         )
         .await
@@ -1048,6 +1546,7 @@ mod tests {
             2,
             RemoteFetchMode::CacheFirst,
             None,
+            None,
         );
         let second = get_actions(
             &pool,
@@ -1055,6 +1554,7 @@ mod tests {
             repo.to_str().unwrap(),
             2,
             RemoteFetchMode::CacheFirst,
+            None,
             None,
         );
         let (first, second) = tokio::join!(first, second);
@@ -1085,6 +1585,7 @@ mod tests {
             1,
             RemoteFetchMode::CacheFirst,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -1096,6 +1597,7 @@ mod tests {
             repo.to_str().unwrap(),
             1,
             RemoteFetchMode::NetworkOnly,
+            None,
             None,
         )
         .await
@@ -1127,6 +1629,7 @@ mod tests {
             1,
             RemoteFetchMode::CacheFirst,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -1146,6 +1649,7 @@ mod tests {
             repo.to_str().unwrap(),
             1,
             RemoteFetchMode::CacheFirst,
+            None,
             None,
         )
         .await

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -1,18 +1,20 @@
 use crate::db::{self, DbWriteTx, OutputLine, Project, Session, Step, Task};
+use crate::file_search::{SearchMap, SearchOpts};
 use crate::git_ops;
 use crate::github;
+use crate::github_remote;
 use crate::lsp::LspMap;
 use crate::pty::{self, ActivePtyMap};
 use crate::task::{
     self, ActiveMap, ApprovalResponse, HookPtyMap, PendingApprovalEntry, PendingApprovalMeta,
     PendingApprovals, PendingControlResponses, SetupInProgress,
 };
-use crate::file_search::{SearchMap, SearchOpts};
 use crate::tsgo_check::TsgoCheckMap;
 use crate::watcher::FileWatcherMap;
 use crate::worktree;
 use serde::Serialize;
 use sqlx::sqlite::SqlitePool;
+use std::sync::Arc;
 use tauri::{AppHandle, Emitter, Manager, State};
 use tokio::task::JoinError;
 use uuid::Uuid;
@@ -21,13 +23,35 @@ fn flatten_join<T>(result: Result<Result<T, String>, JoinError>) -> Result<T, St
     result.map_err(|e| format!("Task join error: {e}"))?
 }
 
-fn emit_git_status_changed(app: &AppHandle, task_id: &str) {
+fn emit_git_local_changed(app: &AppHandle, task_id: &str) {
     let _ = app.emit(
-        "git-status-changed",
+        "git-local-changed",
         crate::stream::GitStatusChangedEvent {
             task_id: task_id.to_string(),
         },
     );
+}
+
+fn emit_github_remote_invalidated(app: &AppHandle, task_id: &str, scopes: &[&str]) {
+    let _ = app.emit(
+        "github-remote-invalidated",
+        crate::stream::GitHubRemoteInvalidatedEvent {
+            task_id: task_id.to_string(),
+            scopes: scopes.iter().map(|s| s.to_string()).collect(),
+        },
+    );
+}
+
+fn github_remote_invalidator(
+    app: &AppHandle,
+) -> github_remote::InvalidateFn {
+    let app = app.clone();
+    Arc::new(move |task_id, scopes| {
+        let _ = app.emit(
+            "github-remote-invalidated",
+            crate::stream::GitHubRemoteInvalidatedEvent { task_id, scopes },
+        );
+    })
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -220,8 +244,10 @@ pub async fn export_project_config(
         "startCommand": &project.start_command,
     });
     let pretty = serde_json::to_string_pretty(&config).unwrap_or_default();
-    let config_path =
-        resolve_config_path(&project.repo_path, task.as_ref().map(|t| t.worktree_path.as_str()));
+    let config_path = resolve_config_path(
+        &project.repo_path,
+        task.as_ref().map(|t| t.worktree_path.as_str()),
+    );
     std::fs::write(&config_path, format!("{pretty}\n"))
         .map_err(|e| format!("Failed to write .verun.json: {e}"))
 }
@@ -255,8 +281,10 @@ pub async fn import_project_config(
         None => None,
     };
 
-    let config_path =
-        resolve_config_path(&project.repo_path, task.as_ref().map(|t| t.worktree_path.as_str()));
+    let config_path = resolve_config_path(
+        &project.repo_path,
+        task.as_ref().map(|t| t.worktree_path.as_str()),
+    );
     let (setup, destroy, start) = task::parse_verun_config_file(&config_path)
         .ok_or_else(|| "No .verun.json found or file is empty".to_string())?;
 
@@ -1082,7 +1110,7 @@ pub async fn merge_branch(
         })
         .await,
     )?;
-    emit_git_status_changed(&app, &task_id);
+    emit_git_local_changed(&app, &task_id);
     Ok(())
 }
 
@@ -1098,7 +1126,10 @@ pub async fn get_branch_status(
 
     let last_pushed = t.last_pushed_sha.clone();
     let status = flatten_join(
-        tokio::task::spawn_blocking(move || worktree::get_branch_status(&t.worktree_path, last_pushed.as_deref())).await,
+        tokio::task::spawn_blocking(move || {
+            worktree::get_branch_status(&t.worktree_path, last_pushed.as_deref())
+        })
+        .await,
     )?;
 
     if let Some(sha) = status.tracking_sha {
@@ -1262,7 +1293,7 @@ pub async fn git_stage(
         })
         .await,
     )?;
-    emit_git_status_changed(&app, &task_id);
+    emit_git_local_changed(&app, &task_id);
     Ok(())
 }
 
@@ -1280,7 +1311,7 @@ pub async fn git_unstage(
     flatten_join(
         tokio::task::spawn_blocking(move || git_ops::unstage_files(&t.worktree_path, &paths)).await,
     )?;
-    emit_git_status_changed(&app, &task_id);
+    emit_git_local_changed(&app, &task_id);
     Ok(())
 }
 
@@ -1298,7 +1329,7 @@ pub async fn git_commit(
     let hash = flatten_join(
         tokio::task::spawn_blocking(move || git_ops::commit(&t.worktree_path, &message)).await,
     )?;
-    emit_git_status_changed(&app, &task_id);
+    emit_git_local_changed(&app, &task_id);
     Ok(hash)
 }
 
@@ -1326,7 +1357,14 @@ pub async fn git_push(
         })
         .await,
     )?;
-    emit_git_status_changed(&app, &task_id);
+    db::invalidate_github_cache(
+        pool.inner(),
+        &task_id,
+        &["overview", "actions", "jobs", "logs"],
+    )
+    .await?;
+    emit_git_local_changed(&app, &task_id);
+    emit_github_remote_invalidated(&app, &task_id, &["overview", "actions"]);
     Ok(())
 }
 
@@ -1343,7 +1381,14 @@ pub async fn git_pull(
     let output = flatten_join(
         tokio::task::spawn_blocking(move || git_ops::pull_branch(&t.worktree_path)).await,
     )?;
-    emit_git_status_changed(&app, &task_id);
+    db::invalidate_github_cache(
+        pool.inner(),
+        &task_id,
+        &["overview", "actions", "jobs", "logs"],
+    )
+    .await?;
+    emit_git_local_changed(&app, &task_id);
+    emit_github_remote_invalidated(&app, &task_id, &["overview", "actions"]);
     Ok(output)
 }
 
@@ -1370,7 +1415,14 @@ pub async fn git_commit_and_push(
         })
         .await,
     )?;
-    emit_git_status_changed(&app, &task_id);
+    db::invalidate_github_cache(
+        pool.inner(),
+        &task_id,
+        &["overview", "actions", "jobs", "logs"],
+    )
+    .await?;
+    emit_git_local_changed(&app, &task_id);
+    emit_github_remote_invalidated(&app, &task_id, &["overview", "actions"]);
     Ok(hash)
 }
 
@@ -1545,7 +1597,8 @@ pub async fn create_pull_request(
         })
         .await,
     )?;
-    emit_git_status_changed(&app, &task_id);
+    db::invalidate_github_cache(pool.inner(), &task_id, &["overview"]).await?;
+    emit_github_remote_invalidated(&app, &task_id, &["overview"]);
     Ok(pr)
 }
 
@@ -1562,7 +1615,8 @@ pub async fn mark_pr_ready(
     flatten_join(
         tokio::task::spawn_blocking(move || github::mark_pr_ready(&t.worktree_path)).await,
     )?;
-    emit_git_status_changed(&app, &task_id);
+    db::invalidate_github_cache(pool.inner(), &task_id, &["overview"]).await?;
+    emit_github_remote_invalidated(&app, &task_id, &["overview"]);
     Ok(())
 }
 
@@ -1593,7 +1647,14 @@ pub async fn merge_pull_request(
         })
         .await,
     )?;
-    emit_git_status_changed(&app, &task_id);
+    db::invalidate_github_cache(
+        pool.inner(),
+        &task_id,
+        &["overview", "actions", "jobs", "logs"],
+    )
+    .await?;
+    emit_git_local_changed(&app, &task_id);
+    emit_github_remote_invalidated(&app, &task_id, &["overview", "actions"]);
     Ok(())
 }
 
@@ -1638,7 +1699,14 @@ pub async fn git_ship(
         })
         .await,
     )?;
-    emit_git_status_changed(&app, &task_id);
+    db::invalidate_github_cache(
+        pool.inner(),
+        &task_id,
+        &["overview", "actions", "jobs", "logs"],
+    )
+    .await?;
+    emit_git_local_changed(&app, &task_id);
+    emit_github_remote_invalidated(&app, &task_id, &["overview", "actions"]);
     Ok(pr)
 }
 
@@ -1677,9 +1745,106 @@ pub async fn has_conflicts(pool: State<'_, SqlitePool>, task_id: String) -> Resu
     flatten_join(tokio::task::spawn_blocking(move || github::has_conflicts(&t.worktree_path)).await)
 }
 
+#[tauri::command]
+pub async fn get_github_overview(
+    app: AppHandle,
+    pool: State<'_, SqlitePool>,
+    task_id: String,
+    mode: Option<String>,
+) -> Result<github_remote::GitHubOverviewSnapshot, String> {
+    let t = db::get_task(pool.inner(), &task_id)
+        .await?
+        .ok_or_else(|| format!("Task {task_id} not found"))?;
+    let mode = github_remote::RemoteFetchMode::parse(mode.as_deref());
+
+    github_remote::get_overview(
+        pool.inner(),
+        &task_id,
+        &t.worktree_path,
+        mode,
+        Some(github_remote_invalidator(&app)),
+    )
+    .await
+}
+
 // ---------------------------------------------------------------------------
 // GitHub Actions (workflow runs)
 // ---------------------------------------------------------------------------
+
+#[tauri::command]
+pub async fn get_github_actions(
+    app: AppHandle,
+    pool: State<'_, SqlitePool>,
+    task_id: String,
+    limit: Option<u32>,
+    mode: Option<String>,
+) -> Result<github_remote::GitHubActionsSnapshot, String> {
+    let t = db::get_task(pool.inner(), &task_id)
+        .await?
+        .ok_or_else(|| format!("Task {task_id} not found"))?;
+    let limit = limit.unwrap_or(25);
+    let mode = github_remote::RemoteFetchMode::parse(mode.as_deref());
+
+    github_remote::get_actions(
+        pool.inner(),
+        &task_id,
+        &t.worktree_path,
+        limit,
+        mode,
+        Some(github_remote_invalidator(&app)),
+    )
+    .await
+}
+
+#[tauri::command]
+pub async fn get_github_workflow_jobs(
+    app: AppHandle,
+    pool: State<'_, SqlitePool>,
+    task_id: String,
+    run_id: u64,
+    mode: Option<String>,
+) -> Result<github_remote::WorkflowJobsSnapshot, String> {
+    let t = db::get_task(pool.inner(), &task_id)
+        .await?
+        .ok_or_else(|| format!("Task {task_id} not found"))?;
+    let mode = github_remote::RemoteFetchMode::parse(mode.as_deref());
+
+    github_remote::get_workflow_jobs(
+        pool.inner(),
+        &task_id,
+        &t.worktree_path,
+        run_id,
+        mode,
+        Some(github_remote_invalidator(&app)),
+    )
+    .await
+}
+
+#[tauri::command]
+pub async fn get_github_workflow_log(
+    app: AppHandle,
+    pool: State<'_, SqlitePool>,
+    task_id: String,
+    job_id: u64,
+    max_bytes: Option<u32>,
+    mode: Option<String>,
+) -> Result<github_remote::WorkflowLogSnapshot, String> {
+    let t = db::get_task(pool.inner(), &task_id)
+        .await?
+        .ok_or_else(|| format!("Task {task_id} not found"))?;
+    let mode = github_remote::RemoteFetchMode::parse(mode.as_deref());
+
+    github_remote::get_workflow_log(
+        pool.inner(),
+        &task_id,
+        &t.worktree_path,
+        job_id,
+        max_bytes.unwrap_or(0) as usize,
+        mode,
+        Some(github_remote_invalidator(&app)),
+    )
+    .await
+}
 
 #[tauri::command]
 pub async fn list_workflow_runs(
@@ -1720,7 +1885,7 @@ pub async fn list_workflow_jobs(
 pub async fn get_workflow_failed_logs(
     pool: State<'_, SqlitePool>,
     task_id: String,
-    run_id: u64,
+    _run_id: u64,
     job_id: u64,
     max_bytes: Option<u32>,
 ) -> Result<String, String> {
@@ -1733,7 +1898,7 @@ pub async fn get_workflow_failed_logs(
 
     flatten_join(
         tokio::task::spawn_blocking(move || {
-            github::get_failed_step_logs(&t.worktree_path, run_id, job_id, max_bytes)
+            github::get_failed_step_logs(&t.worktree_path, job_id, max_bytes)
         })
         .await,
     )
@@ -1758,7 +1923,8 @@ pub async fn rerun_workflow_run(
         })
         .await,
     )?;
-    emit_git_status_changed(&app, &task_id);
+    db::invalidate_github_cache(pool.inner(), &task_id, &["actions", "jobs", "logs"]).await?;
+    emit_github_remote_invalidated(&app, &task_id, &["actions"]);
     Ok(())
 }
 
@@ -1777,7 +1943,8 @@ pub async fn rerun_workflow_job(
         tokio::task::spawn_blocking(move || github::rerun_workflow_job(&t.worktree_path, job_id))
             .await,
     )?;
-    emit_git_status_changed(&app, &task_id);
+    db::invalidate_github_cache(pool.inner(), &task_id, &["actions", "jobs", "logs"]).await?;
+    emit_github_remote_invalidated(&app, &task_id, &["actions"]);
     Ok(())
 }
 
@@ -1796,7 +1963,8 @@ pub async fn cancel_workflow_run(
         tokio::task::spawn_blocking(move || github::cancel_workflow(&t.worktree_path, run_id))
             .await,
     )?;
-    emit_git_status_changed(&app, &task_id);
+    db::invalidate_github_cache(pool.inner(), &task_id, &["actions", "jobs", "logs"]).await?;
+    emit_github_remote_invalidated(&app, &task_id, &["actions"]);
     Ok(())
 }
 
@@ -2069,11 +2237,7 @@ pub fn new_agent_cache() -> AgentCache {
 /// the result in the cache. The ordering is load-bearing: GUI-launched
 /// apps on macOS start with a stripped PATH, so running detection first
 /// would mark agents installed in nvm/homebrew/~/.local/bin as missing.
-pub async fn init_agents_cache<R, D>(
-    cache: AgentCache,
-    reload_path: R,
-    detect: D,
-) -> Vec<AgentInfo>
+pub async fn init_agents_cache<R, D>(cache: AgentCache, reload_path: R, detect: D) -> Vec<AgentInfo>
 where
     R: FnOnce() + Send + 'static,
     D: FnOnce() -> Vec<AgentInfo> + Send + 'static,
@@ -2149,8 +2313,7 @@ pub async fn refresh_agents(
 ) -> Result<(), String> {
     let cache = std::sync::Arc::clone(&*cache);
     tauri::async_runtime::spawn(async move {
-        let agents =
-            init_agents_cache(cache, crate::env_path::reload_now, detect_all_agents).await;
+        let agents = init_agents_cache(cache, crate::env_path::reload_now, detect_all_agents).await;
         let _ = app.emit("agents-updated", agents);
     });
     Ok(())
@@ -2869,10 +3032,7 @@ pub async fn upload_attachment(
 /// rendering an attached image so the chat-view restore path doesn't load
 /// every blob up front.
 #[tauri::command]
-pub async fn get_blob(
-    app_data: State<'_, AppDataDir>,
-    hash: String,
-) -> Result<Vec<u8>, String> {
+pub async fn get_blob(app_data: State<'_, AppDataDir>, hash: String) -> Result<Vec<u8>, String> {
     blob::read_blob_bytes(&app_data.0, &hash).await
 }
 

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -28,6 +28,7 @@ fn emit_git_local_changed(app: &AppHandle, task_id: &str) {
         "git-local-changed",
         crate::stream::GitStatusChangedEvent {
             task_id: task_id.to_string(),
+            remote_likely_changed: false,
         },
     );
 }
@@ -51,6 +52,13 @@ fn github_remote_invalidator(
             "github-remote-invalidated",
             crate::stream::GitHubRemoteInvalidatedEvent { task_id, scopes },
         );
+    })
+}
+
+fn github_remote_debugger(app: &AppHandle) -> github_remote::DebugFn {
+    let app = app.clone();
+    Arc::new(move |event| {
+        let _ = app.emit("github-remote-debug", event);
     })
 }
 
@@ -1763,6 +1771,7 @@ pub async fn get_github_overview(
         &t.worktree_path,
         mode,
         Some(github_remote_invalidator(&app)),
+        Some(github_remote_debugger(&app)),
     )
     .await
 }
@@ -1792,6 +1801,7 @@ pub async fn get_github_actions(
         limit,
         mode,
         Some(github_remote_invalidator(&app)),
+        Some(github_remote_debugger(&app)),
     )
     .await
 }
@@ -1816,6 +1826,7 @@ pub async fn get_github_workflow_jobs(
         run_id,
         mode,
         Some(github_remote_invalidator(&app)),
+        Some(github_remote_debugger(&app)),
     )
     .await
 }
@@ -1842,6 +1853,7 @@ pub async fn get_github_workflow_log(
         max_bytes.unwrap_or(0) as usize,
         mode,
         Some(github_remote_invalidator(&app)),
+        Some(github_remote_debugger(&app)),
     )
     .await
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ mod fd_limit;
 mod file_search;
 mod git_ops;
 mod github;
+mod github_remote;
 mod ipc;
 mod lsp;
 mod markdown_skills;
@@ -325,11 +326,15 @@ pub fn run() {
             ipc::git_ship,
             ipc::get_ci_checks,
             ipc::get_branch_url,
+            ipc::get_github_overview,
             ipc::has_conflicts,
             // GitHub Actions
             ipc::list_workflow_runs,
             ipc::list_workflow_jobs,
             ipc::get_workflow_failed_logs,
+            ipc::get_github_actions,
+            ipc::get_github_workflow_jobs,
+            ipc::get_github_workflow_log,
             ipc::rerun_workflow_run,
             ipc::rerun_workflow_job,
             ipc::cancel_workflow_run,

--- a/src-tauri/src/markdown_skills.rs
+++ b/src-tauri/src/markdown_skills.rs
@@ -15,7 +15,9 @@ use std::path::Path;
 /// single-line `key: value` entries with optional wrapping quotes. Full YAML
 /// would require a dependency we don't need for two fields.
 pub fn parse_skill_frontmatter(text: &str) -> Option<AgentSkill> {
-    let rest = text.strip_prefix("---\n").or_else(|| text.strip_prefix("---\r\n"))?;
+    let rest = text
+        .strip_prefix("---\n")
+        .or_else(|| text.strip_prefix("---\r\n"))?;
     let end = rest.find("\n---")?;
     let block = &rest[..end];
 
@@ -177,11 +179,7 @@ mod tests {
             "alpha",
             "---\nname: alpha\ndescription: A\n---\n",
         );
-        write_skill(
-            tmp.path(),
-            "beta",
-            "---\nname: beta\ndescription: B\n---\n",
-        );
+        write_skill(tmp.path(), "beta", "---\nname: beta\ndescription: B\n---\n");
         fs::create_dir_all(tmp.path().join("not-a-skill")).unwrap();
 
         let mut skills = scan_skills_dir(tmp.path());

--- a/src-tauri/src/stream.rs
+++ b/src-tauri/src/stream.rs
@@ -155,6 +155,7 @@ pub struct TaskNameEvent {
 #[serde(rename_all = "camelCase")]
 pub struct GitStatusChangedEvent {
     pub task_id: String,
+    pub remote_likely_changed: bool,
 }
 
 /// Emitted to frontend when cached GitHub remote state is invalidated.
@@ -163,6 +164,21 @@ pub struct GitStatusChangedEvent {
 pub struct GitHubRemoteInvalidatedEvent {
     pub task_id: String,
     pub scopes: Vec<String>,
+}
+
+/// Emitted to frontend with debug info about GitHub cache/fetch activity.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GitHubRemoteDebugEvent {
+    pub task_id: String,
+    pub scope: String,
+    pub stage: String,
+    pub mode: Option<String>,
+    pub cache_state: Option<String>,
+    pub from_cache: Option<bool>,
+    pub duration_ms: Option<u64>,
+    pub detail: Option<String>,
+    pub emitted_at: i64,
 }
 
 /// Emitted to frontend when a task's hook starts, completes, or fails
@@ -1406,6 +1422,52 @@ fn now_ms() -> i64 {
         .unwrap_or(0)
 }
 
+fn github_remote_scopes_for_tool_start(tool: &str, input: &str) -> Option<Vec<String>> {
+    let tool = tool.trim().to_ascii_lowercase();
+    if tool != "bash" && tool != "commandexecution" && tool != "command_execution" {
+        return None;
+    }
+
+    let input = input.to_ascii_lowercase();
+    let pr_mutation = [
+        "gh pr create",
+        "gh pr reopen",
+        "gh pr close",
+        "gh pr ready",
+        "gh pr merge",
+    ]
+    .iter()
+    .any(|needle| input.contains(needle));
+
+    if pr_mutation {
+        Some(vec!["overview".to_string()])
+    } else {
+        None
+    }
+}
+
+fn process_github_remote_invalidation(
+    pending: &mut Vec<Vec<String>>,
+    item: &OutputItem,
+) -> Option<Vec<String>> {
+    match item {
+        OutputItem::ToolStart { tool, input } => {
+            if let Some(scopes) = github_remote_scopes_for_tool_start(tool, input) {
+                pending.push(scopes);
+            }
+            None
+        }
+        OutputItem::ToolResult { is_error, .. } => {
+            let scopes = pending.first().cloned();
+            if scopes.is_some() {
+                pending.remove(0);
+            }
+            if *is_error { None } else { scopes }
+        }
+        _ => None,
+    }
+}
+
 /// Stream stdout from the claude process, parse NDJSON events, emit
 /// structured items to frontend, persist to DB, and return all captured lines.
 ///
@@ -1442,6 +1504,7 @@ pub async fn stream_and_capture(
     // turn completes, because the rollout file isn't persisted until then.
     let mut pending_resume_id: Option<String> = None;
     let defers_resume = agent.defers_resume_id_until_turn_end();
+    let mut pending_github_invalidations: Vec<Vec<String>> = Vec::new();
 
     loop {
         let deadline = tokio::time::sleep(FLUSH_INTERVAL);
@@ -1557,6 +1620,18 @@ pub async fn stream_and_capture(
                         let mut has_immediate = false;
                         let mut is_turn_end = false;
                         for item in &items {
+                            if let Some(scopes) = process_github_remote_invalidation(
+                                &mut pending_github_invalidations,
+                                item,
+                            ) {
+                                let _ = app.emit(
+                                    "github-remote-invalidated",
+                                    GitHubRemoteInvalidatedEvent {
+                                        task_id: task_id.clone(),
+                                        scopes,
+                                    },
+                                );
+                            }
                             match item {
                                 OutputItem::Text { .. } | OutputItem::Thinking { .. } => {
                                     if !buffer.is_empty() {
@@ -1710,7 +1785,7 @@ pub async fn stream_and_capture_rpc(
     // that fires throughout the turn. Cache the most recent breakdown so we
     // can populate the next `TurnEnd` before emitting it to the UI / db.
     let mut last_token_usage: Option<CodexTokenUsage> = None;
-    let _ = task_id; // reserved for snapshot hook parity with legacy path
+    let mut pending_github_invalidations: Vec<Vec<String>> = Vec::new();
 
     loop {
         let deadline = tokio::time::sleep(FLUSH_INTERVAL);
@@ -1744,6 +1819,18 @@ pub async fn stream_and_capture_rpc(
                         let mut is_turn_end = false;
 
                         for item in &items {
+                            if let Some(scopes) = process_github_remote_invalidation(
+                                &mut pending_github_invalidations,
+                                item,
+                            ) {
+                                let _ = app.emit(
+                                    "github-remote-invalidated",
+                                    GitHubRemoteInvalidatedEvent {
+                                        task_id: task_id.clone(),
+                                        scopes,
+                                    },
+                                );
+                            }
                             match item {
                                 OutputItem::Text { .. }
                                 | OutputItem::Thinking { .. }
@@ -2829,6 +2916,89 @@ mod tests {
         let json = serde_json::to_value(&event).unwrap();
         assert_eq!(json["sessionId"], "s-001");
         assert_eq!(json["status"], "done");
+    }
+
+    #[test]
+    fn git_status_event_serializes_remote_likely_changed_as_camel_case() {
+        let event = GitStatusChangedEvent {
+            task_id: "t-001".into(),
+            remote_likely_changed: true,
+        };
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["taskId"], "t-001");
+        assert_eq!(json["remoteLikelyChanged"], true);
+    }
+
+    #[test]
+    fn github_remote_debug_event_serializes_as_camel_case() {
+        let event = GitHubRemoteDebugEvent {
+            task_id: "t-001".into(),
+            scope: "overview".into(),
+            stage: "fetch-success".into(),
+            mode: Some("network-only".into()),
+            cache_state: Some("miss".into()),
+            from_cache: Some(false),
+            duration_ms: Some(42),
+            detail: Some("overview".into()),
+            emitted_at: 123,
+        };
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["taskId"], "t-001");
+        assert_eq!(json["cacheState"], "miss");
+        assert_eq!(json["durationMs"], 42);
+        assert_eq!(json["emittedAt"], 123);
+    }
+
+    #[test]
+    fn github_pr_reopen_triggers_overview_invalidation_after_successful_result() {
+        let mut pending = Vec::new();
+
+        let start = OutputItem::ToolStart {
+            tool: "Bash".into(),
+            input: r#"{"command":"gh pr reopen 5"}"#.into(),
+        };
+        assert!(process_github_remote_invalidation(&mut pending, &start).is_none());
+        assert_eq!(pending, vec![vec!["overview".to_string()]]);
+
+        let result = OutputItem::ToolResult {
+            text: "Reopened the existing PR".into(),
+            is_error: false,
+        };
+        let scopes = process_github_remote_invalidation(&mut pending, &result);
+        assert_eq!(scopes, Some(vec!["overview".to_string()]));
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn github_pr_reopen_does_not_invalidate_on_failed_result() {
+        let mut pending = Vec::new();
+
+        let start = OutputItem::ToolStart {
+            tool: "Bash".into(),
+            input: r#"{"command":"gh pr reopen 5"}"#.into(),
+        };
+        process_github_remote_invalidation(&mut pending, &start);
+
+        let result = OutputItem::ToolResult {
+            text: "failed".into(),
+            is_error: true,
+        };
+        let scopes = process_github_remote_invalidation(&mut pending, &result);
+        assert_eq!(scopes, None);
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn github_pr_checks_does_not_arm_invalidation() {
+        let mut pending = Vec::new();
+
+        let start = OutputItem::ToolStart {
+            tool: "Bash".into(),
+            input: r#"{"command":"gh pr checks 5"}"#.into(),
+        };
+        let scopes = process_github_remote_invalidation(&mut pending, &start);
+        assert_eq!(scopes, None);
+        assert!(pending.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/stream.rs
+++ b/src-tauri/src/stream.rs
@@ -150,11 +150,19 @@ pub struct TaskNameEvent {
     pub name: String,
 }
 
-/// Emitted to frontend when git status may have changed (session ended)
+/// Emitted to frontend when local git state may have changed.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GitStatusChangedEvent {
     pub task_id: String,
+}
+
+/// Emitted to frontend when cached GitHub remote state is invalidated.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GitHubRemoteInvalidatedEvent {
+    pub task_id: String,
+    pub scopes: Vec<String>,
 }
 
 /// Emitted to frontend when a task's hook starts, completes, or fails
@@ -257,10 +265,7 @@ fn parse_sdk_event_value(v: &serde_json::Value) -> Vec<OutputItem> {
                 .and_then(|s| s.as_str())
                 .or_else(|| v.get("status").and_then(|s| s.as_str()))
                 .unwrap_or("unknown");
-            let is_error = v
-                .get("is_error")
-                .and_then(|e| e.as_bool())
-                .unwrap_or(false);
+            let is_error = v.get("is_error").and_then(|e| e.as_bool()).unwrap_or(false);
             let error = v
                 .get("error")
                 .and_then(|e| e.as_str())
@@ -682,10 +687,7 @@ fn parse_sdk_event_value(v: &serde_json::Value) -> Vec<OutputItem> {
 /// top-level `type` strings; this one maps RPC `method` strings.
 ///
 /// Wire ref: t3code `packages/effect-codex-app-server/src/_generated/meta.gen.ts`.
-pub fn process_codex_rpc_notification(
-    method: &str,
-    params: &serde_json::Value,
-) -> Vec<OutputItem> {
+pub fn process_codex_rpc_notification(method: &str, params: &serde_json::Value) -> Vec<OutputItem> {
     match method {
         // -- Token deltas (streamed into the current assistant / thinking block) --
         "item/agentMessage/delta" => params
@@ -915,7 +917,10 @@ pub fn process_codex_rpc_notification(
 
         // -- Turn completion --
         "turn/completed" => {
-            let turn = params.get("turn").cloned().unwrap_or(serde_json::Value::Null);
+            let turn = params
+                .get("turn")
+                .cloned()
+                .unwrap_or(serde_json::Value::Null);
             let status_str = turn
                 .get("status")
                 .and_then(|s| s.as_str())
@@ -981,7 +986,11 @@ fn format_codex_file_change(item: &serde_json::Value) -> Vec<OutputItem> {
         // not a bare string. Older CLIs emitted a string; accept both.
         let kind = change
             .get("kind")
-            .and_then(|k| k.get("type").and_then(|t| t.as_str()).or_else(|| k.as_str()))
+            .and_then(|k| {
+                k.get("type")
+                    .and_then(|t| t.as_str())
+                    .or_else(|| k.as_str())
+            })
             .unwrap_or("");
         let tool = match kind {
             "add" => "Write",
@@ -1663,9 +1672,7 @@ pub async fn stream_and_capture(
     }
 
     flush_buffer(&app, &session_id, &mut buffer);
-    StreamResult {
-        error: last_error,
-    }
+    StreamResult { error: last_error }
 }
 
 /// JSON-RPC streaming loop for Codex `app-server`. Mirrors the legacy
@@ -1678,9 +1685,7 @@ pub async fn stream_and_capture_rpc(
     app: AppHandle,
     session_id: String,
     task_id: String,
-    mut events_rx: tokio::sync::mpsc::UnboundedReceiver<
-        crate::agent::codex_rpc::CodexRpcEvent,
-    >,
+    mut events_rx: tokio::sync::mpsc::UnboundedReceiver<crate::agent::codex_rpc::CodexRpcEvent>,
     stdin: Arc<TokioMutex<Option<ChildStdin>>>,
     busy: Arc<AtomicBool>,
     _pending_approvals: PendingApprovals,
@@ -1907,9 +1912,7 @@ pub async fn stream_and_capture_rpc(
     }
 
     flush_buffer(&app, &session_id, &mut buffer);
-    StreamResult {
-        error: last_error,
-    }
+    StreamResult { error: last_error }
 }
 
 /// Check if a line is a `control_request` for tool approval.
@@ -2240,10 +2243,7 @@ pub fn extract_codex_token_usage(params: &serde_json::Value) -> Option<CodexToke
 
 /// Stamp the most recent `thread/tokenUsage/updated` breakdown onto a
 /// `TurnEnd` item. Leaves non-`TurnEnd` items untouched.
-pub fn patch_turn_end_with_usage(
-    item: OutputItem,
-    usage: &Option<CodexTokenUsage>,
-) -> OutputItem {
+pub fn patch_turn_end_with_usage(item: OutputItem, usage: &Option<CodexTokenUsage>) -> OutputItem {
     match (item, usage) {
         (
             OutputItem::TurnEnd {
@@ -2319,9 +2319,7 @@ pub fn persist_codex_plan_if_ready(item: OutputItem, worktree_path: &Path) -> Ou
                 match persist_codex_plan_markdown(worktree_path, &item_id, &text) {
                     Ok(p) => Some(p.to_string_lossy().into_owned()),
                     Err(e) => {
-                        eprintln!(
-                            "[verun][codex-rpc] failed to persist plan markdown: {e}"
-                        );
+                        eprintln!("[verun][codex-rpc] failed to persist plan markdown: {e}");
                         None
                     }
                 }
@@ -2502,8 +2500,12 @@ fn encode_codex_user_input_response(
         let ids = input.get("_codexQuestionIds").and_then(|v| v.as_object());
         if let (Some(answers), Some(ids)) = (answers, ids) {
             for (question_text, answer_val) in answers {
-                let Some(answer_text) = answer_val.as_str() else { continue };
-                let Some(id_val) = ids.get(question_text) else { continue };
+                let Some(answer_text) = answer_val.as_str() else {
+                    continue;
+                };
+                let Some(id_val) = ids.get(question_text) else {
+                    continue;
+                };
                 let Some(id) = id_val.as_str() else { continue };
                 out.insert(
                     id.to_string(),
@@ -2516,8 +2518,8 @@ fn encode_codex_user_input_response(
         "id": server_req_id,
         "result": { "answers": serde_json::Value::Object(out) },
     });
-    let mut bytes = serde_json::to_vec(&frame)
-        .map_err(|e| format!("serialize user input response: {e}"))?;
+    let mut bytes =
+        serde_json::to_vec(&frame).map_err(|e| format!("serialize user input response: {e}"))?;
     bytes.push(b'\n');
     Ok(bytes)
 }
@@ -2721,7 +2723,10 @@ mod tests {
         let (message, raw) = err.expect("expected ErrorMessage item");
         assert_eq!(message, "Prompt is too long");
         let raw = raw.expect("expected raw JSON payload");
-        assert!(raw.contains("\"<synthetic>\""), "raw should carry source JSON: {raw}");
+        assert!(
+            raw.contains("\"<synthetic>\""),
+            "raw should carry source JSON: {raw}"
+        );
         // Should NOT emit a duplicate plain Text item for the same synthetic error.
         assert!(
             !items.iter().any(|i| matches!(i, OutputItem::Text { .. })),
@@ -3103,10 +3108,17 @@ mod tests {
         let items = process_codex_rpc_notification("item/completed", &params);
         assert_eq!(items.len(), 1);
         match &items[0] {
-            OutputItem::CodexPlanReady { item_id, text, file_path } => {
+            OutputItem::CodexPlanReady {
+                item_id,
+                text,
+                file_path,
+            } => {
                 assert_eq!(item_id, "p1");
                 assert!(text.contains("design it"));
-                assert!(file_path.is_none(), "filePath is filled by the stream loop after writing");
+                assert!(
+                    file_path.is_none(),
+                    "filePath is filled by the stream loop after writing"
+                );
             }
             other => panic!("expected CodexPlanReady, got {other:?}"),
         }
@@ -3227,9 +3239,7 @@ mod tests {
 
     #[test]
     fn patch_turn_end_preserves_non_turn_end_items() {
-        let item = OutputItem::Text {
-            text: "hi".into(),
-        };
+        let item = OutputItem::Text { text: "hi".into() };
         match patch_turn_end_with_usage(item, &None) {
             OutputItem::Text { text } => assert_eq!(text, "hi"),
             other => panic!("expected Text, got {other:?}"),
@@ -3525,9 +3535,18 @@ mod tests {
             .and_then(|v| v.as_array())
             .expect("questions array");
         assert_eq!(qs.len(), 1);
-        assert_eq!(qs[0].get("question").and_then(|v| v.as_str()), Some("Pick a framework"));
-        assert_eq!(qs[0].get("header").and_then(|v| v.as_str()), Some("Frontend"));
-        assert_eq!(qs[0].get("multiSelect").and_then(|v| v.as_bool()), Some(false));
+        assert_eq!(
+            qs[0].get("question").and_then(|v| v.as_str()),
+            Some("Pick a framework")
+        );
+        assert_eq!(
+            qs[0].get("header").and_then(|v| v.as_str()),
+            Some("Frontend")
+        );
+        assert_eq!(
+            qs[0].get("multiSelect").and_then(|v| v.as_bool()),
+            Some(false)
+        );
         let opts = qs[0].get("options").and_then(|v| v.as_array()).unwrap();
         assert_eq!(opts.len(), 2);
         assert_eq!(opts[0].get("label").and_then(|v| v.as_str()), Some("Solid"));

--- a/src-tauri/src/task.rs
+++ b/src-tauri/src/task.rs
@@ -2212,6 +2212,7 @@ async fn spawn_codex_app_server_session(
             "git-local-changed",
             stream::GitStatusChangedEvent {
                 task_id: monitor_tid,
+                remote_likely_changed: true,
             },
         );
     });
@@ -2655,6 +2656,7 @@ pub async fn spawn_session_process(
             "git-local-changed",
             stream::GitStatusChangedEvent {
                 task_id: monitor_tid,
+                remote_likely_changed: true,
             },
         );
     });

--- a/src-tauri/src/task.rs
+++ b/src-tauri/src/task.rs
@@ -21,98 +21,445 @@ use uuid::Uuid;
 
 const ADJECTIVES: &[&str] = &[
     // State/condition
-    "broken", "stale", "null", "dangling", "cursed", "legacy", "flaky", "frozen", "leaky",
-    "panicking", "volatile", "blocked", "corrupt", "unhandled", "undefined", "deprecated",
-    "recursive", "mutating", "thrashing", "fragile", "poisoned", "detached", "overloaded",
+    "broken",
+    "stale",
+    "null",
+    "dangling",
+    "cursed",
+    "legacy",
+    "flaky",
+    "frozen",
+    "leaky",
+    "panicking",
+    "volatile",
+    "blocked",
+    "corrupt",
+    "unhandled",
+    "undefined",
+    "deprecated",
+    "recursive",
+    "mutating",
+    "thrashing",
+    "fragile",
+    "poisoned",
+    "detached",
+    "overloaded",
     "async",
     // Behavior
-    "haunted", "sleeping", "spinning", "crashing", "burning", "exploding", "melting", "drifting",
-    "sneaking", "lurking", "escaping", "leaking", "hanging", "starving", "evicting", "colliding",
+    "haunted",
+    "sleeping",
+    "spinning",
+    "crashing",
+    "burning",
+    "exploding",
+    "melting",
+    "drifting",
+    "sneaking",
+    "lurking",
+    "escaping",
+    "leaking",
+    "hanging",
+    "starving",
+    "evicting",
+    "colliding",
     "flushing",
     // Dev-lifecycle
-    "tangled", "nested", "bloated", "sharded", "cached", "proxied", "forked", "merged",
-    "rebased", "squashed", "reverted", "patched", "shipped", "hotfixed", "hacked", "yolo",
+    "tangled",
+    "nested",
+    "bloated",
+    "sharded",
+    "cached",
+    "proxied",
+    "forked",
+    "merged",
+    "rebased",
+    "squashed",
+    "reverted",
+    "patched",
+    "shipped",
+    "hotfixed",
+    "hacked",
+    "yolo",
     // Modern buzzwords
-    "serverless", "containerized", "orchestrated", "distributed", "eventual", "idempotent",
-    "immutable", "stateless", "reactive", "declarative", "imperative", "functional", "monadic",
-    "curried", "memoized", "lazy",
+    "serverless",
+    "containerized",
+    "orchestrated",
+    "distributed",
+    "eventual",
+    "idempotent",
+    "immutable",
+    "stateless",
+    "reactive",
+    "declarative",
+    "imperative",
+    "functional",
+    "monadic",
+    "curried",
+    "memoized",
+    "lazy",
 ];
 
 const NOUNS_GENERIC: &[&str] = &[
     // Classic CS
-    "pointer", "closure", "semaphore", "deadlock", "segfault", "exception", "footgun",
-    "regression", "monolith", "bottleneck", "timeout", "mutex", "thread", "heap", "pipeline",
-    "iterator", "dependency", "hotfix", "workaround", "refactor", "codebase", "spaghetti",
-    "callback", "stack",
+    "pointer",
+    "closure",
+    "semaphore",
+    "deadlock",
+    "segfault",
+    "exception",
+    "footgun",
+    "regression",
+    "monolith",
+    "bottleneck",
+    "timeout",
+    "mutex",
+    "thread",
+    "heap",
+    "pipeline",
+    "iterator",
+    "dependency",
+    "hotfix",
+    "workaround",
+    "refactor",
+    "codebase",
+    "spaghetti",
+    "callback",
+    "stack",
     // Architecture/infra
-    "microservice", "abstraction", "singleton", "factory", "middleware", "gateway", "proxy",
-    "cache", "queue", "broker", "replica", "sidecar", "loadbalancer", "circuit", "backpressure",
+    "microservice",
+    "abstraction",
+    "singleton",
+    "factory",
+    "middleware",
+    "gateway",
+    "proxy",
+    "cache",
+    "queue",
+    "broker",
+    "replica",
+    "sidecar",
+    "loadbalancer",
+    "circuit",
+    "backpressure",
     "checkpoint",
     // Dev pain
-    "migration", "rollback", "incident", "postmortem", "oncall", "flakiness", "flakytest",
-    "techdebt", "bikeshed", "yagni", "rewrite", "greenfield", "brownfield", "triage", "runbook",
+    "migration",
+    "rollback",
+    "incident",
+    "postmortem",
+    "oncall",
+    "flakiness",
+    "flakytest",
+    "techdebt",
+    "bikeshed",
+    "yagni",
+    "rewrite",
+    "greenfield",
+    "brownfield",
+    "triage",
+    "runbook",
     // Modern concepts
-    "container", "webhook", "cronjob", "sideeffect", "invariant", "predicate", "combinator",
-    "monad", "functor", "reducer", "selector", "observable", "subscription", "serializer",
-    "hydration", "abstraction", "interface",
+    "container",
+    "webhook",
+    "cronjob",
+    "sideeffect",
+    "invariant",
+    "predicate",
+    "combinator",
+    "monad",
+    "functor",
+    "reducer",
+    "selector",
+    "observable",
+    "subscription",
+    "serializer",
+    "hydration",
+    "abstraction",
+    "interface",
 ];
 
 const NOUNS_RUST: &[&str] = &[
-    "borrow", "lifetime", "trait", "ownership", "unsafe", "transmute", "phantom", "future",
-    "executor", "clippy", "linker", "crate", "macro", "reference", "slice", "deriving",
-    "pinbox", "allocator", "borrowchecker", "dropglue", "sendbound", "syncbound", "arcmutex",
-    "refcell", "rwlock", "channel", "tokioruntime", "asynctrait", "pinned", "variance",
-    "covariance", "contravariance", "turbofish", "newtype", "typestate", "destructor", "waker",
-    "poll", "spawntask", "blockingcall", "unsafecode", "rawpointer", "dangler", "useafterfree",
-    "doublefree", "stacksmash", "intoverflow", "datarace", "borrowmut", "movesemantics",
-    "copytype", "cloneimpl", "derefcoercion", "autoref",
+    "borrow",
+    "lifetime",
+    "trait",
+    "ownership",
+    "unsafe",
+    "transmute",
+    "phantom",
+    "future",
+    "executor",
+    "clippy",
+    "linker",
+    "crate",
+    "macro",
+    "reference",
+    "slice",
+    "deriving",
+    "pinbox",
+    "allocator",
+    "borrowchecker",
+    "dropglue",
+    "sendbound",
+    "syncbound",
+    "arcmutex",
+    "refcell",
+    "rwlock",
+    "channel",
+    "tokioruntime",
+    "asynctrait",
+    "pinned",
+    "variance",
+    "covariance",
+    "contravariance",
+    "turbofish",
+    "newtype",
+    "typestate",
+    "destructor",
+    "waker",
+    "poll",
+    "spawntask",
+    "blockingcall",
+    "unsafecode",
+    "rawpointer",
+    "dangler",
+    "useafterfree",
+    "doublefree",
+    "stacksmash",
+    "intoverflow",
+    "datarace",
+    "borrowmut",
+    "movesemantics",
+    "copytype",
+    "cloneimpl",
+    "derefcoercion",
+    "autoref",
 ];
 
 const NOUNS_JS: &[&str] = &[
-    "prototype", "hoisting", "coercion", "bundler", "polyfill", "transpiler", "promise",
-    "hydration", "rerender", "middleware", "lockfile", "semver", "treeshake", "eslint",
-    "tsconfig", "webpack", "vite", "closure", "eventloop", "callstack", "microtask",
-    "macrotask", "settimeout", "npmaudit", "leftpad", "yarnwhy", "nodemodules", "peerconflict",
-    "typewidening", "typenarrowing", "anytype", "assertion", "overload", "memoization",
-    "stalestate", "staleclosure", "useeffect", "infiniteloop", "proptypes", "hookrule",
-    "propdrilling", "reactivity", "solidstore", "sveltestores", "nextrouter", "bundlesize",
-    "chunksplitting", "codesplitting", "lazyload", "suspense", "concurrentmode", "diffing",
-    "treeflattening", "signalapocalypse",
+    "prototype",
+    "hoisting",
+    "coercion",
+    "bundler",
+    "polyfill",
+    "transpiler",
+    "promise",
+    "hydration",
+    "rerender",
+    "middleware",
+    "lockfile",
+    "semver",
+    "treeshake",
+    "eslint",
+    "tsconfig",
+    "webpack",
+    "vite",
+    "closure",
+    "eventloop",
+    "callstack",
+    "microtask",
+    "macrotask",
+    "settimeout",
+    "npmaudit",
+    "leftpad",
+    "yarnwhy",
+    "nodemodules",
+    "peerconflict",
+    "typewidening",
+    "typenarrowing",
+    "anytype",
+    "assertion",
+    "overload",
+    "memoization",
+    "stalestate",
+    "staleclosure",
+    "useeffect",
+    "infiniteloop",
+    "proptypes",
+    "hookrule",
+    "propdrilling",
+    "reactivity",
+    "solidstore",
+    "sveltestores",
+    "nextrouter",
+    "bundlesize",
+    "chunksplitting",
+    "codesplitting",
+    "lazyload",
+    "suspense",
+    "concurrentmode",
+    "diffing",
+    "treeflattening",
+    "signalapocalypse",
 ];
 
 const NOUNS_PYTHON: &[&str] = &[
-    "pickle", "gil", "decorator", "metaclass", "generator", "virtualenv", "dunder", "lambda",
-    "walrus", "asyncio", "celery", "pydantic", "namespace", "unpacking", "dataclass",
-    "comprehension", "typehint", "importerror", "monkeypatch", "mutabledefault", "latebound",
-    "circularimport", "venv", "conda", "poetrylock", "pipfreeze", "pipconflict", "egginfo",
-    "abstractmethod", "classmethod", "staticmethod", "propertydecorator", "slots", "weakref",
-    "finalizer", "garbagecollector", "cyclicref", "asyncgenerator", "coroutine", "threadlocal",
-    "multiprocessing", "pickling", "shelve", "ormquery", "djangomigration", "flaskcontext",
-    "fastapimodel", "pandasframe", "numpybroadcast", "typeerror", "indentationerror",
-    "syntaxwarning", "deprecationwarn", "runtimeerror",
+    "pickle",
+    "gil",
+    "decorator",
+    "metaclass",
+    "generator",
+    "virtualenv",
+    "dunder",
+    "lambda",
+    "walrus",
+    "asyncio",
+    "celery",
+    "pydantic",
+    "namespace",
+    "unpacking",
+    "dataclass",
+    "comprehension",
+    "typehint",
+    "importerror",
+    "monkeypatch",
+    "mutabledefault",
+    "latebound",
+    "circularimport",
+    "venv",
+    "conda",
+    "poetrylock",
+    "pipfreeze",
+    "pipconflict",
+    "egginfo",
+    "abstractmethod",
+    "classmethod",
+    "staticmethod",
+    "propertydecorator",
+    "slots",
+    "weakref",
+    "finalizer",
+    "garbagecollector",
+    "cyclicref",
+    "asyncgenerator",
+    "coroutine",
+    "threadlocal",
+    "multiprocessing",
+    "pickling",
+    "shelve",
+    "ormquery",
+    "djangomigration",
+    "flaskcontext",
+    "fastapimodel",
+    "pandasframe",
+    "numpybroadcast",
+    "typeerror",
+    "indentationerror",
+    "syntaxwarning",
+    "deprecationwarn",
+    "runtimeerror",
 ];
 
 const NOUNS_GO: &[&str] = &[
-    "goroutine", "channel", "interface", "defer", "recover", "embedding", "reflection",
-    "vendor", "context", "waitgroup", "errorf", "nilpointer", "module", "struct", "receiver",
-    "concurrency", "gofmt", "init", "goroutineleak", "channelblock", "selectstmt",
-    "closurecapture", "nilinterface", "goroutinepool", "ticker", "timer", "signalchan",
-    "syncmap", "atomicop", "mutexlock", "rwmutex", "oncefn", "poolreset", "goroutinerace",
-    "datarace", "golangci", "govet", "gomod", "gosum", "buildtag", "cgocall", "unsafeptr",
-    "typeassert", "panicrecovery", "namedreturn", "deferorder", "initorder", "blankimport",
-    "shadowedvar", "shortdecl", "multireturn", "errorwrap", "errortarget", "errorchain",
+    "goroutine",
+    "channel",
+    "interface",
+    "defer",
+    "recover",
+    "embedding",
+    "reflection",
+    "vendor",
+    "context",
+    "waitgroup",
+    "errorf",
+    "nilpointer",
+    "module",
+    "struct",
+    "receiver",
+    "concurrency",
+    "gofmt",
+    "init",
+    "goroutineleak",
+    "channelblock",
+    "selectstmt",
+    "closurecapture",
+    "nilinterface",
+    "goroutinepool",
+    "ticker",
+    "timer",
+    "signalchan",
+    "syncmap",
+    "atomicop",
+    "mutexlock",
+    "rwmutex",
+    "oncefn",
+    "poolreset",
+    "goroutinerace",
+    "datarace",
+    "golangci",
+    "govet",
+    "gomod",
+    "gosum",
+    "buildtag",
+    "cgocall",
+    "unsafeptr",
+    "typeassert",
+    "panicrecovery",
+    "namedreturn",
+    "deferorder",
+    "initorder",
+    "blankimport",
+    "shadowedvar",
+    "shortdecl",
+    "multireturn",
+    "errorwrap",
+    "errortarget",
+    "errorchain",
 ];
 
 const NOUNS_JAVA: &[&str] = &[
-    "nullpointer", "classloader", "reflection", "serializable", "generics", "boilerplate",
-    "singleton", "factory", "enterprise", "inheritance", "bytecode", "jvm", "annotation",
-    "abstraction", "dependency", "injection", "exception", "stackoverflowex", "outofmemory",
-    "classcastex", "arraybounds", "concurrentmod", "deadlockjvm", "threadpool", "executorservice",
-    "springbean", "hibernateproxy", "jpaquery", "lazyload", "eagerfetch", "transactional",
-    "aspectj", "cglibproxy", "lombokdata", "buildergenerator", "mapstruct", "jacksondeser",
-    "gradledep", "mavenplugin", "classpathconflict", "jarconflict", "modulepath", "jigsaw",
-    "recordtype", "sealedclass", "patternmatch", "virtualthread", "loom", "graalvm",
-    "nativeimage", "jitcompile", "g1gc", "zgc",
+    "nullpointer",
+    "classloader",
+    "reflection",
+    "serializable",
+    "generics",
+    "boilerplate",
+    "singleton",
+    "factory",
+    "enterprise",
+    "inheritance",
+    "bytecode",
+    "jvm",
+    "annotation",
+    "abstraction",
+    "dependency",
+    "injection",
+    "exception",
+    "stackoverflowex",
+    "outofmemory",
+    "classcastex",
+    "arraybounds",
+    "concurrentmod",
+    "deadlockjvm",
+    "threadpool",
+    "executorservice",
+    "springbean",
+    "hibernateproxy",
+    "jpaquery",
+    "lazyload",
+    "eagerfetch",
+    "transactional",
+    "aspectj",
+    "cglibproxy",
+    "lombokdata",
+    "buildergenerator",
+    "mapstruct",
+    "jacksondeser",
+    "gradledep",
+    "mavenplugin",
+    "classpathconflict",
+    "jarconflict",
+    "modulepath",
+    "jigsaw",
+    "recordtype",
+    "sealedclass",
+    "patternmatch",
+    "virtualthread",
+    "loom",
+    "graalvm",
+    "nativeimage",
+    "jitcompile",
+    "g1gc",
+    "zgc",
 ];
 
 fn collect_stack_nouns(repo_path: &str) -> Vec<&'static str> {
@@ -1050,11 +1397,10 @@ pub async fn send_message(
                         "Codex RPC session missing request id counter — cannot reuse process"
                             .to_string()
                     })?;
-                    let current_turn_id =
-                        entry.codex_current_turn_id.clone().ok_or_else(|| {
-                            "Codex RPC session missing current-turn slot — cannot reuse process"
-                                .to_string()
-                        })?;
+                    let current_turn_id = entry.codex_current_turn_id.clone().ok_or_else(|| {
+                        "Codex RPC session missing current-turn slot — cannot reuse process"
+                            .to_string()
+                    })?;
                     entry.current_permission_mode = want_permission_mode.to_string();
                     entry.current_model.clone_from(&model);
                     FastPath::GoRpc {
@@ -1595,8 +1941,7 @@ async fn spawn_codex_app_server_session(
 
     let pending = codex_rpc::new_pending_rpc_responses();
     let next_id = Arc::new(AtomicI64::new(1));
-    let (events_tx, events_rx) =
-        tokio::sync::mpsc::unbounded_channel::<codex_rpc::CodexRpcEvent>();
+    let (events_tx, events_rx) = tokio::sync::mpsc::unbounded_channel::<codex_rpc::CodexRpcEvent>();
     codex_rpc::spawn_reader(stdout, pending.clone(), events_tx);
 
     // -- 1. initialize + initialized --
@@ -1633,12 +1978,30 @@ async fn spawn_codex_app_server_session(
                 eprintln!(
                     "[verun][codex-rpc][{session_id}] thread/resume recoverable, falling back to thread/start: {err}"
                 );
-                start_new_thread(&*agent, &stdin, &pending, &next_id, &worktree_path, trust_level, model.as_deref()).await?
+                start_new_thread(
+                    &*agent,
+                    &stdin,
+                    &pending,
+                    &next_id,
+                    &worktree_path,
+                    trust_level,
+                    model.as_deref(),
+                )
+                .await?
             }
             Err(err) => return Err(format!("codex thread/resume failed: {err}")),
         }
     } else {
-        start_new_thread(&*agent, &stdin, &pending, &next_id, &worktree_path, trust_level, model.as_deref()).await?
+        start_new_thread(
+            &*agent,
+            &stdin,
+            &pending,
+            &next_id,
+            &worktree_path,
+            trust_level,
+            model.as_deref(),
+        )
+        .await?
     };
 
     // Persist the thread id immediately — no waiting for turn end.
@@ -1775,9 +2138,7 @@ async fn spawn_codex_app_server_session(
         let status = if let Some((_, mut proc)) = monitor_active.remove(&monitor_sid) {
             let exit_status = proc.child.wait().await.ok();
             let exit_code = exit_status.as_ref().and_then(|s| s.code());
-            eprintln!(
-                "[verun][codex-rpc][{monitor_sid}] exited code={exit_code:?}"
-            );
+            eprintln!("[verun][codex-rpc][{monitor_sid}] exited code={exit_code:?}");
             stream::map_exit_status(exit_code)
         } else {
             return;
@@ -1785,17 +2146,17 @@ async fn spawn_codex_app_server_session(
 
         let config_path = format!("{wt_for_hooks}/.verun.json");
         if let Some((setup, destroy, start)) = parse_verun_config_file(&config_path) {
-            let auto_start =
-                if let Some(pool) = monitor_app.try_state::<sqlx::sqlite::SqlitePool>() {
-                    db::get_project(pool.inner(), &monitor_pid)
-                        .await
-                        .ok()
-                        .flatten()
-                        .map(|p| p.auto_start)
-                        .unwrap_or(false)
-                } else {
-                    false
-                };
+            let auto_start = if let Some(pool) = monitor_app.try_state::<sqlx::sqlite::SqlitePool>()
+            {
+                db::get_project(pool.inner(), &monitor_pid)
+                    .await
+                    .ok()
+                    .flatten()
+                    .map(|p| p.auto_start)
+                    .unwrap_or(false)
+            } else {
+                false
+            };
             let _ = monitor_db_tx
                 .send(db::DbWrite::UpdateProjectHooks {
                     id: monitor_pid.clone(),
@@ -1848,7 +2209,7 @@ async fn spawn_codex_app_server_session(
             },
         );
         let _ = monitor_app.emit(
-            "git-status-changed",
+            "git-local-changed",
             stream::GitStatusChangedEvent {
                 task_id: monitor_tid,
             },
@@ -1934,9 +2295,7 @@ fn spawn_turn_start_response_watcher(
         if !busy.load(Ordering::SeqCst) {
             return;
         }
-        eprintln!(
-            "[verun][codex-rpc][{session_id}] turn/start failed: {err_msg}"
-        );
+        eprintln!("[verun][codex-rpc][{session_id}] turn/start failed: {err_msg}");
         busy.store(false, Ordering::SeqCst);
         let _ = app.emit(
             "session-output",
@@ -2293,7 +2652,7 @@ pub async fn spawn_session_process(
 
         // Notify frontend that git status may have changed
         let _ = monitor_app.emit(
-            "git-status-changed",
+            "git-local-changed",
             stream::GitStatusChangedEvent {
                 task_id: monitor_tid,
             },
@@ -2381,7 +2740,10 @@ pub async fn abort_message(
                     }
                 }
             } else {
-                (Some(agent.encode_stream_interrupt(&new_control_request_id())?), false)
+                (
+                    Some(agent.encode_stream_interrupt(&new_control_request_id())?),
+                    false,
+                )
             };
             if let Some(bytes) = maybe_bytes {
                 // Best-effort: if stdin is already closed we fall through
@@ -2534,12 +2896,8 @@ pub async fn interrupt_session(active: &ActiveMap, session_id: &str) -> Result<(
         .map(|proc| proc.stdin.clone())
         .ok_or_else(|| "No active session".to_string())?;
 
-    let (_req_id, _rx) = send_control_request(
-        &stdin,
-        None,
-        serde_json::json!({ "subtype": "interrupt" }),
-    )
-    .await?;
+    let (_req_id, _rx) =
+        send_control_request(&stdin, None, serde_json::json!({ "subtype": "interrupt" })).await?;
     Ok(())
 }
 
@@ -3259,8 +3617,7 @@ mod tests {
     fn active_session_ids_for_task_excludes_other_tasks_sessions() {
         // Active sessions: s1, s2 belong to task A; s3, s4 belong to task B.
         // Archiving task B should return only s3, s4 - never s1, s2.
-        let active_ids: Vec<String> =
-            vec!["s1".into(), "s2".into(), "s3".into(), "s4".into()];
+        let active_ids: Vec<String> = vec!["s1".into(), "s2".into(), "s3".into(), "s4".into()];
         let task_b_session_ids = ["s3".to_string(), "s4".to_string()];
         let mut result = active_session_ids_for_task(active_ids, &task_b_session_ids);
         result.sort();

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -107,6 +107,7 @@ pub fn start_watching(
                         "git-local-changed",
                         crate::stream::GitStatusChangedEvent {
                             task_id: tid.clone(),
+                            remote_likely_changed: false,
                         },
                     );
                 }

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -80,10 +80,9 @@ pub fn start_watching(
                 for event in &events {
                     if event.kind == DebouncedEventKind::Any {
                         // Events from the extra git dir (worktree git state) →
-                        // git-status-changed only, never file-tree-changed.
-                        let from_extra_git = extra_git_dirs
-                            .iter()
-                            .any(|gd| event.path.starts_with(gd));
+                        // local git state only, never file-tree-changed.
+                        let from_extra_git =
+                            extra_git_dirs.iter().any(|gd| event.path.starts_with(gd));
                         if from_extra_git {
                             git_changed = true;
                             continue;
@@ -105,7 +104,7 @@ pub fn start_watching(
                 }
                 if git_changed {
                     let _ = app.emit(
-                        "git-status-changed",
+                        "git-local-changed",
                         crate::stream::GitStatusChangedEvent {
                             task_id: tid.clone(),
                         },

--- a/src-tauri/src/worktree.rs
+++ b/src-tauri/src/worktree.rs
@@ -319,7 +319,10 @@ pub struct BranchStatus {
     pub tracking_sha: Option<String>,
 }
 
-pub fn get_branch_status(worktree_path: &str, last_pushed_sha: Option<&str>) -> Result<BranchStatus, String> {
+pub fn get_branch_status(
+    worktree_path: &str,
+    last_pushed_sha: Option<&str>,
+) -> Result<BranchStatus, String> {
     let current = get_current_branch(worktree_path)?;
     let base_ref = find_compare_ref(worktree_path, &current)?;
     let (behind, ahead) = rev_list_left_right(worktree_path, &base_ref, &current);
@@ -336,7 +339,12 @@ pub fn get_branch_status(worktree_path: &str, last_pushed_sha: Option<&str>) -> 
         (ahead, None)
     };
 
-    Ok(BranchStatus { ahead, behind, unpushed, tracking_sha })
+    Ok(BranchStatus {
+        ahead,
+        behind,
+        unpushed,
+        tracking_sha,
+    })
 }
 
 fn resolve_ref(worktree_path: &str, refname: &str) -> Option<String> {

--- a/src/components/ActionsPanel.test.tsx
+++ b/src/components/ActionsPanel.test.tsx
@@ -54,6 +54,24 @@ const gitMocks = vi.hoisted(() => ({
 }))
 vi.mock('../store/git', () => gitMocks)
 
+const githubDebugMocks = vi.hoisted(() => ({
+  githubDebugEntriesForTask: vi.fn(() => [
+    {
+      id: 1,
+      taskId: 't1',
+      scope: 'overview',
+      stage: 'fetch-success',
+      mode: 'network-only',
+      cacheState: 'miss',
+      fromCache: false,
+      durationMs: 42,
+      emittedAt: 1_746_000_000_000,
+      detail: 'overview refreshed',
+    },
+  ]),
+}))
+vi.mock('../store/githubDebug', () => githubDebugMocks)
+
 import { ActionsPanel } from './ActionsPanel'
 import { clearActionsState, stopPolling } from '../store/actions'
 
@@ -81,6 +99,12 @@ async function flush() {
 describe('<ActionsPanel /> layout', () => {
   beforeEach(() => {
     cleanup()
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    })
     stopPolling('t1')
     clearActionsState('t1')
     ipcMocks.getGithubActions.mockReset()
@@ -233,5 +257,47 @@ describe('<ActionsPanel /> layout', () => {
     // Run row should no longer show the red failure X
     const redIcon = rowBtn.querySelector('.text-red-400')
     expect(redIcon).toBeNull()
+  })
+
+  test('dev builds render a GitHub debug panel with recent request activity', async () => {
+    ipcMocks.getGithubActions.mockResolvedValue({
+      runs: [run({ databaseId: 1, state: 'success', workflowName: 'CI' })],
+      fetchedAt: 1,
+      staleAt: 2,
+      expiresAt: 3,
+      isStale: false,
+      fromCache: false,
+    })
+
+    const { getByText, container } = render(() => <ActionsPanel taskId="t1" />)
+    await flush()
+
+    expect(getByText('GitHub Debug')).toBeTruthy()
+    expect(container.textContent).toContain('fetch-success')
+    expect(container.textContent).toContain('overview')
+    expect(container.textContent).toContain('network-only')
+  })
+
+  test('dev builds can copy the full GitHub debug log', async () => {
+    ipcMocks.getGithubActions.mockResolvedValue({
+      runs: [run({ databaseId: 1, state: 'success', workflowName: 'CI' })],
+      fetchedAt: 1,
+      staleAt: 2,
+      expiresAt: 3,
+      isStale: false,
+      fromCache: false,
+    })
+
+    const { container } = render(() => <ActionsPanel taskId="t1" />)
+    await flush()
+
+    const copyButton = container.querySelector('[title="Copy all debug logs"]') as HTMLButtonElement | null
+    expect(copyButton).toBeTruthy()
+
+    await fireEvent.click(copyButton!)
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(navigator.clipboard.writeText).mock.calls[0]?.[0]).toContain('fetch-success')
+    expect(vi.mocked(navigator.clipboard.writeText).mock.calls[0]?.[0]).toContain('overview')
   })
 })

--- a/src/components/ActionsPanel.test.tsx
+++ b/src/components/ActionsPanel.test.tsx
@@ -9,9 +9,9 @@ vi.mock('@tauri-apps/api/event', () => ({
 vi.mock('@tauri-apps/plugin-opener', () => ({ openUrl: vi.fn() }))
 
 const ipcMocks = vi.hoisted(() => ({
-  listWorkflowRuns: vi.fn(),
-  listWorkflowJobs: vi.fn(),
-  getWorkflowFailedLogs: vi.fn(),
+  getGithubActions: vi.fn(),
+  getGithubWorkflowJobs: vi.fn(),
+  getGithubWorkflowLog: vi.fn(),
   rerunWorkflowRun: vi.fn(),
   cancelWorkflowRun: vi.fn(),
   createSession: vi.fn(),
@@ -83,17 +83,33 @@ describe('<ActionsPanel /> layout', () => {
     cleanup()
     stopPolling('t1')
     clearActionsState('t1')
-    ipcMocks.listWorkflowRuns.mockReset()
-    ipcMocks.listWorkflowJobs.mockReset()
+    ipcMocks.getGithubActions.mockReset()
+    ipcMocks.getGithubWorkflowJobs.mockReset()
+    ipcMocks.getGithubWorkflowLog.mockReset()
     ipcMocks.rerunWorkflowRun.mockReset()
   })
 
   test('relative time is rendered after the hover action cluster on both failed and success rows', async () => {
-    ipcMocks.listWorkflowRuns.mockResolvedValue([
-      run({ databaseId: 1, state: 'failure', workflowName: 'CI' }),
-      run({ databaseId: 2, state: 'success', workflowName: 'Release' }),
-    ])
-    ipcMocks.listWorkflowJobs.mockResolvedValue([])
+    ipcMocks.getGithubActions.mockResolvedValue({
+      runs: [
+        run({ databaseId: 1, state: 'failure', workflowName: 'CI' }),
+        run({ databaseId: 2, state: 'success', workflowName: 'Release' }),
+      ],
+      fetchedAt: 1,
+      staleAt: 2,
+      expiresAt: 3,
+      isStale: false,
+      fromCache: false,
+    })
+    ipcMocks.getGithubWorkflowJobs.mockResolvedValue({
+      runId: 1,
+      jobs: [],
+      fetchedAt: 1,
+      staleAt: 2,
+      expiresAt: 3,
+      isStale: false,
+      fromCache: false,
+    })
 
     const { container } = render(() => <ActionsPanel taskId="t1" />)
     await flush()
@@ -113,13 +129,36 @@ describe('<ActionsPanel /> layout', () => {
   })
 
   test('clicking a failed job expands an inline panel with logs and action buttons', async () => {
-    ipcMocks.listWorkflowRuns.mockResolvedValue([
-      run({ databaseId: 1, state: 'failure', workflowName: 'CI' }),
-    ])
-    ipcMocks.listWorkflowJobs.mockResolvedValue([
-      { databaseId: 10, name: 'Type Check', state: 'failure', startedAt: '2026-04-20T10:00:00Z', completedAt: '2026-04-20T10:01:12Z', url: 'https://github.com/x/y/runs/10' },
-    ])
-    ipcMocks.getWorkflowFailedLogs.mockResolvedValue('error TS2322: Type mismatch at foo.ts:17')
+    ipcMocks.getGithubActions.mockResolvedValue({
+      runs: [
+        run({ databaseId: 1, state: 'failure', workflowName: 'CI' }),
+      ],
+      fetchedAt: 1,
+      staleAt: 2,
+      expiresAt: 3,
+      isStale: false,
+      fromCache: false,
+    })
+    ipcMocks.getGithubWorkflowJobs.mockResolvedValue({
+      runId: 1,
+      jobs: [
+        { databaseId: 10, name: 'Type Check', state: 'failure', startedAt: '2026-04-20T10:00:00Z', completedAt: '2026-04-20T10:01:12Z', url: 'https://github.com/x/y/runs/10' },
+      ],
+      fetchedAt: 1,
+      staleAt: 2,
+      expiresAt: 3,
+      isStale: false,
+      fromCache: false,
+    })
+    ipcMocks.getGithubWorkflowLog.mockResolvedValue({
+      jobId: 10,
+      text: 'error TS2322: Type mismatch at foo.ts:17',
+      fetchedAt: 1,
+      staleAt: 2,
+      expiresAt: 3,
+      isStale: false,
+      fromCache: false,
+    })
 
     const { container } = render(() => <ActionsPanel taskId="t1" />)
     await flush()
@@ -140,7 +179,7 @@ describe('<ActionsPanel /> layout', () => {
 
     // Logs panel appears with the log text
     expect(container.textContent).toContain('error TS2322')
-    expect(ipcMocks.getWorkflowFailedLogs).toHaveBeenCalledWith('t1', 1, 10)
+    expect(ipcMocks.getGithubWorkflowLog).toHaveBeenCalledWith('t1', 10)
 
     // Action buttons are in the expanded panel
     expect(container.querySelector('[title="Re-run this job"]')).not.toBeNull()
@@ -149,12 +188,27 @@ describe('<ActionsPanel /> layout', () => {
   })
 
   test('rerunning a failing run optimistically renders the running (spinner) icon', async () => {
-    ipcMocks.listWorkflowRuns.mockResolvedValue([
-      run({ databaseId: 42, state: 'failure', workflowName: 'CI' }),
-    ])
-    ipcMocks.listWorkflowJobs.mockResolvedValue([
-      { databaseId: 10, name: 'test', state: 'failure', startedAt: '2026-04-20T10:00:00Z', completedAt: '2026-04-20T10:01:00Z', url: 'u' },
-    ])
+    ipcMocks.getGithubActions.mockResolvedValue({
+      runs: [
+        run({ databaseId: 42, state: 'failure', workflowName: 'CI' }),
+      ],
+      fetchedAt: 1,
+      staleAt: 2,
+      expiresAt: 3,
+      isStale: false,
+      fromCache: false,
+    })
+    ipcMocks.getGithubWorkflowJobs.mockResolvedValue({
+      runId: 42,
+      jobs: [
+        { databaseId: 10, name: 'test', state: 'failure', startedAt: '2026-04-20T10:00:00Z', completedAt: '2026-04-20T10:01:00Z', url: 'u' },
+      ],
+      fetchedAt: 1,
+      staleAt: 2,
+      expiresAt: 3,
+      isStale: false,
+      fromCache: false,
+    })
     ipcMocks.rerunWorkflowRun.mockResolvedValue(undefined)
 
     const { container } = render(() => <ActionsPanel taskId="t1" />)

--- a/src/components/ActionsPanel.tsx
+++ b/src/components/ActionsPanel.tsx
@@ -12,6 +12,7 @@ import {
   rerunFailedJobsForRun, rerunSingleJob,
 } from '../store/actions'
 import { taskGit } from '../store/git'
+import { githubDebugEntriesForTask } from '../store/githubDebug'
 import { taskById } from '../store/tasks'
 import { sessionsForTask, sendMessage } from '../store/sessions'
 import { selectedSessionForTask } from '../store/taskContext'
@@ -25,6 +26,23 @@ import { Popover } from './Popover'
 
 interface Props {
   taskId: string
+}
+
+function formatGitHubDebugEntries(entries: ReturnType<typeof githubDebugEntriesForTask>): string {
+  return entries
+    .map((entry) => {
+      const parts = [
+        new Date(entry.emittedAt).toISOString(),
+        entry.scope,
+        entry.stage,
+      ]
+      if (entry.mode) parts.push(`mode=${entry.mode}`)
+      if (entry.cacheState) parts.push(`cache=${entry.cacheState}`)
+      if (entry.fromCache !== undefined) parts.push(`source=${entry.fromCache ? 'cache' : 'network'}`)
+      if (entry.durationMs !== undefined) parts.push(`duration=${entry.durationMs}ms`)
+      return entry.detail ? `${parts.join(' | ')}\n${entry.detail}` : parts.join(' | ')
+    })
+    .join('\n\n')
 }
 
 function stateIcon(state: WorkflowRunState): Component<{ size: number; class?: string }> {
@@ -644,6 +662,7 @@ export const ActionsPanel: Component<Props> = (props) => {
   const state = () => actionsState[props.taskId]
   const git = () => taskGit(props.taskId)
   const task = () => taskById(props.taskId)
+  const [debugCopied, setDebugCopied] = createSignal(false)
 
   const branch = () => task()?.branch ?? ''
   const repo = () => git().github
@@ -696,6 +715,16 @@ export const ActionsPanel: Component<Props> = (props) => {
   })
 
   const polling = () => !!state() && isAnyRunActive(props.taskId)
+  const debugEntries = () => githubDebugEntriesForTask(props.taskId).slice(-20).reverse()
+  const copyDebugLogs = async () => {
+    try {
+      await navigator.clipboard.writeText(formatGitHubDebugEntries(debugEntries()))
+      setDebugCopied(true)
+      window.setTimeout(() => setDebugCopied(false), 1200)
+    } catch (e) {
+      addToast(`Copy failed: ${e}`, 'error')
+    }
+  }
 
   return (
     <div class="flex flex-col h-full">
@@ -767,6 +796,57 @@ export const ActionsPanel: Component<Props> = (props) => {
                 {run => <ActionsRunRow taskId={props.taskId} run={run} />}
               </For>
             </Show>
+          </div>
+        </Show>
+
+        <Show when={import.meta.env.DEV && debugEntries().length > 0}>
+          <div class="mt-2 border-t-1 border-t-solid border-t-outline/8">
+            <div class="px-3 py-2">
+              <div class="flex items-center gap-2">
+                <div class="text-[10px] font-semibold uppercase tracking-wide text-text-dim/80">
+                  GitHub Debug
+                </div>
+                <button
+                  class="ml-auto h-5 rounded px-1.5 flex items-center gap-1 text-[10px] text-text-dim hover:text-text-secondary hover:bg-surface-2 transition-colors"
+                  onClick={copyDebugLogs}
+                  title="Copy all debug logs"
+                >
+                  <Show when={debugCopied()} fallback={<Copy size={11} />}>
+                    <Check size={11} />
+                  </Show>
+                  <span>{debugCopied() ? 'Copied' : 'Copy all'}</span>
+                </button>
+              </div>
+              <div class="mt-2 flex flex-col gap-1.5">
+                <For each={debugEntries()}>
+                  {(entry) => (
+                    <div class="rounded-md bg-surface-2/70 px-2 py-1.5 text-[10px] leading-4 text-text-dim">
+                      <div class="flex items-center gap-1.5 text-text-secondary">
+                        <span class="font-medium">{entry.stage}</span>
+                        <span class="text-text-dim/70">{entry.scope}</span>
+                        <Show when={entry.mode}>
+                          <span class="text-accent/80">{entry.mode}</span>
+                        </Show>
+                        <Show when={entry.cacheState}>
+                          <span class="text-text-dim/70">{entry.cacheState}</span>
+                        </Show>
+                        <Show when={entry.fromCache !== undefined}>
+                          <span class={entry.fromCache ? 'text-emerald-400/90' : 'text-amber-400/90'}>
+                            {entry.fromCache ? 'cache' : 'network'}
+                          </span>
+                        </Show>
+                        <Show when={entry.durationMs !== undefined}>
+                          <span class="tabular-nums text-text-dim/70">{entry.durationMs}ms</span>
+                        </Show>
+                      </div>
+                      <Show when={entry.detail}>
+                        <div class="mt-0.5 break-all text-text-dim/75">{entry.detail}</div>
+                      </Show>
+                    </div>
+                  )}
+                </For>
+              </div>
+            </div>
           </div>
         </Show>
       </div>

--- a/src/components/GitActions.tsx
+++ b/src/components/GitActions.tsx
@@ -98,7 +98,8 @@ export const GitActions: Component<Props> = (props) => {
     setOpen(false)
     setConfirming(null)
     closeMergePanel()
-    refreshTaskGit(props.taskId)
+    refreshTaskGit(props.taskId, { local: true, remote: false })
+    refreshTaskGit(props.taskId, { local: false, remote: true })
   }))
 
   const send = (message: string) => {
@@ -136,7 +137,7 @@ export const GitActions: Component<Props> = (props) => {
       await ipc.gitPush(props.taskId)
       addToast('Pushed to remote', 'success')
       invalidateRemote(props.taskId)
-      await refreshTaskGit(props.taskId, { force: true })
+      await refreshTaskGit(props.taskId, { local: true, remote: true, force: true })
     } catch (e: any) {
       send(`push to remote. The error was: ${e}`)
     }
@@ -161,7 +162,7 @@ export const GitActions: Component<Props> = (props) => {
       addToast('PR merged', 'success')
       closeMergePanel()
       invalidateRemote(props.taskId)
-      await refreshTaskGit(props.taskId, { force: true })
+      await refreshTaskGit(props.taskId, { local: true, remote: true, force: true })
     } catch (e: any) {
       if (!force) {
         setMergeFailure(String(e))
@@ -179,7 +180,7 @@ export const GitActions: Component<Props> = (props) => {
       await ipc.markPrReady(props.taskId)
       addToast('PR marked as ready for review', 'success')
       invalidateRemote(props.taskId)
-      await refreshTaskGit(props.taskId, { force: true })
+      await refreshTaskGit(props.taskId, { local: false, remote: true, force: true })
     } catch (e: any) {
       addToast(`Failed to mark PR ready: ${e}`, 'error')
     }

--- a/src/lib/appInit.ts
+++ b/src/lib/appInit.ts
@@ -5,6 +5,7 @@ import { loadAgents, initAgentListeners } from '../store/agents'
 import { initSessionListeners, initSessionWindowFocusRefresh, syncSessionStatuses } from '../store/sessions'
 import { initTerminalListeners } from '../store/terminals'
 import { initGitListeners, initWindowFocusRefresh } from '../store/git'
+import { initActionsListeners } from '../store/actions'
 import { initOpenFilesRefresh } from '../store/fileSync'
 import { initSetupListeners } from '../store/setup'
 import { loadTasks, taskById } from '../store/tasks'
@@ -40,6 +41,7 @@ export async function initListeners() {
     initSessionListeners(),
     initTerminalListeners(),
     initGitListeners(),
+    initActionsListeners(),
     initProjectListeners(),
     initSetupListeners(),
     initAgentListeners(),

--- a/src/lib/appInit.ts
+++ b/src/lib/appInit.ts
@@ -5,6 +5,7 @@ import { loadAgents, initAgentListeners } from '../store/agents'
 import { initSessionListeners, initSessionWindowFocusRefresh, syncSessionStatuses } from '../store/sessions'
 import { initTerminalListeners } from '../store/terminals'
 import { initGitListeners, initWindowFocusRefresh } from '../store/git'
+import { initGitHubDebugListeners } from '../store/githubDebug'
 import { initActionsListeners } from '../store/actions'
 import { initOpenFilesRefresh } from '../store/fileSync'
 import { initSetupListeners } from '../store/setup'
@@ -41,6 +42,7 @@ export async function initListeners() {
     initSessionListeners(),
     initTerminalListeners(),
     initGitListeners(),
+    initGitHubDebugListeners(),
     initActionsListeners(),
     initProjectListeners(),
     initSetupListeners(),

--- a/src/lib/ipc.test.ts
+++ b/src/lib/ipc.test.ts
@@ -34,6 +34,13 @@ describe('ipc', () => {
     expect(typeof ipc.getRepoInfo).toBe('function')
   })
 
+  test('consolidated GitHub wrappers are exported', () => {
+    expect(typeof ipc.getGithubOverview).toBe('function')
+    expect(typeof ipc.getGithubActions).toBe('function')
+    expect(typeof ipc.getGithubWorkflowJobs).toBe('function')
+    expect(typeof ipc.getGithubWorkflowLog).toBe('function')
+  })
+
   test('utility functions are exported', () => {
     expect(typeof ipc.openInFinder).toBe('function')
   })

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -1,5 +1,5 @@
 import { invoke } from '@tauri-apps/api/core'
-import type { Project, Task, TaskWithSession, Session, OutputLine, RepoInfo, AttachmentRef, AgentSkill, AgentInfo, AgentType, GitStatus, FileDiff, DiffContents, BranchCommit, GitHubRepo, PrInfo, CiCheck, WorkflowRun, WorkflowJob, ToolApprovalRequest, TrustLevel, AuditEntry, PtySpawnResult, PtyListEntry, FileEntry, Step, BlobRef, StorageStats } from '../types'
+import type { Project, Task, TaskWithSession, Session, OutputLine, RepoInfo, AttachmentRef, AgentSkill, AgentInfo, AgentType, GitStatus, FileDiff, DiffContents, BranchCommit, GitHubRepo, PrInfo, CiCheck, WorkflowRun, WorkflowJob, ToolApprovalRequest, TrustLevel, AuditEntry, PtySpawnResult, PtyListEntry, FileEntry, Step, BlobRef, StorageStats, GitHubOverviewSnapshot, GitHubActionsSnapshot, WorkflowJobsSnapshot, WorkflowLogSnapshot, RemoteFetchMode } from '../types'
 
 const DEMO = import.meta.env.VITE_DEMO_MODE === 'true'
 const seed = () => import('./seedData')
@@ -256,6 +256,21 @@ export const hasConflicts = (taskId: string): Promise<boolean> =>
     ? seed().then(d => d.DEMO_GIT_DATA[taskId]?.pr?.mergeable === 'CONFLICTING')
     : invoke<boolean>('has_conflicts', { taskId })
 
+export const getGithubOverview = (taskId: string, mode?: RemoteFetchMode): Promise<GitHubOverviewSnapshot> =>
+  DEMO
+    ? seed().then(d => ({
+      github: d.DEMO_GIT_DATA[taskId]?.github ?? null,
+      branchUrl: d.DEMO_GIT_DATA[taskId]?.branchUrl ?? null,
+      pr: d.DEMO_GIT_DATA[taskId]?.pr ?? null,
+      checks: d.DEMO_GIT_DATA[taskId]?.checks ?? [],
+      fetchedAt: Date.now(),
+      staleAt: Date.now() + 30_000,
+      expiresAt: Date.now() + 300_000,
+      isStale: false,
+      fromCache: false,
+    }))
+    : invoke<GitHubOverviewSnapshot>('get_github_overview', { taskId, mode })
+
 // GitHub Actions
 export const listWorkflowRuns = (taskId: string, limit?: number): Promise<WorkflowRun[]> =>
   DEMO ? Promise.resolve([]) : invoke<WorkflowRun[]>('list_workflow_runs', { taskId, limit })
@@ -274,6 +289,44 @@ export const rerunWorkflowJob = (taskId: string, jobId: number): Promise<void> =
 
 export const cancelWorkflowRun = (taskId: string, runId: number): Promise<void> =>
   invoke<void>('cancel_workflow_run', { taskId, runId })
+
+export const getGithubActions = (taskId: string, limit?: number, mode?: RemoteFetchMode): Promise<GitHubActionsSnapshot> =>
+  DEMO
+    ? Promise.resolve({
+      runs: [],
+      fetchedAt: Date.now(),
+      staleAt: Date.now() + 10_000,
+      expiresAt: Date.now() + 300_000,
+      isStale: false,
+      fromCache: false,
+    })
+    : invoke<GitHubActionsSnapshot>('get_github_actions', { taskId, limit, mode })
+
+export const getGithubWorkflowJobs = (taskId: string, runId: number, mode?: RemoteFetchMode): Promise<WorkflowJobsSnapshot> =>
+  DEMO
+    ? Promise.resolve({
+      runId,
+      jobs: [],
+      fetchedAt: Date.now(),
+      staleAt: Date.now() + 10_000,
+      expiresAt: Date.now() + 300_000,
+      isStale: false,
+      fromCache: false,
+    })
+    : invoke<WorkflowJobsSnapshot>('get_github_workflow_jobs', { taskId, runId, mode })
+
+export const getGithubWorkflowLog = (taskId: string, jobId: number, maxBytes?: number, mode?: RemoteFetchMode): Promise<WorkflowLogSnapshot> =>
+  DEMO
+    ? Promise.resolve({
+      jobId,
+      text: '',
+      fetchedAt: Date.now(),
+      staleAt: Date.now() + 10_000,
+      expiresAt: Date.now() + 300_000,
+      isStale: false,
+      fromCache: false,
+    })
+    : invoke<WorkflowLogSnapshot>('get_github_workflow_log', { taskId, jobId, maxBytes, mode })
 
 // File listing
 export const listWorktreeFiles = (taskId: string) =>

--- a/src/store/actions.test.ts
+++ b/src/store/actions.test.ts
@@ -6,9 +6,9 @@ vi.mock('@tauri-apps/api/event', () => ({
 }))
 
 const ipcMocks = vi.hoisted(() => ({
-  listWorkflowRuns: vi.fn(),
-  listWorkflowJobs: vi.fn(),
-  getWorkflowFailedLogs: vi.fn(),
+  getGithubActions: vi.fn(),
+  getGithubWorkflowJobs: vi.fn(),
+  getGithubWorkflowLog: vi.fn(),
   rerunWorkflowRun: vi.fn(),
   rerunWorkflowJob: vi.fn(),
   cancelWorkflowRun: vi.fn(),
@@ -47,19 +47,26 @@ function run(partial: Partial<WorkflowRun> = {}): WorkflowRun {
 describe('actions store', () => {
   beforeEach(() => {
     clearActionsState('t1')
-    ipcMocks.listWorkflowRuns.mockReset()
-    ipcMocks.listWorkflowJobs.mockReset()
-    ipcMocks.getWorkflowFailedLogs.mockReset()
+    ipcMocks.getGithubActions.mockReset()
+    ipcMocks.getGithubWorkflowJobs.mockReset()
+    ipcMocks.getGithubWorkflowLog.mockReset()
     ipcMocks.rerunWorkflowRun.mockReset()
     ipcMocks.rerunWorkflowJob.mockReset()
     ipcMocks.cancelWorkflowRun.mockReset()
   })
 
   test('refreshWorkflowRuns populates state', async () => {
-    ipcMocks.listWorkflowRuns.mockResolvedValue([
-      run({ databaseId: 100, state: 'running' }),
-      run({ databaseId: 99, state: 'success' }),
-    ])
+    ipcMocks.getGithubActions.mockResolvedValue({
+      runs: [
+        run({ databaseId: 100, state: 'running' }),
+        run({ databaseId: 99, state: 'success' }),
+      ],
+      fetchedAt: 1,
+      staleAt: 2,
+      expiresAt: 3,
+      isStale: false,
+      fromCache: false,
+    })
 
     await refreshWorkflowRuns('t1')
 
@@ -69,7 +76,7 @@ describe('actions store', () => {
   })
 
   test('refreshWorkflowRuns swallows ipc errors', async () => {
-    ipcMocks.listWorkflowRuns.mockRejectedValue(new Error('gh missing'))
+    ipcMocks.getGithubActions.mockRejectedValue(new Error('gh missing'))
 
     await refreshWorkflowRuns('t1')
 
@@ -78,19 +85,33 @@ describe('actions store', () => {
   })
 
   test('isAnyRunActive returns true when a run is queued or running', async () => {
-    ipcMocks.listWorkflowRuns.mockResolvedValue([
-      run({ databaseId: 1, state: 'success' }),
-      run({ databaseId: 2, state: 'running' }),
-    ])
+    ipcMocks.getGithubActions.mockResolvedValue({
+      runs: [
+        run({ databaseId: 1, state: 'success' }),
+        run({ databaseId: 2, state: 'running' }),
+      ],
+      fetchedAt: 1,
+      staleAt: 2,
+      expiresAt: 3,
+      isStale: false,
+      fromCache: false,
+    })
     await refreshWorkflowRuns('t1')
     expect(isAnyRunActive('t1')).toBe(true)
   })
 
   test('isAnyRunActive returns false when all runs settled', async () => {
-    ipcMocks.listWorkflowRuns.mockResolvedValue([
-      run({ databaseId: 1, state: 'success' }),
-      run({ databaseId: 2, state: 'failure' }),
-    ])
+    ipcMocks.getGithubActions.mockResolvedValue({
+      runs: [
+        run({ databaseId: 1, state: 'success' }),
+        run({ databaseId: 2, state: 'failure' }),
+      ],
+      fetchedAt: 1,
+      staleAt: 2,
+      expiresAt: 3,
+      isStale: false,
+      fromCache: false,
+    })
     await refreshWorkflowRuns('t1')
     expect(isAnyRunActive('t1')).toBe(false)
   })
@@ -99,7 +120,15 @@ describe('actions store', () => {
     const jobs: WorkflowJob[] = [
       { databaseId: 10, name: 'test', state: 'failure', startedAt: null, completedAt: null, url: 'u' },
     ]
-    ipcMocks.listWorkflowJobs.mockResolvedValue(jobs)
+    ipcMocks.getGithubWorkflowJobs.mockResolvedValue({
+      runId: 42,
+      jobs,
+      fetchedAt: 1,
+      staleAt: 2,
+      expiresAt: 3,
+      isStale: false,
+      fromCache: false,
+    })
 
     await loadJobsForRun('t1', 42)
 
@@ -107,10 +136,18 @@ describe('actions store', () => {
   })
 
   test('buildFixPrompt composes a structured summary (job, workflow, run, step, gh command)', async () => {
-    ipcMocks.getWorkflowFailedLogs.mockResolvedValue([
+    ipcMocks.getGithubWorkflowLog.mockResolvedValue({
+      jobId: 77,
+      text: [
       'Type Check\tRun build\t2026-04-22T10:00:01Z compiling',
       'Type Check\tRun build\t2026-04-22T10:00:02Z ##[error]boom',
-    ].join('\n'))
+      ].join('\n'),
+      fetchedAt: 1,
+      staleAt: 2,
+      expiresAt: 3,
+      isStale: false,
+      fromCache: false,
+    })
 
     const prompt = await buildFixPrompt('t1', { runNumber: 42, workflowName: 'CI', runId: 999, jobId: 77, jobName: 'test' })
 
@@ -125,11 +162,19 @@ describe('actions store', () => {
   })
 
   test('buildFixPrompt surfaces structured error annotations (file:line:col title msg)', async () => {
-    ipcMocks.getWorkflowFailedLogs.mockResolvedValue([
+    ipcMocks.getGithubWorkflowLog.mockResolvedValue({
+      jobId: 1,
+      text: [
       'Type Check\tRun build\t2026-04-22T10:00:01Z ##[error]file=src/foo.ts,line=17,col=3,title=TS2322::Type mismatch',
       'Type Check\tRun build\t2026-04-22T10:00:02Z ##[error]file=src/bar.ts,line=42::Another error',
       'Type Check\tRun build\t2026-04-22T10:00:03Z ##[error]boom without location',
-    ].join('\n'))
+      ].join('\n'),
+      fetchedAt: 1,
+      staleAt: 2,
+      expiresAt: 3,
+      isStale: false,
+      fromCache: false,
+    })
 
     const prompt = await buildFixPrompt('t1', { runNumber: 1, workflowName: 'CI', runId: 1, jobId: 1, jobName: 'test' })
 
@@ -142,19 +187,27 @@ describe('actions store', () => {
   })
 
   test('buildFixPrompt reuses cached logs without hitting ipc', async () => {
-    ipcMocks.getWorkflowFailedLogs.mockResolvedValue('Type Check\tRun build\t2026-04-22T10:00:01Z ##[error]cached boom')
+    ipcMocks.getGithubWorkflowLog.mockResolvedValue({
+      jobId: 77,
+      text: 'Type Check\tRun build\t2026-04-22T10:00:01Z ##[error]cached boom',
+      fetchedAt: 1,
+      staleAt: 2,
+      expiresAt: 3,
+      isStale: false,
+      fromCache: false,
+    })
     await loadJobLogs('t1', 999, 77)
-    expect(ipcMocks.getWorkflowFailedLogs).toHaveBeenCalledTimes(1)
+    expect(ipcMocks.getGithubWorkflowLog).toHaveBeenCalledTimes(1)
 
-    ipcMocks.getWorkflowFailedLogs.mockClear()
+    ipcMocks.getGithubWorkflowLog.mockClear()
     const prompt = await buildFixPrompt('t1', { runNumber: 42, workflowName: 'CI', runId: 999, jobId: 77, jobName: 'test' })
 
-    expect(ipcMocks.getWorkflowFailedLogs).not.toHaveBeenCalled()
+    expect(ipcMocks.getGithubWorkflowLog).not.toHaveBeenCalled()
     expect(prompt).toContain('cached boom')
   })
 
   test('buildFixPrompt falls back to just the gh command when logs unavailable', async () => {
-    ipcMocks.getWorkflowFailedLogs.mockRejectedValue(new Error('no perms'))
+    ipcMocks.getGithubWorkflowLog.mockRejectedValue(new Error('no perms'))
 
     const prompt = await buildFixPrompt('t1', { runNumber: 1, workflowName: 'CI', runId: 1, jobId: 55, jobName: 'test' })
 
@@ -163,7 +216,14 @@ describe('actions store', () => {
   })
 
   test('clearActionsState removes the task entry', async () => {
-    ipcMocks.listWorkflowRuns.mockResolvedValue([run()])
+    ipcMocks.getGithubActions.mockResolvedValue({
+      runs: [run()],
+      fetchedAt: 1,
+      staleAt: 2,
+      expiresAt: 3,
+      isStale: false,
+      fromCache: false,
+    })
     await refreshWorkflowRuns('t1')
     expect(actionsState['t1']).toBeTruthy()
 
@@ -172,9 +232,14 @@ describe('actions store', () => {
   })
 
   test('markRunRerunning flips run state to queued', async () => {
-    ipcMocks.listWorkflowRuns.mockResolvedValue([
-      run({ databaseId: 42, state: 'failure' }),
-    ])
+    ipcMocks.getGithubActions.mockResolvedValue({
+      runs: [run({ databaseId: 42, state: 'failure' })],
+      fetchedAt: 1,
+      staleAt: 2,
+      expiresAt: 3,
+      isStale: false,
+      fromCache: false,
+    })
     await refreshWorkflowRuns('t1')
     expect(actionsState['t1']?.runs[0].state).toBe('failure')
 
@@ -185,11 +250,26 @@ describe('actions store', () => {
   })
 
   test('markRunRerunning marks cached jobs as queued', async () => {
-    ipcMocks.listWorkflowRuns.mockResolvedValue([run({ databaseId: 42, state: 'failure' })])
-    ipcMocks.listWorkflowJobs.mockResolvedValue([
+    ipcMocks.getGithubActions.mockResolvedValue({
+      runs: [run({ databaseId: 42, state: 'failure' })],
+      fetchedAt: 1,
+      staleAt: 2,
+      expiresAt: 3,
+      isStale: false,
+      fromCache: false,
+    })
+    ipcMocks.getGithubWorkflowJobs.mockResolvedValue({
+      runId: 42,
+      jobs: [
       { databaseId: 1, name: 'test', state: 'failure', startedAt: '2026-04-20T10:00:00Z', completedAt: '2026-04-20T10:01:00Z', url: 'u' },
       { databaseId: 2, name: 'lint', state: 'success', startedAt: '2026-04-20T10:00:00Z', completedAt: '2026-04-20T10:01:00Z', url: 'u' },
-    ])
+      ],
+      fetchedAt: 1,
+      staleAt: 2,
+      expiresAt: 3,
+      isStale: false,
+      fromCache: false,
+    })
     await refreshWorkflowRuns('t1')
     await loadJobsForRun('t1', 42)
 
@@ -202,7 +282,14 @@ describe('actions store', () => {
   })
 
   test('rerunFailedJobsForRun calls ipc and optimistically updates state', async () => {
-    ipcMocks.listWorkflowRuns.mockResolvedValue([run({ databaseId: 42, state: 'failure' })])
+    ipcMocks.getGithubActions.mockResolvedValue({
+      runs: [run({ databaseId: 42, state: 'failure' })],
+      fetchedAt: 1,
+      staleAt: 2,
+      expiresAt: 3,
+      isStale: false,
+      fromCache: false,
+    })
     ipcMocks.rerunWorkflowRun.mockResolvedValue(undefined)
     await refreshWorkflowRuns('t1')
 
@@ -213,41 +300,86 @@ describe('actions store', () => {
   })
 
   test('refreshWorkflowRuns does not clobber the optimistic queued state inside the rerun grace window', async () => {
-    ipcMocks.listWorkflowRuns.mockResolvedValueOnce([run({ databaseId: 42, state: 'failure' })])
+    ipcMocks.getGithubActions.mockResolvedValueOnce({
+      runs: [run({ databaseId: 42, state: 'failure' })],
+      fetchedAt: 1,
+      staleAt: 2,
+      expiresAt: 3,
+      isStale: false,
+      fromCache: false,
+    })
     await refreshWorkflowRuns('t1')
     markRunRerunning('t1', 42)
     expect(actionsState['t1']?.runs[0].state).toBe('queued')
 
     // GH still reports the old attempt as failure for a few seconds after rerun
-    ipcMocks.listWorkflowRuns.mockResolvedValueOnce([run({ databaseId: 42, state: 'failure' })])
+    ipcMocks.getGithubActions.mockResolvedValueOnce({
+      runs: [run({ databaseId: 42, state: 'failure' })],
+      fetchedAt: 1,
+      staleAt: 2,
+      expiresAt: 3,
+      isStale: false,
+      fromCache: false,
+    })
     await refreshWorkflowRuns('t1')
 
     expect(actionsState['t1']?.runs[0].state).toBe('queued')
   })
 
   test('refreshWorkflowRuns does not clobber optimistic queued jobs inside the rerun grace window', async () => {
-    ipcMocks.listWorkflowRuns.mockResolvedValueOnce([run({ databaseId: 42, state: 'failure' })])
-    ipcMocks.listWorkflowJobs.mockResolvedValueOnce([
+    ipcMocks.getGithubActions.mockResolvedValueOnce({
+      runs: [run({ databaseId: 42, state: 'failure' })],
+      fetchedAt: 1,
+      staleAt: 2,
+      expiresAt: 3,
+      isStale: false,
+      fromCache: false,
+    })
+    ipcMocks.getGithubWorkflowJobs.mockResolvedValueOnce({
+      runId: 42,
+      jobs: [
       { databaseId: 1, name: 'test', state: 'failure', startedAt: '2026-04-20T10:00:00Z', completedAt: '2026-04-20T10:01:00Z', url: 'u' },
-    ])
+      ],
+      fetchedAt: 1,
+      staleAt: 2,
+      expiresAt: 3,
+      isStale: false,
+      fromCache: false,
+    })
     await refreshWorkflowRuns('t1')
     await loadJobsForRun('t1', 42)
     markRunRerunning('t1', 42)
 
     // Next poll: GH returns stale jobs list
-    ipcMocks.listWorkflowJobs.mockResolvedValueOnce([
+    ipcMocks.getGithubWorkflowJobs.mockResolvedValueOnce({
+      runId: 42,
+      jobs: [
       { databaseId: 1, name: 'test', state: 'failure', startedAt: '2026-04-20T10:00:00Z', completedAt: '2026-04-20T10:01:00Z', url: 'u' },
-    ])
+      ],
+      fetchedAt: 1,
+      staleAt: 2,
+      expiresAt: 3,
+      isStale: false,
+      fromCache: false,
+    })
     await loadJobsForRun('t1', 42)
 
     expect(actionsState['t1']?.jobsByRun[42]?.[0].state).toBe('queued')
   })
 
   test('loadJobLogs caches logs keyed by jobId', async () => {
-    ipcMocks.getWorkflowFailedLogs.mockResolvedValue('some log tail')
+    ipcMocks.getGithubWorkflowLog.mockResolvedValue({
+      jobId: 55,
+      text: 'some log tail',
+      fetchedAt: 1,
+      staleAt: 2,
+      expiresAt: 3,
+      isStale: false,
+      fromCache: false,
+    })
     await loadJobLogs('t1', 999, 55)
 
-    expect(ipcMocks.getWorkflowFailedLogs).toHaveBeenCalledWith('t1', 999, 55)
+    expect(ipcMocks.getGithubWorkflowLog).toHaveBeenCalledWith('t1', 55)
     expect(actionsState['t1']?.logsByJob[55]?.text).toBe('some log tail')
     expect(actionsState['t1']?.logsByJob[55]?.loading).toBe(false)
     expect(actionsState['t1']?.logsByJob[55]?.error).toBeNull()
@@ -255,7 +387,15 @@ describe('actions store', () => {
 
   test('loadJobLogs dedupes concurrent calls', async () => {
     let resolveFn: (v: string) => void = () => {}
-    ipcMocks.getWorkflowFailedLogs.mockReturnValue(new Promise<string>(r => { resolveFn = r }))
+    ipcMocks.getGithubWorkflowLog.mockReturnValue(new Promise(r => { resolveFn = (v: string) => r({
+      jobId: 10,
+      text: v,
+      fetchedAt: 1,
+      staleAt: 2,
+      expiresAt: 3,
+      isStale: false,
+      fromCache: false,
+    }) }))
 
     const p1 = loadJobLogs('t1', 1, 10)
     const p2 = loadJobLogs('t1', 1, 10)
@@ -264,12 +404,12 @@ describe('actions store', () => {
     resolveFn('logs here')
     await Promise.all([p1, p2])
 
-    expect(ipcMocks.getWorkflowFailedLogs).toHaveBeenCalledTimes(1)
+    expect(ipcMocks.getGithubWorkflowLog).toHaveBeenCalledTimes(1)
     expect(actionsState['t1']?.logsByJob[10]?.text).toBe('logs here')
   })
 
   test('loadJobLogs stores error on ipc failure', async () => {
-    ipcMocks.getWorkflowFailedLogs.mockRejectedValue(new Error('no perms'))
+    ipcMocks.getGithubWorkflowLog.mockRejectedValue(new Error('no perms'))
     await loadJobLogs('t1', 1, 10)
 
     expect(actionsState['t1']?.logsByJob[10]?.error).toContain('no perms')
@@ -277,11 +417,26 @@ describe('actions store', () => {
   })
 
   test('rerunSingleJob calls the job-level IPC and only flips the target job to queued', async () => {
-    ipcMocks.listWorkflowRuns.mockResolvedValue([run({ databaseId: 42, state: 'failure' })])
-    ipcMocks.listWorkflowJobs.mockResolvedValue([
+    ipcMocks.getGithubActions.mockResolvedValue({
+      runs: [run({ databaseId: 42, state: 'failure' })],
+      fetchedAt: 1,
+      staleAt: 2,
+      expiresAt: 3,
+      isStale: false,
+      fromCache: false,
+    })
+    ipcMocks.getGithubWorkflowJobs.mockResolvedValue({
+      runId: 42,
+      jobs: [
       { databaseId: 10, name: 'test', state: 'failure', startedAt: '2026-04-20T10:00:00Z', completedAt: '2026-04-20T10:01:00Z', url: 'u' },
       { databaseId: 11, name: 'lint', state: 'success', startedAt: '2026-04-20T10:00:00Z', completedAt: '2026-04-20T10:01:00Z', url: 'u' },
-    ])
+      ],
+      fetchedAt: 1,
+      staleAt: 2,
+      expiresAt: 3,
+      isStale: false,
+      fromCache: false,
+    })
     ipcMocks.rerunWorkflowJob.mockResolvedValue(undefined)
 
     await refreshWorkflowRuns('t1')

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -59,7 +59,8 @@ export async function refreshWorkflowRuns(taskId: string, limit = 25): Promise<v
 
   const promise = (async () => {
     try {
-      const runs = await ipc.listWorkflowRuns(taskId, limit)
+      const snapshot = await ipc.getGithubActions(taskId, limit, 'cache-first')
+      const runs = snapshot.runs
       const staleJobRuns: number[] = []
       setActionsState(produce(s => {
         const state = s[taskId]
@@ -85,7 +86,7 @@ export async function refreshWorkflowRuns(taskId: string, limit = 25): Promise<v
             state.runs.push(incoming)
           }
         }
-        state.lastRefresh = Date.now()
+        state.lastRefresh = snapshot.fetchedAt
         state.error = null
         state.loading = false
       }))
@@ -108,7 +109,8 @@ export async function refreshWorkflowRuns(taskId: string, limit = 25): Promise<v
 export async function loadJobsForRun(taskId: string, runId: number): Promise<void> {
   ensure(taskId)
   try {
-    const jobs = await ipc.listWorkflowJobs(taskId, runId)
+    const snapshot = await ipc.getGithubWorkflowJobs(taskId, runId, 'cache-first')
+    const jobs = snapshot.jobs
     setActionsState(produce(s => {
       const state = s[taskId]
       if (!state) return
@@ -132,7 +134,7 @@ export async function loadJobsForRun(taskId: string, runId: number): Promise<voi
 
 const inflightLogs = new Map<string, Promise<void>>()
 
-export async function loadJobLogs(taskId: string, runId: number, jobId: number): Promise<void> {
+export async function loadJobLogs(taskId: string, _runId: number, jobId: number): Promise<void> {
   ensure(taskId)
   const key = `${taskId}:${jobId}`
   const existing = inflightLogs.get(key)
@@ -152,11 +154,12 @@ export async function loadJobLogs(taskId: string, runId: number, jobId: number):
 
   const promise = (async () => {
     try {
-      const text = await ipc.getWorkflowFailedLogs(taskId, runId, jobId)
+      const snapshot = await ipc.getGithubWorkflowLog(taskId, jobId)
+      const text = snapshot.text
       setActionsState(produce(s => {
         const state = s[taskId]
         if (!state) return
-        state.logsByJob[jobId] = { text, loading: false, error: null, fetchedAt: Date.now() }
+        state.logsByJob[jobId] = { text, loading: false, error: null, fetchedAt: snapshot.fetchedAt }
       }))
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e)
@@ -281,7 +284,7 @@ export async function buildFixPrompt(taskId: string, ctx: FixContext): Promise<s
   let raw: string | null = cached ?? null
   if (raw == null) {
     try {
-      raw = await ipc.getWorkflowFailedLogs(taskId, ctx.runId, ctx.jobId)
+      raw = (await ipc.getGithubWorkflowLog(taskId, ctx.jobId)).text
     } catch {
       raw = null
     }
@@ -354,9 +357,9 @@ let listenersInitialized = false
 export async function initActionsListeners(): Promise<void> {
   if (listenersInitialized) return
   listenersInitialized = true
-  await listen<{ taskId: string }>('git-status-changed', (event) => {
-    const { taskId } = event.payload
-    if (actionsState[taskId]) {
+  await listen<{ taskId: string, scopes: string[] }>('github-remote-invalidated', (event) => {
+    const { taskId, scopes } = event.payload
+    if (actionsState[taskId] && scopes.includes('actions')) {
       refreshWorkflowRuns(taskId)
     }
   })

--- a/src/store/git.test.ts
+++ b/src/store/git.test.ts
@@ -1,9 +1,30 @@
 import { describe, test, expect, beforeEach, vi, afterEach } from 'vitest'
 
-vi.mock('@tauri-apps/api/event', () => ({
-  listen: vi.fn().mockResolvedValue(() => {}),
-  emit: vi.fn(),
-}))
+const eventMocks = vi.hoisted(() => {
+  const listeners = new Map<string, (event: { payload: any }) => void>()
+  return {
+    listeners,
+    listen: vi.fn(async (name: string, cb: (event: { payload: any }) => void) => {
+      listeners.set(name, cb)
+      return () => listeners.delete(name)
+    }),
+    emit: vi.fn(),
+  }
+})
+
+vi.mock('@tauri-apps/api/event', () => eventMocks)
+
+const uiMocks = vi.hoisted(() => {
+  let selectedTask: string | null = null
+  return {
+    selectedTaskId: () => selectedTask,
+    __setSelectedTaskId: (taskId: string | null) => {
+      selectedTask = taskId
+    },
+  }
+})
+
+vi.mock('./ui', () => uiMocks)
 
 vi.mock('../lib/ipc', () => ({
   getGitStatus: vi.fn().mockResolvedValue({ files: [], summary: '' }),
@@ -23,12 +44,13 @@ vi.mock('../lib/ipc', () => ({
   }),
 }))
 
-import { clearTaskGitState, refreshTaskGit, taskGit } from './git'
+import { clearTaskGitState, initGitListeners, refreshTaskGit, taskGit } from './git'
 import * as ipc from '../lib/ipc'
 
 describe('refreshTaskGit', () => {
   beforeEach(() => {
     vi.useFakeTimers()
+    uiMocks.__setSelectedTaskId(null)
     clearTaskGitState('t-debounce')
     clearTaskGitState('t-force')
     clearTaskGitState('t-local-default')
@@ -131,5 +153,67 @@ describe('refreshTaskGit', () => {
       name: 'repo',
       url: 'https://github.com/local/repo',
     })
+  })
+
+  test('git-local-changed with remoteLikelyChanged refreshes remote overview for tracked tasks', async () => {
+    await refreshTaskGit('t-remote', { local: false, remote: true, force: true })
+    expect(ipc.getGithubOverview).toHaveBeenCalledTimes(1)
+
+    await initGitListeners()
+    eventMocks.listeners.get('git-local-changed')?.({ payload: { taskId: 't-remote', remoteLikelyChanged: true } })
+
+    await vi.runAllTimersAsync()
+
+    expect(ipc.getGitStatus).toHaveBeenCalledTimes(1)
+    expect(ipc.getGithubOverview).toHaveBeenCalledTimes(2)
+  })
+
+  test('git-local-changed without remoteLikelyChanged stays local-only', async () => {
+    await refreshTaskGit('t-remote', { local: false, remote: true, force: true })
+    expect(ipc.getGithubOverview).toHaveBeenCalledTimes(1)
+
+    await initGitListeners()
+    eventMocks.listeners.get('git-local-changed')?.({ payload: { taskId: 't-remote' } })
+
+    await vi.runAllTimersAsync()
+
+    expect(ipc.getGitStatus).toHaveBeenCalledTimes(1)
+    expect(ipc.getGithubOverview).toHaveBeenCalledTimes(1)
+  })
+
+  test('git-local-changed with remoteLikelyChanged refreshes remote overview for the selected task even before remote tracking', async () => {
+    uiMocks.__setSelectedTaskId('t-selected')
+
+    await initGitListeners()
+    eventMocks.listeners.get('git-local-changed')?.({ payload: { taskId: 't-selected', remoteLikelyChanged: true } })
+
+    await vi.runAllTimersAsync()
+
+    expect(ipc.getGitStatus).toHaveBeenCalledTimes(1)
+    expect(ipc.getGithubOverview).toHaveBeenCalledTimes(1)
+    expect(ipc.getGithubOverview).toHaveBeenCalledWith('t-selected', 'network-only')
+  })
+
+  test('file-tree-changed refreshes local git state without remote overview', async () => {
+    await initGitListeners()
+    eventMocks.listeners.get('file-tree-changed')?.({ payload: { taskId: 't-file-edit', path: 'src' } })
+
+    await vi.runAllTimersAsync()
+
+    expect(ipc.getGitStatus).toHaveBeenCalledTimes(1)
+    expect(ipc.getGitStatus).toHaveBeenCalledWith('t-file-edit')
+    expect(ipc.getGithubOverview).not.toHaveBeenCalled()
+  })
+
+  test('file-tree-changed bursts debounce into one local git refresh', async () => {
+    await initGitListeners()
+    eventMocks.listeners.get('file-tree-changed')?.({ payload: { taskId: 't-file-edit', path: 'src' } })
+    eventMocks.listeners.get('file-tree-changed')?.({ payload: { taskId: 't-file-edit', path: 'src/components' } })
+    eventMocks.listeners.get('file-tree-changed')?.({ payload: { taskId: 't-file-edit', path: 'src/store' } })
+
+    await vi.runAllTimersAsync()
+
+    expect(ipc.getGitStatus).toHaveBeenCalledTimes(1)
+    expect(ipc.getGithubOverview).not.toHaveBeenCalled()
   })
 })

--- a/src/store/git.test.ts
+++ b/src/store/git.test.ts
@@ -9,10 +9,18 @@ vi.mock('../lib/ipc', () => ({
   getGitStatus: vi.fn().mockResolvedValue({ files: [], summary: '' }),
   getBranchCommits: vi.fn().mockResolvedValue([]),
   getBranchStatus: vi.fn().mockResolvedValue([0, 0, 0]),
-  getPullRequest: vi.fn().mockResolvedValue(null),
-  getBranchUrl: vi.fn().mockResolvedValue(null),
   checkGithub: vi.fn().mockResolvedValue(null),
-  getCiChecks: vi.fn().mockResolvedValue([]),
+  getGithubOverview: vi.fn().mockResolvedValue({
+    github: null,
+    branchUrl: null,
+    pr: null,
+    checks: [],
+    fetchedAt: 1,
+    staleAt: 2,
+    expiresAt: 3,
+    isStale: false,
+    fromCache: false,
+  }),
 }))
 
 import { refreshTaskGit } from './git'
@@ -24,6 +32,8 @@ describe('refreshTaskGit', () => {
     vi.mocked(ipc.getGitStatus).mockClear()
     vi.mocked(ipc.getBranchCommits).mockClear()
     vi.mocked(ipc.getBranchStatus).mockClear()
+    vi.mocked(ipc.checkGithub).mockClear()
+    vi.mocked(ipc.getGithubOverview).mockClear()
   })
 
   afterEach(() => {
@@ -51,6 +61,25 @@ describe('refreshTaskGit', () => {
     await p
 
     expect(ipc.getGitStatus).toHaveBeenCalledTimes(1)
+  })
+
+  test('default refresh is local-only and does not fetch remote overview', async () => {
+    refreshTaskGit('t-local-default')
+
+    await vi.runAllTimersAsync()
+
+    expect(ipc.getGitStatus).toHaveBeenCalledTimes(1)
+    expect(ipc.checkGithub).toHaveBeenCalledTimes(1)
+    expect(ipc.getGithubOverview).not.toHaveBeenCalled()
+  })
+
+  test('explicit remote refresh fetches consolidated overview once', async () => {
+    const p = refreshTaskGit('t-remote', { local: false, remote: true, force: true })
+    await p
+
+    expect(ipc.getGitStatus).not.toHaveBeenCalled()
+    expect(ipc.getGithubOverview).toHaveBeenCalledTimes(1)
+    expect(ipc.getGithubOverview).toHaveBeenCalledWith('t-remote', 'network-only')
   })
 
   test('independent tasks each get their own debounce', async () => {

--- a/src/store/git.test.ts
+++ b/src/store/git.test.ts
@@ -23,12 +23,19 @@ vi.mock('../lib/ipc', () => ({
   }),
 }))
 
-import { refreshTaskGit } from './git'
+import { clearTaskGitState, refreshTaskGit, taskGit } from './git'
 import * as ipc from '../lib/ipc'
 
 describe('refreshTaskGit', () => {
   beforeEach(() => {
     vi.useFakeTimers()
+    clearTaskGitState('t-debounce')
+    clearTaskGitState('t-force')
+    clearTaskGitState('t-local-default')
+    clearTaskGitState('t-remote')
+    clearTaskGitState('t-a')
+    clearTaskGitState('t-b')
+    clearTaskGitState('t-github-source')
     vi.mocked(ipc.getGitStatus).mockClear()
     vi.mocked(ipc.getBranchCommits).mockClear()
     vi.mocked(ipc.getBranchStatus).mockClear()
@@ -92,5 +99,37 @@ describe('refreshTaskGit', () => {
     expect(ipc.getGitStatus).toHaveBeenCalledTimes(2)
     expect(ipc.getGitStatus).toHaveBeenCalledWith('t-a')
     expect(ipc.getGitStatus).toHaveBeenCalledWith('t-b')
+  })
+
+  test('remote refresh does not overwrite github repo set by local detection', async () => {
+    vi.mocked(ipc.checkGithub).mockResolvedValueOnce({
+      owner: 'local',
+      name: 'repo',
+      url: 'https://github.com/local/repo',
+    })
+    vi.mocked(ipc.getGithubOverview).mockResolvedValueOnce({
+      github: {
+        owner: 'remote',
+        name: 'repo',
+        url: 'https://github.com/remote/repo',
+      },
+      branchUrl: null,
+      pr: null,
+      checks: [],
+      fetchedAt: 1,
+      staleAt: 2,
+      expiresAt: 3,
+      isStale: false,
+      fromCache: false,
+    })
+
+    await refreshTaskGit('t-github-source', { local: true, remote: false, force: true })
+    await refreshTaskGit('t-github-source', { local: false, remote: true, force: true })
+
+    expect(taskGit('t-github-source').github).toEqual({
+      owner: 'local',
+      name: 'repo',
+      url: 'https://github.com/local/repo',
+    })
   })
 })

--- a/src/store/git.ts
+++ b/src/store/git.ts
@@ -2,6 +2,7 @@ import { createStore, produce } from 'solid-js/store'
 import { listen } from '@tauri-apps/api/event'
 import * as ipc from '../lib/ipc'
 import type { GitStatus, BranchCommit, PrInfo, CiCheck, GitHubRepo } from '../types'
+import { selectedTaskId } from './ui'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -204,9 +205,20 @@ export async function initGitListeners(): Promise<void> {
   if (listenersInitialized) return
   listenersInitialized = true
 
-  await listen<{ taskId: string }>('git-local-changed', (event) => {
-    const { taskId } = event.payload
+  await listen<{ taskId: string, remoteLikelyChanged?: boolean }>('git-local-changed', (event) => {
+    const { taskId, remoteLikelyChanged } = event.payload
+    const shouldRefreshRemote = remoteLikelyChanged
+      && (remoteTrackedTasks.has(taskId) || selectedTaskId() === taskId)
+    if (shouldRefreshRemote) {
+      invalidateRemote(taskId)
+      refreshTaskGit(taskId, { local: true, remote: true, force: true })
+      return
+    }
     refreshTaskGit(taskId, { local: true, remote: false, force: true })
+  })
+
+  await listen<{ taskId: string, path: string }>('file-tree-changed', (event) => {
+    refreshTaskGit(event.payload.taskId, { local: true, remote: false })
   })
 
   await listen<{ taskId: string, scopes: string[] }>('github-remote-invalidated', (event) => {

--- a/src/store/git.ts
+++ b/src/store/git.ts
@@ -107,7 +107,8 @@ async function refreshRemote(taskId: string): Promise<void> {
     state.pr = snapshot.pr
     state.checks = snapshot.checks
     state.branchUrl = snapshot.branchUrl
-    state.github = snapshot.github
+    // Repo detection is local git state; preserve that as the source of truth.
+    if (!state.github) state.github = snapshot.github
     state.lastRemoteRefresh = snapshot.fetchedAt
   }))
 }

--- a/src/store/git.ts
+++ b/src/store/git.ts
@@ -26,7 +26,7 @@ export interface TaskGitState {
 
 export interface RefreshOpts {
   local?: boolean   // default true
-  remote?: boolean  // default true
+  remote?: boolean  // default false
   force?: boolean   // bypass remote TTL
 }
 
@@ -65,6 +65,7 @@ const inflightLocal = new Map<string, Promise<void>>()
 const inflightRemote = new Map<string, Promise<void>>()
 const localDebounceTimers = new Map<string, ReturnType<typeof setTimeout>>()
 const localDebounceResolvers = new Map<string, Array<() => void>>()
+const remoteTrackedTasks = new Set<string>()
 
 const LOCAL_DEBOUNCE_MS = 150
 
@@ -75,10 +76,11 @@ function ensureKey(taskId: string) {
 }
 
 async function refreshLocal(taskId: string): Promise<void> {
-  const [status, commits, branchStatus] = await Promise.all([
+  const [status, commits, branchStatus, github] = await Promise.all([
     ipc.getGitStatus(taskId).catch(() => null),
     ipc.getBranchCommits(taskId).catch(() => [] as BranchCommit[]),
     ipc.getBranchStatus(taskId).catch(() => [0, 0, 0] as [number, number, number]),
+    ipc.checkGithub(taskId).catch(() => null),
   ])
 
   setGitStates(produce(s => {
@@ -91,29 +93,22 @@ async function refreshLocal(taskId: string): Promise<void> {
       behind: branchStatus[1],
       unpushed: branchStatus[2],
     }
+    state.github = github
     state.lastLocalRefresh = Date.now()
   }))
 }
 
 async function refreshRemote(taskId: string): Promise<void> {
-  const [prInfo, branchUrl, github] = await Promise.all([
-    ipc.getPullRequest(taskId).catch(() => null),
-    ipc.getBranchUrl(taskId).catch(() => null),
-    ipc.checkGithub(taskId).catch(() => null),
-  ])
-
-  const ciChecks = prInfo
-    ? await ipc.getCiChecks(taskId).catch(() => [] as CiCheck[])
-    : []
+  const snapshot = await ipc.getGithubOverview(taskId, 'network-only')
 
   setGitStates(produce(s => {
     const state = s[taskId]
     if (!state) return
-    state.pr = prInfo
-    state.checks = ciChecks
-    state.branchUrl = branchUrl
-    state.github = github
-    state.lastRemoteRefresh = Date.now()
+    state.pr = snapshot.pr
+    state.checks = snapshot.checks
+    state.branchUrl = snapshot.branchUrl
+    state.github = snapshot.github
+    state.lastRemoteRefresh = snapshot.fetchedAt
   }))
 }
 
@@ -121,7 +116,7 @@ export async function refreshTaskGit(
   taskId: string,
   opts: RefreshOpts = {},
 ): Promise<void> {
-  const { local = true, remote = true, force = false } = opts
+  const { local = true, remote = false, force = false } = opts
 
   ensureKey(taskId)
 
@@ -164,6 +159,7 @@ export async function refreshTaskGit(
   }
 
   if (remote) {
+    remoteTrackedTasks.add(taskId)
     const state = gitStates[taskId]
     const stale = !state || force || Date.now() - state.lastRemoteRefresh > REMOTE_TTL
 
@@ -184,6 +180,7 @@ export async function refreshTaskGit(
 
 /** Reset remote TTL so next refreshTaskGit with remote=true will fetch fresh. */
 export function invalidateRemote(taskId: string): void {
+  remoteTrackedTasks.add(taskId)
   setGitStates(produce(s => {
     const state = s[taskId]
     if (state) state.lastRemoteRefresh = 0
@@ -192,6 +189,7 @@ export function invalidateRemote(taskId: string): void {
 
 /** Remove a task's state entirely (on task deletion). */
 export function clearTaskGitState(taskId: string): void {
+  remoteTrackedTasks.delete(taskId)
   setGitStates(produce(s => { delete s[taskId] }))
 }
 
@@ -205,17 +203,24 @@ export async function initGitListeners(): Promise<void> {
   if (listenersInitialized) return
   listenersInitialized = true
 
-  await listen<{ taskId: string }>('git-status-changed', (event) => {
+  await listen<{ taskId: string }>('git-local-changed', (event) => {
     const { taskId } = event.payload
-    invalidateRemote(taskId)
-    refreshTaskGit(taskId, { local: true, remote: true, force: true })
+    refreshTaskGit(taskId, { local: true, remote: false, force: true })
+  })
+
+  await listen<{ taskId: string, scopes: string[] }>('github-remote-invalidated', (event) => {
+    const { taskId, scopes } = event.payload
+    if (scopes.includes('overview')) {
+      invalidateRemote(taskId)
+      refreshTaskGit(taskId, { local: false, remote: true, force: true })
+    }
   })
 }
 
 export function initWindowFocusRefresh(): void {
   document.addEventListener('visibilitychange', () => {
     if (document.visibilityState === 'visible') {
-      for (const taskId of Object.keys(gitStates)) {
+      for (const taskId of remoteTrackedTasks) {
         refreshTaskGit(taskId, { local: false, remote: true, force: true })
       }
     }

--- a/src/store/githubDebug.ts
+++ b/src/store/githubDebug.ts
@@ -1,0 +1,64 @@
+import { listen } from '@tauri-apps/api/event'
+import { createStore, produce } from 'solid-js/store'
+import type { GitHubDebugEvent } from '../types'
+
+const MAX_DEBUG_ENTRIES = 200
+
+export const [githubDebugState, setGitHubDebugState] = createStore<Record<string, GitHubDebugEvent[]>>({})
+
+function appendEntry(taskId: string, entry: GitHubDebugEvent) {
+  setGitHubDebugState(produce((state) => {
+    if (!state[taskId]) state[taskId] = []
+    state[taskId].push(entry)
+    if (state[taskId].length > MAX_DEBUG_ENTRIES) {
+      state[taskId].splice(0, state[taskId].length - MAX_DEBUG_ENTRIES)
+    }
+  }))
+}
+
+export function pushGitHubDebugEntry(entry: GitHubDebugEvent): void {
+  appendEntry(entry.taskId, entry)
+}
+
+export function githubDebugEntriesForTask(taskId: string): GitHubDebugEvent[] {
+  return githubDebugState[taskId] ?? []
+}
+
+export function clearGitHubDebug(taskId: string): void {
+  setGitHubDebugState(produce((state) => {
+    delete state[taskId]
+  }))
+}
+
+let listenersInitialized = false
+
+export async function initGitHubDebugListeners(): Promise<void> {
+  if (!import.meta.env.DEV || listenersInitialized) return
+  listenersInitialized = true
+
+  await listen<GitHubDebugEvent>('github-remote-debug', (event) => {
+    pushGitHubDebugEntry(event.payload)
+  })
+
+  await listen<{ taskId: string, remoteLikelyChanged?: boolean }>('git-local-changed', (event) => {
+    pushGitHubDebugEntry({
+      taskId: event.payload.taskId,
+      scope: 'overview',
+      stage: 'git-local-changed',
+      mode: 'event',
+      detail: event.payload.remoteLikelyChanged ? 'remoteLikelyChanged=true' : 'remoteLikelyChanged=false',
+      emittedAt: Date.now(),
+    })
+  })
+
+  await listen<{ taskId: string, scopes: string[] }>('github-remote-invalidated', (event) => {
+    pushGitHubDebugEntry({
+      taskId: event.payload.taskId,
+      scope: event.payload.scopes.join(','),
+      stage: 'github-remote-invalidated',
+      mode: 'event',
+      detail: event.payload.scopes.join(','),
+      emittedAt: Date.now(),
+    })
+  })
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -393,6 +393,18 @@ export interface WorkflowLogSnapshot {
 
 export type RemoteFetchMode = 'cache-first' | 'stale-while-revalidate' | 'network-only'
 
+export interface GitHubDebugEvent {
+  taskId: string
+  scope: string
+  stage: string
+  mode?: RemoteFetchMode | 'event'
+  cacheState?: 'miss' | 'fresh' | 'stale'
+  fromCache?: boolean
+  durationMs?: number
+  detail?: string
+  emittedAt: number
+}
+
 // Terminal / PTY types
 
 export interface TerminalInstance {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -327,6 +327,18 @@ export interface CiCheck {
   url: string
 }
 
+export interface GitHubOverviewSnapshot {
+  github: GitHubRepo | null
+  branchUrl: string | null
+  pr: PrInfo | null
+  checks: CiCheck[]
+  fetchedAt: number
+  staleAt: number
+  expiresAt: number
+  isStale: boolean
+  fromCache: boolean
+}
+
 export type WorkflowRunState = 'queued' | 'running' | 'success' | 'failure' | 'cancelled' | 'skipped'
 
 export interface WorkflowRun {
@@ -349,6 +361,37 @@ export interface WorkflowJob {
   completedAt: string | null
   url: string
 }
+
+export interface GitHubActionsSnapshot {
+  runs: WorkflowRun[]
+  fetchedAt: number
+  staleAt: number
+  expiresAt: number
+  isStale: boolean
+  fromCache: boolean
+}
+
+export interface WorkflowJobsSnapshot {
+  runId: number
+  jobs: WorkflowJob[]
+  fetchedAt: number
+  staleAt: number
+  expiresAt: number
+  isStale: boolean
+  fromCache: boolean
+}
+
+export interface WorkflowLogSnapshot {
+  jobId: number
+  text: string
+  fetchedAt: number
+  staleAt: number
+  expiresAt: number
+  isStale: boolean
+  fromCache: boolean
+}
+
+export type RemoteFetchMode = 'cache-first' | 'stale-while-revalidate' | 'network-only'
 
 // Terminal / PTY types
 


### PR DESCRIPTION
## Summary
- add a Rust-side GitHub remote snapshot/cache layer with stale-while-revalidate refreshes, singleflight fetch dedupe, and scoped invalidation events
- move GitHub subprocess reads off the Tokio runtime and consolidate the frontend GitHub refresh flow around the new cached IPC surface
- include the related agent, task, blob, and runtime updates already present in this branch, plus test and docs updates

## Testing
- make check
