### PR TITLE
feat: add Cmd+Alt+Left/Right shortcut to cycle sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Cmd+Alt+Left/Right now cycles between sessions in the current task when viewing a session (wraps at edges). The shortcut still cycles editor tabs when a file is open, mirroring Ctrl+Tab's view-aware behavior
 - File edits detected by the worktree watcher now trigger a debounced local git refresh, so status/commits/branch state update automatically as you change code without hitting GitHub
 - Local git refresh now uses non-locking read-only git commands, so viewing status no longer rewrites `.git/index` and self-triggers endless `git-local-changed` watcher loops
 - Successful in-chat `gh pr create/reopen/close/ready/merge` commands now invalidate GitHub overview immediately, so PR state updates without waiting for process exit or background refresh

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -7,7 +7,7 @@ import { ArchivedPage } from './ArchivedPage'
 import { NewTaskDialog } from './NewTaskDialog'
 import { AddProjectDialog } from './AddProjectDialog'
 import { BtsBuilderDialog } from './BtsBuilderDialog'
-import { sidebarWidth, setSidebarWidth, showSettings, setShowSettings, showArchived, setShowArchived, toggleTerminal, showTerminal, setShowTerminal, newTaskProjectId, setNewTaskProjectId, requestNewTaskForProject, focusOrSelectTask, pickAndAddProject, addProjectPath, setAddProjectPath, showBtsBuilder, setShowBtsBuilder, setSelectedProjectId, siblingTaskInList } from '../store/ui'
+import { sidebarWidth, setSidebarWidth, showSettings, setShowSettings, showArchived, setShowArchived, toggleTerminal, showTerminal, setShowTerminal, newTaskProjectId, setNewTaskProjectId, requestNewTaskForProject, focusOrSelectTask, pickAndAddProject, addProjectPath, setAddProjectPath, showBtsBuilder, setShowBtsBuilder, setSelectedProjectId, siblingTaskInList, nextSessionIdInTask } from '../store/ui'
 import * as ipc from '../lib/ipc'
 import { spawnTerminal, focusActiveTerminal, terminalsForTask, activeTerminalId, setActiveTerminalForTask, isStartCommandRunning, spawnStartCommand, stopStartCommand, hydrateTerminalsForTask } from '../store/terminals'
 import { activeTasksForProject, taskById } from '../store/tasks'
@@ -205,14 +205,21 @@ export const Layout: Component = () => {
           })
         }
       }
-      // Cmd+Alt+Right / Cmd+Alt+Left — switch editor tabs
-      if (modPressed(e) && e.altKey && e.key === 'ArrowRight') {
+      // Cmd+Alt+Right / Cmd+Alt+Left — cycle sessions in session view,
+      // cycle editor tabs in file view (mirrors Ctrl+Tab below).
+      if (modPressed(e) && e.altKey && (e.key === 'ArrowRight' || e.key === 'ArrowLeft')) {
         const tid = selectedTaskId()
-        if (tid) { e.preventDefault(); nextTab(tid) }
-      }
-      if (modPressed(e) && e.altKey && e.key === 'ArrowLeft') {
-        const tid = selectedTaskId()
-        if (tid) { e.preventDefault(); prevTab(tid) }
+        if (tid) {
+          e.preventDefault()
+          const dir = e.key === 'ArrowRight' ? 'next' : 'prev'
+          if (mainView(tid) !== 'session') {
+            if (dir === 'next') nextTab(tid); else prevTab(tid)
+          } else {
+            const list = sessionsForTask(tid)
+            const next = nextSessionIdInTask(tid, dir, list)
+            if (next) setSelectedSessionIdForTask(tid, next)
+          }
+        }
       }
       // Cmd+Alt+Down / Cmd+Alt+Up — move to next/previous task in the sidebar
       if (modPressed(e) && e.altKey && (e.key === 'ArrowDown' || e.key === 'ArrowUp')) {

--- a/src/store/ui.test.ts
+++ b/src/store/ui.test.ts
@@ -24,6 +24,7 @@ import {
   pickAndAddProject,
   setSelectedSessionIdForTask,
   siblingTaskInList,
+  nextSessionIdInTask,
 } from './ui'
 import { selectedSessionForTask, clearTaskContext } from './taskContext'
 import * as ipc from '../lib/ipc'
@@ -142,6 +143,40 @@ describe('siblingTaskInList', () => {
   test('falls back to first/last when current id is not in list', () => {
     expect(siblingTaskInList(tasks, 'gone', 'down')?.id).toBe('t-a')
     expect(siblingTaskInList(tasks, 'gone', 'up')?.id).toBe('t-c')
+  })
+})
+
+describe('nextSessionIdInTask', () => {
+  beforeEach(() => {
+    clearTaskContext('t-A')
+    setSelectedTaskId(null)
+  })
+
+  test('returns null when the task has no sessions', () => {
+    expect(nextSessionIdInTask('t-A', 'next', [])).toBeNull()
+    expect(nextSessionIdInTask('t-A', 'prev', [])).toBeNull()
+  })
+
+  test('next picks first session when none is selected', () => {
+    expect(nextSessionIdInTask('t-A', 'next', [{ id: 's1' }, { id: 's2' }])).toBe('s1')
+  })
+
+  test('prev picks last session when none is selected', () => {
+    expect(nextSessionIdInTask('t-A', 'prev', [{ id: 's1' }, { id: 's2' }])).toBe('s2')
+  })
+
+  test('cycles forward and wraps', () => {
+    setSelectedSessionIdForTask('t-A', 's1')
+    expect(nextSessionIdInTask('t-A', 'next', [{ id: 's1' }, { id: 's2' }, { id: 's3' }])).toBe('s2')
+    setSelectedSessionIdForTask('t-A', 's3')
+    expect(nextSessionIdInTask('t-A', 'next', [{ id: 's1' }, { id: 's2' }, { id: 's3' }])).toBe('s1')
+  })
+
+  test('cycles backward and wraps', () => {
+    setSelectedSessionIdForTask('t-A', 's2')
+    expect(nextSessionIdInTask('t-A', 'prev', [{ id: 's1' }, { id: 's2' }, { id: 's3' }])).toBe('s1')
+    setSelectedSessionIdForTask('t-A', 's1')
+    expect(nextSessionIdInTask('t-A', 'prev', [{ id: 's1' }, { id: 's2' }, { id: 's3' }])).toBe('s3')
   })
 })
 

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -312,6 +312,22 @@ export function focusOrSelectTask(task: { id: string; projectId: string; name: s
   setShowArchived(false)
 }
 
+// Cycle the selected session within a task. Mirrors siblingTaskInList:
+// wraps at edges, and when nothing is selected, 'next' picks first and
+// 'prev' picks last so the shortcut still moves to something.
+export function nextSessionIdInTask(
+  taskId: string,
+  direction: 'next' | 'prev',
+  sessions: { id: string }[],
+): string | null {
+  const sib = siblingTaskInList(
+    sessions,
+    selectedSessionForTask(taskId),
+    direction === 'next' ? 'down' : 'up',
+  )
+  return sib?.id ?? null
+}
+
 // Pure helper for Cmd+Alt+Up/Down sidebar navigation. Wraps around at the
 // edges. When nothing is selected, Down picks the first task and Up picks the
 // last so the shortcut still does something useful.


### PR DESCRIPTION
## Summary

Add a context-aware Cmd+Alt+Left/Right keyboard shortcut that cycles between sessions in the current task when viewing a session, and cycles editor tabs when viewing a file. Mirrors the existing Ctrl+Tab view-aware behavior.

Sessions wrap at edges with sensible defaults: next picks the first session when none is selected, prev picks the last.

## Changes

- New helper `nextSessionIdInTask(taskId, dir, sessions)` in `src/store/ui.ts` wraps the pure `siblingTaskInList` cycler with task-aware session selection
- Made `Cmd+Alt+Left/Right` context-aware in `src/components/Layout.tsx` (gates on `mainView(tid)`)
- Added 5 unit tests covering empty list, no-selection defaults, cycling, and wrap behavior

## Test plan

- [x] `pnpm check` passes (typecheck clean)
- [x] All 532 tests pass (`pnpm test`)
- [x] Tested manually: open a task with 2+ sessions, in session view press Cmd+Alt+Right/Left to cycle