### PR TITLE
Eventual microtask 599

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- New Plugins page (sidebar puzzle icon) lists every plugin from configured Claude Code marketplaces with search, marketplace filter, sort by install count, and one-click install/uninstall. Backed by a thin Rust wrapper around `claude plugin list/install/uninstall` so the CLI stays the source of truth for what's installed. Scope picker is gated to user-only when no project is selected; project/local become available once a project is in focus, so installs target the right `.claude/settings.json`
 - Cmd+Alt+Left/Right now cycles between sessions in the current task when viewing a session (wraps at edges). The shortcut still cycles editor tabs when a file is open, mirroring Ctrl+Tab's view-aware behavior
 - File edits detected by the worktree watcher now trigger a debounced local git refresh, so status/commits/branch state update automatically as you change code without hitting GitHub
 - Local git refresh now uses non-locking read-only git commands, so viewing status no longer rewrites `.git/index` and self-triggers endless `git-local-changed` watcher loops

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Pluggable agent backend with first-class support for Claude Code and Codex (plan
 - **Fork from any message** - hover any past reply to rewind the conversation in place, or branch into a new task with the worktree restored to the code as it was at that exact turn. Verun takes a git snapshot at every turn, so you can undo an entire direction - not just a line of code
 - **Tool approval** - configurable trust levels per task: supervised, normal, or full auto
 - **UI / Terminal toggle for Claude** - flip any Claude session into a real PTY running `claude --resume` to use the unmodified TUI, while history, fork, and search keep working because Verun tails the on-disk transcript. The mode is sticky per session with an app-wide default in Settings
+- **Plugin marketplace browser** - browse, search, and install Claude Code plugins from any configured marketplace without leaving Verun
 - **Notifications** - desktop alerts when an agent finishes, fails, or needs approval so you can context-switch away
 
 ## Full workspace, not just a launcher

--- a/docs/superpowers/plans/2026-05-01-plugin-marketplace.md
+++ b/docs/superpowers/plans/2026-05-01-plugin-marketplace.md
@@ -1,0 +1,1398 @@
+# Plugin Marketplace Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a "Plugins" page to Verun that lists every Claude Code plugin from configured marketplaces, lets the user search/filter/sort, and installs or uninstalls a plugin with one click into a chosen scope (user / project / local).
+
+**Architecture:** Thin frontend over the `claude plugin ...` CLI. A new `plugin_marketplace` Rust module shells out to `claude plugin list/install/uninstall/enable/disable/marketplace ...`, parses the JSON, and exposes typed Tauri commands. The frontend adds a top-level page (toggled like SettingsPage / ArchivedPage) with a card grid powered by a Solid store that mirrors the catalog and tracks pending operations. No persistence: the catalog is held in memory, refreshed on user action; the source of truth for installed/enabled state is whatever `claude plugin list --json` returns.
+
+**Tech Stack:** Rust (`tokio::task::spawn_blocking` + `std::process::Command`, `serde_json`), Solid.js (`createStore`, `<For>`, `createMemo`), UnoCSS, Tauri commands wired through `src-tauri/src/ipc.rs` and `src/lib/ipc.ts`. Tests run via `cargo test` and `pnpm test`.
+
+**Out of scope for v1 (deferred):**
+- Per-plugin detail drawer reading `plugin.json` from cache.
+- UI for adding/removing marketplaces (users can still use `claude plugin marketplace add` directly).
+- Update flow / enable+disable toggle on already-installed plugins (uninstall + reinstall is the v1 path).
+
+---
+
+## File Structure
+
+**Rust (backend):**
+- Create: `src-tauri/src/plugin_marketplace.rs` — subprocess wrappers, parsing, types. Mirrors the shape of `github.rs`: synchronous `pub fn` helpers that build a `Command`, run it, and parse `--json` output.
+- Modify: `src-tauri/src/lib.rs` — `mod plugin_marketplace;` declaration and 8 new entries in the `tauri::generate_handler![...]` block.
+- Modify: `src-tauri/src/ipc.rs` — 8 new `#[tauri::command] pub async fn` thin wrappers that call `tokio::task::spawn_blocking` with the helpers from `plugin_marketplace.rs`.
+
+**TypeScript (frontend):**
+- Modify: `src/types/index.ts` — append plugin types (`PluginInfo`, `PluginCatalog`, `PluginSource`, `MarketplaceInfo`, `PluginScope`).
+- Modify: `src/lib/ipc.ts` — append 8 typed `invoke` wrappers under a new `// Plugins` section.
+- Modify: `src/lib/ipc.test.ts` — add a `test('all plugin functions are exported', ...)` block.
+- Create: `src/store/plugins.ts` — Solid store holding `catalog`, `marketplaces`, a `pending: Set<string>` for in-flight install/uninstall ops, and a `loadCatalog()` action.
+- Modify: `src/store/ui.ts` — add `showPlugins` signal alongside `showSettings` / `showArchived`.
+- Create: `src/components/PluginsPage.tsx` — full-screen page (search + filter + sort + grid).
+- Create: `src/components/PluginCard.tsx` — single card with install/uninstall button + scope picker.
+- Create: `src/components/PluginCard.test.tsx` — render + click tests.
+- Create: `src/components/PluginsPage.test.tsx` — filtering/sorting/search tests.
+- Modify: `src/components/Layout.tsx` — mount `<PluginsPage />` when `showPlugins()` is true (same `<Show when=...>` shape as Settings/Archived).
+- Modify: `src/components/Sidebar.tsx` — add a Puzzle icon button that calls `setShowPlugins(true)`, placed beside the gear/archive buttons.
+
+**Docs:**
+- Modify: `CHANGELOG.md` — append a bullet under `## Unreleased`.
+- Modify: `README.md` — add one bullet under the Features list.
+
+---
+
+## Task 1: Rust subprocess wrapper, types, and version check
+
+**Files:**
+- Create: `src-tauri/src/plugin_marketplace.rs`
+- Modify: `src-tauri/src/lib.rs` (add module declaration only — handler registration is Task 5)
+
+**What this task delivers:** A self-contained Rust module that can answer "is `claude plugin` available?" plus the type definitions every later task will use. No IPC wiring yet.
+
+- [ ] **Step 1: Write the failing test for `is_supported()`**
+
+Append to a new `#[cfg(test)] mod tests` block at the bottom of `src-tauri/src/plugin_marketplace.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_supported_returns_bool() {
+        // Smoke test: function returns without panicking. We can't assert
+        // true/false because CI may or may not have `claude` on PATH.
+        let _ = is_supported();
+    }
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+```bash
+cargo test -p verun_lib plugin_marketplace::tests::is_supported_returns_bool
+```
+
+Expected: FAIL with "no function named is_supported" (or similar — the module doesn't exist yet).
+
+- [ ] **Step 3: Create the module with types and `is_supported`**
+
+Create `src-tauri/src/plugin_marketplace.rs`:
+
+```rust
+//! Wraps the `claude plugin ...` CLI to power Verun's in-app plugin
+//! marketplace browser. We deliberately avoid re-implementing install
+//! mechanics — the CLI is the source of truth for what's installed,
+//! enabled, and which marketplaces are configured.
+
+use serde::{Deserialize, Serialize};
+use std::process::Command;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginSource {
+    /// e.g. "git-subdir" | "url" | "github" | "local". Optional because
+    /// some entries report `source` as a bare relative path string.
+    #[serde(default)]
+    pub source: Option<String>,
+    #[serde(default)]
+    pub url: Option<String>,
+    #[serde(default)]
+    pub repo: Option<String>,
+    #[serde(default)]
+    pub path: Option<String>,
+    #[serde(rename = "ref", default)]
+    pub git_ref: Option<String>,
+    #[serde(default)]
+    pub sha: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AvailablePlugin {
+    pub plugin_id: String,
+    pub name: String,
+    #[serde(default)]
+    pub description: String,
+    pub marketplace_name: String,
+    /// `source` may be either an object or a bare string (e.g. "./plugins/foo")
+    /// in the CLI output. We keep it loose as `serde_json::Value` so callers
+    /// can render whatever's available.
+    #[serde(default)]
+    pub source: serde_json::Value,
+    #[serde(default)]
+    pub version: Option<String>,
+    #[serde(default)]
+    pub install_count: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InstalledPlugin {
+    /// Format: "<name>@<marketplace>"
+    pub id: String,
+    #[serde(default)]
+    pub version: Option<String>,
+    pub scope: String, // "user" | "project" | "local"
+    pub enabled: bool,
+    #[serde(default)]
+    pub install_path: Option<String>,
+    #[serde(default)]
+    pub installed_at: Option<String>,
+    #[serde(default)]
+    pub last_updated: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginCatalog {
+    pub installed: Vec<InstalledPlugin>,
+    pub available: Vec<AvailablePlugin>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MarketplaceInfo {
+    pub name: String,
+    /// "github" | "url" | "local" | etc.
+    #[serde(default)]
+    pub source: Option<String>,
+    #[serde(default)]
+    pub repo: Option<String>,
+    #[serde(default)]
+    pub url: Option<String>,
+    #[serde(default)]
+    pub install_location: Option<String>,
+}
+
+/// Returns true if `claude plugin --help` exits 0 — i.e. the installed
+/// `claude` CLI is new enough to have the plugin subcommand.
+pub fn is_supported() -> bool {
+    Command::new("claude")
+        .args(["plugin", "--help"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_supported_returns_bool() {
+        let _ = is_supported();
+    }
+}
+```
+
+- [ ] **Step 4: Register the module**
+
+In `src-tauri/src/lib.rs`, find the `mod` declarations (around line 1-24) and add `mod plugin_marketplace;` alphabetically (after `mod policy;`):
+
+```rust
+mod policy;
+mod plugin_marketplace;
+mod pty;
+```
+
+- [ ] **Step 5: Run tests to verify pass + zero clippy warnings**
+
+```bash
+cargo test -p verun_lib plugin_marketplace
+cargo clippy -p verun_lib -- -D warnings
+```
+
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src-tauri/src/plugin_marketplace.rs src-tauri/src/lib.rs
+git commit -m "feat(plugins): add plugin_marketplace module with types and version check"
+```
+
+---
+
+## Task 2: Catalog and marketplace listing (parsing + shell-out)
+
+**Files:**
+- Modify: `src-tauri/src/plugin_marketplace.rs`
+
+**What this task delivers:** Two functions — `list_catalog()` and `list_marketplaces()` — backed by parsing tests against frozen JSON fixtures so we don't depend on the live CLI.
+
+- [ ] **Step 1: Write the failing parser tests**
+
+Append to the `mod tests` block in `src-tauri/src/plugin_marketplace.rs`:
+
+```rust
+#[test]
+fn parses_catalog_json() {
+    let raw = r#"{
+      "installed": [{
+        "id": "superpowers@claude-plugins-official",
+        "version": "5.0.7",
+        "scope": "user",
+        "enabled": true,
+        "installPath": "/x/y/z",
+        "installedAt": "2026-05-01T00:00:00Z",
+        "lastUpdated": "2026-05-01T00:00:00Z"
+      }],
+      "available": [{
+        "pluginId": "asana@claude-plugins-official",
+        "name": "asana",
+        "description": "Asana integration",
+        "marketplaceName": "claude-plugins-official",
+        "source": "./external_plugins/asana",
+        "installCount": 8126
+      },{
+        "pluginId": "alloydb@claude-plugins-official",
+        "name": "alloydb",
+        "description": "AlloyDB",
+        "marketplaceName": "claude-plugins-official",
+        "source": {"source":"url","url":"https://example.com/x.git"}
+      }]
+    }"#;
+    let cat: PluginCatalog = serde_json::from_str(raw).unwrap();
+    assert_eq!(cat.installed.len(), 1);
+    assert_eq!(cat.installed[0].id, "superpowers@claude-plugins-official");
+    assert!(cat.installed[0].enabled);
+    assert_eq!(cat.available.len(), 2);
+    assert_eq!(cat.available[0].name, "asana");
+    assert_eq!(cat.available[0].install_count, Some(8126));
+    // String-form source still parses (kept as Value)
+    assert!(cat.available[0].source.is_string());
+    assert!(cat.available[1].source.is_object());
+}
+
+#[test]
+fn parses_marketplaces_json() {
+    let raw = r#"[{
+      "name": "claude-plugins-official",
+      "source": "github",
+      "repo": "anthropics/claude-plugins-official",
+      "installLocation": "/Users/x/.claude/plugins/marketplaces/claude-plugins-official"
+    }]"#;
+    let list: Vec<MarketplaceInfo> = serde_json::from_str(raw).unwrap();
+    assert_eq!(list.len(), 1);
+    assert_eq!(list[0].name, "claude-plugins-official");
+    assert_eq!(list[0].source.as_deref(), Some("github"));
+    assert_eq!(list[0].repo.as_deref(), Some("anthropics/claude-plugins-official"));
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+```bash
+cargo test -p verun_lib plugin_marketplace
+```
+
+Expected: PASS for both new tests (the types from Task 1 already cover the shape).
+
+- [ ] **Step 3: Add the shell-out functions**
+
+In `src-tauri/src/plugin_marketplace.rs`, below `is_supported`, add:
+
+```rust
+fn run_capture(args: &[&str]) -> Result<String, String> {
+    let output = Command::new("claude")
+        .args(args)
+        .output()
+        .map_err(|e| format!("failed to spawn `claude {}`: {e}", args.join(" ")))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let detail = if !stderr.is_empty() { stderr } else { stdout };
+        return Err(format!("`claude {}` failed: {detail}", args.join(" ")));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// `claude plugin list --json --available`
+pub fn list_catalog() -> Result<PluginCatalog, String> {
+    let out = run_capture(&["plugin", "list", "--json", "--available"])?;
+    serde_json::from_str(&out).map_err(|e| format!("parse catalog json: {e}"))
+}
+
+/// `claude plugin marketplace list --json`
+pub fn list_marketplaces() -> Result<Vec<MarketplaceInfo>, String> {
+    let out = run_capture(&["plugin", "marketplace", "list", "--json"])?;
+    serde_json::from_str(&out).map_err(|e| format!("parse marketplaces json: {e}"))
+}
+```
+
+- [ ] **Step 4: Verify everything still compiles and tests still pass**
+
+```bash
+cargo test -p verun_lib plugin_marketplace
+cargo clippy -p verun_lib -- -D warnings
+```
+
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src-tauri/src/plugin_marketplace.rs
+git commit -m "feat(plugins): list catalog and marketplaces via claude CLI"
+```
+
+---
+
+## Task 3: Install / uninstall / enable / disable
+
+**Files:**
+- Modify: `src-tauri/src/plugin_marketplace.rs`
+
+**What this task delivers:** Mutating actions. Each shells out to `claude plugin <verb> ...` and surfaces stderr on failure. Args composition is unit-tested so we don't have to actually mutate state in CI.
+
+- [ ] **Step 1: Write the failing args-builder test**
+
+Append to the `mod tests` block:
+
+```rust
+#[test]
+fn install_args_compose_correctly() {
+    assert_eq!(
+        install_args("asana@claude-plugins-official", "user"),
+        vec!["plugin", "install", "asana@claude-plugins-official", "--scope", "user"]
+    );
+    assert_eq!(
+        install_args("foo@bar", "project"),
+        vec!["plugin", "install", "foo@bar", "--scope", "project"]
+    );
+}
+
+#[test]
+fn uninstall_args_compose_correctly() {
+    assert_eq!(
+        uninstall_args("asana@claude-plugins-official"),
+        vec!["plugin", "uninstall", "asana@claude-plugins-official"]
+    );
+}
+```
+
+- [ ] **Step 2: Run it to verify fail**
+
+```bash
+cargo test -p verun_lib plugin_marketplace::tests::install_args_compose_correctly
+```
+
+Expected: FAIL — `install_args` not defined.
+
+- [ ] **Step 3: Implement args builders + shell-out functions**
+
+Below `list_marketplaces` in `src-tauri/src/plugin_marketplace.rs`:
+
+```rust
+pub(crate) fn install_args<'a>(plugin_id: &'a str, scope: &'a str) -> Vec<&'a str> {
+    vec!["plugin", "install", plugin_id, "--scope", scope]
+}
+
+pub(crate) fn uninstall_args(plugin_id: &str) -> Vec<&str> {
+    vec!["plugin", "uninstall", plugin_id]
+}
+
+/// `claude plugin install <pluginId> --scope user|project|local`.
+/// `cwd` is the directory the install runs from — required so project /
+/// local scopes write to the right `.claude/settings.json`.
+pub fn install(plugin_id: &str, scope: &str, cwd: &str) -> Result<(), String> {
+    let args = install_args(plugin_id, scope);
+    let output = Command::new("claude")
+        .current_dir(cwd)
+        .args(&args)
+        .output()
+        .map_err(|e| format!("install spawn failed: {e}"))?;
+    if !output.status.success() {
+        return Err(String::from_utf8_lossy(&output.stderr).trim().to_string());
+    }
+    Ok(())
+}
+
+/// `claude plugin uninstall <pluginId>`.
+pub fn uninstall(plugin_id: &str, cwd: &str) -> Result<(), String> {
+    let args = uninstall_args(plugin_id);
+    let output = Command::new("claude")
+        .current_dir(cwd)
+        .args(&args)
+        .output()
+        .map_err(|e| format!("uninstall spawn failed: {e}"))?;
+    if !output.status.success() {
+        return Err(String::from_utf8_lossy(&output.stderr).trim().to_string());
+    }
+    Ok(())
+}
+
+/// `claude plugin enable <pluginId>`.
+pub fn enable(plugin_id: &str, cwd: &str) -> Result<(), String> {
+    let output = Command::new("claude")
+        .current_dir(cwd)
+        .args(["plugin", "enable", plugin_id])
+        .output()
+        .map_err(|e| format!("enable spawn failed: {e}"))?;
+    if !output.status.success() {
+        return Err(String::from_utf8_lossy(&output.stderr).trim().to_string());
+    }
+    Ok(())
+}
+
+/// `claude plugin disable <pluginId>`.
+pub fn disable(plugin_id: &str, cwd: &str) -> Result<(), String> {
+    let output = Command::new("claude")
+        .current_dir(cwd)
+        .args(["plugin", "disable", plugin_id])
+        .output()
+        .map_err(|e| format!("disable spawn failed: {e}"))?;
+    if !output.status.success() {
+        return Err(String::from_utf8_lossy(&output.stderr).trim().to_string());
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cargo test -p verun_lib plugin_marketplace
+cargo clippy -p verun_lib -- -D warnings
+```
+
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src-tauri/src/plugin_marketplace.rs
+git commit -m "feat(plugins): install, uninstall, enable, and disable wrappers"
+```
+
+---
+
+## Task 4: Tauri IPC commands
+
+**Files:**
+- Modify: `src-tauri/src/ipc.rs` (add 6 commands)
+- Modify: `src-tauri/src/lib.rs` (register them in `generate_handler!`)
+
+**What this task delivers:** The Rust functions from Tasks 1-3 callable from the frontend via `invoke(...)`. Each command runs the blocking shell-out in `spawn_blocking` to keep the tokio runtime free.
+
+- [ ] **Step 1: Add the 6 commands to ipc.rs**
+
+Append to the bottom of `src-tauri/src/ipc.rs`:
+
+```rust
+// ---------------------------------------------------------------------------
+// Plugin marketplace
+// ---------------------------------------------------------------------------
+
+#[tauri::command]
+pub async fn plugin_is_supported() -> Result<bool, String> {
+    tokio::task::spawn_blocking(crate::plugin_marketplace::is_supported)
+        .await
+        .map_err(|e| format!("Task join error: {e}"))
+}
+
+#[tauri::command]
+pub async fn plugin_list_catalog() -> Result<crate::plugin_marketplace::PluginCatalog, String> {
+    flatten_join(tokio::task::spawn_blocking(crate::plugin_marketplace::list_catalog).await)
+}
+
+#[tauri::command]
+pub async fn plugin_list_marketplaces() -> Result<Vec<crate::plugin_marketplace::MarketplaceInfo>, String> {
+    flatten_join(tokio::task::spawn_blocking(crate::plugin_marketplace::list_marketplaces).await)
+}
+
+#[tauri::command]
+pub async fn plugin_install(plugin_id: String, scope: String, cwd: String) -> Result<(), String> {
+    flatten_join(
+        tokio::task::spawn_blocking(move || {
+            crate::plugin_marketplace::install(&plugin_id, &scope, &cwd)
+        })
+        .await,
+    )
+}
+
+#[tauri::command]
+pub async fn plugin_uninstall(plugin_id: String, cwd: String) -> Result<(), String> {
+    flatten_join(
+        tokio::task::spawn_blocking(move || {
+            crate::plugin_marketplace::uninstall(&plugin_id, &cwd)
+        })
+        .await,
+    )
+}
+
+#[tauri::command]
+pub async fn plugin_set_enabled(plugin_id: String, enabled: bool, cwd: String) -> Result<(), String> {
+    flatten_join(
+        tokio::task::spawn_blocking(move || {
+            if enabled {
+                crate::plugin_marketplace::enable(&plugin_id, &cwd)
+            } else {
+                crate::plugin_marketplace::disable(&plugin_id, &cwd)
+            }
+        })
+        .await,
+    )
+}
+```
+
+- [ ] **Step 2: Register the 6 commands**
+
+In `src-tauri/src/lib.rs`, find the `tauri::generate_handler![...]` block (starts around line 256). Append at the end of the list (right before the closing `])`):
+
+```rust
+            ipc::plugin_is_supported,
+            ipc::plugin_list_catalog,
+            ipc::plugin_list_marketplaces,
+            ipc::plugin_install,
+            ipc::plugin_uninstall,
+            ipc::plugin_set_enabled,
+```
+
+- [ ] **Step 3: Compile and lint**
+
+```bash
+cargo check -p verun_lib
+cargo clippy -p verun_lib -- -D warnings
+```
+
+Expected: green.
+
+- [ ] **Step 4: Smoke test the new commands manually**
+
+In a scratch terminal:
+
+```bash
+pnpm tauri dev --config src-tauri/tauri.dev.conf.json --features dev-notifications
+```
+
+Open devtools console in the running app and run:
+
+```js
+await window.__TAURI__.core.invoke('plugin_is_supported')
+// expect: true (since claude CLI is installed locally)
+const cat = await window.__TAURI__.core.invoke('plugin_list_catalog')
+// expect: { installed: [...], available: [...170+ items] }
+```
+
+Stop the dev server when satisfied.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src-tauri/src/ipc.rs src-tauri/src/lib.rs
+git commit -m "feat(plugins): expose plugin marketplace commands over IPC"
+```
+
+---
+
+## Task 5: Frontend types and IPC wrappers
+
+**Files:**
+- Modify: `src/types/index.ts`
+- Modify: `src/lib/ipc.ts`
+- Modify: `src/lib/ipc.test.ts`
+
+**What this task delivers:** Typed `invoke` wrappers so the rest of the frontend never types the string `'plugin_list_catalog'` again.
+
+- [ ] **Step 1: Write the failing wrapper-export test**
+
+In `src/lib/ipc.test.ts`, append a new `test` block inside the existing `describe('ipc', ...)`:
+
+```ts
+test('all plugin functions are exported', () => {
+    expect(typeof ipc.pluginIsSupported).toBe('function')
+    expect(typeof ipc.pluginListCatalog).toBe('function')
+    expect(typeof ipc.pluginListMarketplaces).toBe('function')
+    expect(typeof ipc.pluginInstall).toBe('function')
+    expect(typeof ipc.pluginUninstall).toBe('function')
+    expect(typeof ipc.pluginSetEnabled).toBe('function')
+})
+```
+
+- [ ] **Step 2: Run it to verify fail**
+
+```bash
+pnpm test src/lib/ipc.test.ts
+```
+
+Expected: FAIL — properties don't exist.
+
+- [ ] **Step 3: Add the types**
+
+Append to `src/types/index.ts`:
+
+```ts
+// ---------- Plugins ----------
+
+export type PluginScope = 'user' | 'project' | 'local'
+
+export interface PluginSourceObject {
+  source?: string
+  url?: string
+  repo?: string
+  path?: string
+  ref?: string
+  sha?: string
+}
+
+// Source can be either a structured object or a bare path string.
+export type PluginSource = PluginSourceObject | string
+
+export interface AvailablePlugin {
+  pluginId: string
+  name: string
+  description: string
+  marketplaceName: string
+  source: PluginSource
+  version?: string
+  installCount?: number
+}
+
+export interface InstalledPlugin {
+  id: string
+  version?: string
+  scope: PluginScope
+  enabled: boolean
+  installPath?: string
+  installedAt?: string
+  lastUpdated?: string
+}
+
+export interface PluginCatalog {
+  installed: InstalledPlugin[]
+  available: AvailablePlugin[]
+}
+
+export interface MarketplaceInfo {
+  name: string
+  source?: string
+  repo?: string
+  url?: string
+  installLocation?: string
+}
+```
+
+- [ ] **Step 4: Add the IPC wrappers**
+
+Append to `src/lib/ipc.ts` (and add the new types to the existing `import type { ... }` line at the top):
+
+```ts
+// Plugins
+export const pluginIsSupported = () =>
+  invoke<boolean>('plugin_is_supported')
+
+export const pluginListCatalog = () =>
+  invoke<PluginCatalog>('plugin_list_catalog')
+
+export const pluginListMarketplaces = () =>
+  invoke<MarketplaceInfo[]>('plugin_list_marketplaces')
+
+export const pluginInstall = (pluginId: string, scope: PluginScope, cwd: string) =>
+  invoke<void>('plugin_install', { pluginId, scope, cwd })
+
+export const pluginUninstall = (pluginId: string, cwd: string) =>
+  invoke<void>('plugin_uninstall', { pluginId, cwd })
+
+export const pluginSetEnabled = (pluginId: string, enabled: boolean, cwd: string) =>
+  invoke<void>('plugin_set_enabled', { pluginId, enabled, cwd })
+```
+
+Update the import line at the top of `src/lib/ipc.ts` to add `PluginCatalog, MarketplaceInfo, PluginScope` to the existing type import.
+
+- [ ] **Step 5: Run tests to verify pass + typecheck**
+
+```bash
+pnpm test src/lib/ipc.test.ts
+pnpm check
+```
+
+Expected: green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/types/index.ts src/lib/ipc.ts src/lib/ipc.test.ts
+git commit -m "feat(plugins): typed IPC wrappers for plugin marketplace"
+```
+
+---
+
+## Task 6: Plugins store + UI signal + Layout / Sidebar wiring
+
+**Files:**
+- Create: `src/store/plugins.ts`
+- Modify: `src/store/ui.ts`
+- Modify: `src/components/Layout.tsx`
+- Modify: `src/components/Sidebar.tsx`
+
+**What this task delivers:** Visible empty page wired to a refresh-on-mount store. The page itself (Task 7) is a placeholder for now; this task puts the navigation in place and fetches the catalog.
+
+- [ ] **Step 1: Create the store**
+
+Create `src/store/plugins.ts`:
+
+```ts
+import { createStore } from 'solid-js/store'
+import { createSignal } from 'solid-js'
+import type { PluginCatalog, MarketplaceInfo, PluginScope } from '../types'
+import * as ipc from '../lib/ipc'
+import { addToast } from './ui'
+
+export const [catalog, setCatalog] = createStore<PluginCatalog>({ installed: [], available: [] })
+export const [marketplaces, setMarketplaces] = createStore<MarketplaceInfo[]>([])
+export const [isSupported, setIsSupported] = createSignal<boolean | null>(null)
+export const [isLoading, setIsLoading] = createSignal(false)
+export const [pending, setPending] = createStore<Record<string, true>>({})
+
+export function isPending(pluginId: string): boolean {
+  return !!pending[pluginId]
+}
+
+export function isInstalled(pluginId: string): boolean {
+  return catalog.installed.some(p => p.id === pluginId)
+}
+
+export async function loadCatalog() {
+  setIsLoading(true)
+  try {
+    const supported = await ipc.pluginIsSupported()
+    setIsSupported(supported)
+    if (!supported) return
+    const [cat, mps] = await Promise.all([
+      ipc.pluginListCatalog(),
+      ipc.pluginListMarketplaces(),
+    ])
+    setCatalog(cat)
+    setMarketplaces(mps)
+  } catch (e) {
+    addToast({ kind: 'error', message: `Failed to load plugin catalog: ${e}` })
+  } finally {
+    setIsLoading(false)
+  }
+}
+
+export async function installPlugin(pluginId: string, scope: PluginScope, cwd: string) {
+  setPending(pluginId, true)
+  try {
+    await ipc.pluginInstall(pluginId, scope, cwd)
+    await loadCatalog()
+    addToast({ kind: 'success', message: `Installed ${pluginId}` })
+  } catch (e) {
+    addToast({ kind: 'error', message: `Install failed: ${e}` })
+  } finally {
+    setPending(pluginId, undefined as unknown as true)
+  }
+}
+
+export async function uninstallPlugin(pluginId: string, cwd: string) {
+  setPending(pluginId, true)
+  try {
+    await ipc.pluginUninstall(pluginId, cwd)
+    await loadCatalog()
+    addToast({ kind: 'success', message: `Uninstalled ${pluginId}` })
+  } catch (e) {
+    addToast({ kind: 'error', message: `Uninstall failed: ${e}` })
+  } finally {
+    setPending(pluginId, undefined as unknown as true)
+  }
+}
+```
+
+- [ ] **Step 2: Add the UI signal**
+
+In `src/store/ui.ts`, find the line `export const [showSettings, setShowSettings] = createSignal(false)` and add directly below it:
+
+```ts
+export const [showPlugins, setShowPlugins] = createSignal(false)
+```
+
+- [ ] **Step 3: Add a placeholder PluginsPage so we can mount it**
+
+Create `src/components/PluginsPage.tsx`:
+
+```tsx
+import { Component, onMount, Show } from 'solid-js'
+import { loadCatalog, isLoading, isSupported } from '../store/plugins'
+import { setShowPlugins } from '../store/ui'
+import { X } from 'lucide-solid'
+
+export const PluginsPage: Component = () => {
+  onMount(() => { void loadCatalog() })
+  return (
+    <div class="absolute inset-0 bg-bg z-20 flex flex-col">
+      <div class="flex items-center justify-between px-4 py-3 border-b-1 border-b-solid border-b-white/8">
+        <h1 class="text-lg font-medium">Plugins</h1>
+        <button class="p-1 rounded hover:bg-white/5" onClick={() => setShowPlugins(false)} aria-label="Close">
+          <X class="w-4 h-4" />
+        </button>
+      </div>
+      <div class="flex-1 overflow-auto p-4">
+        <Show when={isSupported() === false}>
+          <p class="text-sm text-fg/60">Update Claude Code to 2.0+ to use the plugin marketplace.</p>
+        </Show>
+        <Show when={isLoading()}>
+          <p class="text-sm text-fg/60">Loading…</p>
+        </Show>
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Mount it in Layout**
+
+In `src/components/Layout.tsx`, add `showPlugins` to the existing imports from `'../store/ui'`, import `PluginsPage`, and add a `<Show when={showPlugins()}><PluginsPage /></Show>` next to the existing `<Show when={showSettings()}>` block.
+
+- [ ] **Step 5: Add a sidebar button**
+
+In `src/components/Sidebar.tsx`, add `Puzzle` to the existing `lucide-solid` imports, add `setShowPlugins` to the imports from `'../store/ui'`, and add a button beside the existing Settings/Archive buttons:
+
+```tsx
+<button
+  class="p-1.5 rounded hover:bg-white/5"
+  title="Plugins"
+  onClick={() => setShowPlugins(true)}
+>
+  <Puzzle class="w-4 h-4" />
+</button>
+```
+
+- [ ] **Step 6: Verify it renders end-to-end**
+
+```bash
+pnpm tauri dev --config src-tauri/tauri.dev.conf.json --features dev-notifications
+```
+
+Click the Puzzle icon in the sidebar. Expect: a full-screen "Plugins" page with a close X. Console should show no errors. Close, reopen — works.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/store/plugins.ts src/store/ui.ts src/components/PluginsPage.tsx src/components/Layout.tsx src/components/Sidebar.tsx
+git commit -m "feat(plugins): plugins store and full-screen page placeholder"
+```
+
+---
+
+## Task 7: PluginCard with one-click install
+
+**Files:**
+- Create: `src/components/PluginCard.tsx`
+- Create: `src/components/PluginCard.test.tsx`
+
+**What this task delivers:** The unit the user clicks. Default install scope is `user`. A scope picker is reachable via a small dropdown next to the install button. Pending state shows a spinner.
+
+- [ ] **Step 1: Write the failing render test**
+
+Create `src/components/PluginCard.test.tsx`:
+
+```tsx
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { render, fireEvent } from '@solidjs/testing-library'
+import { PluginCard } from './PluginCard'
+import type { AvailablePlugin } from '../types'
+
+vi.mock('../store/plugins', () => ({
+  isInstalled: vi.fn(() => false),
+  isPending: vi.fn(() => false),
+  installPlugin: vi.fn().mockResolvedValue(undefined),
+  uninstallPlugin: vi.fn().mockResolvedValue(undefined),
+}))
+
+const sample: AvailablePlugin = {
+  pluginId: 'asana@claude-plugins-official',
+  name: 'asana',
+  description: 'Asana integration',
+  marketplaceName: 'claude-plugins-official',
+  source: './external_plugins/asana',
+  installCount: 8126,
+}
+
+describe('PluginCard', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  test('renders name, description, and install count', () => {
+    const { getByText } = render(() => <PluginCard plugin={sample} cwd="/tmp" />)
+    expect(getByText('asana')).toBeTruthy()
+    expect(getByText(/Asana integration/)).toBeTruthy()
+    expect(getByText(/8,126/)).toBeTruthy()
+  })
+
+  test('clicking Install calls installPlugin with default scope user', async () => {
+    const { installPlugin } = await import('../store/plugins')
+    const { getByText } = render(() => <PluginCard plugin={sample} cwd="/tmp" />)
+    fireEvent.click(getByText('Install'))
+    expect(installPlugin).toHaveBeenCalledWith('asana@claude-plugins-official', 'user', '/tmp')
+  })
+
+  test('shows Uninstall when already installed', async () => {
+    const mod = await import('../store/plugins')
+    ;(mod.isInstalled as unknown as ReturnType<typeof vi.fn>).mockReturnValue(true)
+    const { getByText } = render(() => <PluginCard plugin={sample} cwd="/tmp" />)
+    expect(getByText('Uninstall')).toBeTruthy()
+  })
+})
+```
+
+- [ ] **Step 2: Run it to verify fail**
+
+```bash
+pnpm test src/components/PluginCard.test.tsx
+```
+
+Expected: FAIL — `PluginCard` not found.
+
+- [ ] **Step 3: Implement the card**
+
+Create `src/components/PluginCard.tsx`:
+
+```tsx
+import { Component, Show, createSignal } from 'solid-js'
+import { Loader2, Download, Trash2, ChevronDown } from 'lucide-solid'
+import type { AvailablePlugin, PluginScope } from '../types'
+import { installPlugin, uninstallPlugin, isInstalled, isPending } from '../store/plugins'
+
+interface Props {
+  plugin: AvailablePlugin
+  cwd: string
+}
+
+export const PluginCard: Component<Props> = (props) => {
+  const [scope, setScope] = createSignal<PluginScope>('user')
+  const [scopeOpen, setScopeOpen] = createSignal(false)
+
+  const installed = () => isInstalled(props.plugin.pluginId)
+  const pending = () => isPending(props.plugin.pluginId)
+
+  return (
+    <div class="ring-1 ring-white/8 rounded-lg p-4 flex flex-col gap-3 bg-bg">
+      <div class="flex items-start justify-between gap-3">
+        <div class="min-w-0 flex-1">
+          <h3 class="font-medium truncate">{props.plugin.name}</h3>
+          <p class="text-xs text-fg/50 truncate">{props.plugin.marketplaceName}</p>
+        </div>
+        <Show when={props.plugin.installCount != null}>
+          <span class="text-xs text-fg/60 shrink-0">
+            {props.plugin.installCount!.toLocaleString()} installs
+          </span>
+        </Show>
+      </div>
+      <p class="text-sm text-fg/80 line-clamp-3">{props.plugin.description}</p>
+      <div class="flex items-center gap-2 mt-auto">
+        <Show
+          when={!installed()}
+          fallback={
+            <button
+              class="flex-1 px-3 py-1.5 rounded ring-1 ring-white/10 hover:bg-white/5 text-sm flex items-center justify-center gap-1.5"
+              disabled={pending()}
+              onClick={() => uninstallPlugin(props.plugin.pluginId, props.cwd)}
+            >
+              <Show when={pending()} fallback={<Trash2 class="w-3.5 h-3.5" />}>
+                <Loader2 class="w-3.5 h-3.5 animate-spin" />
+              </Show>
+              Uninstall
+            </button>
+          }
+        >
+          <button
+            class="flex-1 px-3 py-1.5 rounded bg-accent text-white hover:bg-accent/90 text-sm flex items-center justify-center gap-1.5 disabled:opacity-50"
+            disabled={pending()}
+            onClick={() => installPlugin(props.plugin.pluginId, scope(), props.cwd)}
+          >
+            <Show when={pending()} fallback={<Download class="w-3.5 h-3.5" />}>
+              <Loader2 class="w-3.5 h-3.5 animate-spin" />
+            </Show>
+            Install
+          </button>
+          <div class="relative">
+            <button
+              class="px-2 py-1.5 rounded ring-1 ring-white/10 hover:bg-white/5 text-xs flex items-center gap-1"
+              onClick={() => setScopeOpen(o => !o)}
+              title="Install scope"
+            >
+              {scope()} <ChevronDown class="w-3 h-3" />
+            </button>
+            <Show when={scopeOpen()}>
+              <div class="absolute right-0 top-full mt-1 ring-1 ring-white/10 rounded bg-bg z-10 min-w-24">
+                {(['user', 'project', 'local'] as const).map(s => (
+                  <button
+                    class="block w-full px-3 py-1.5 text-left text-xs hover:bg-white/5"
+                    onClick={() => { setScope(s); setScopeOpen(false) }}
+                  >
+                    {s}
+                  </button>
+                ))}
+              </div>
+            </Show>
+          </div>
+        </Show>
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+```bash
+pnpm test src/components/PluginCard.test.tsx
+pnpm check
+```
+
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/PluginCard.tsx src/components/PluginCard.test.tsx
+git commit -m "feat(plugins): plugin card with one-click install and scope picker"
+```
+
+---
+
+## Task 8: PluginsPage — search, filter, sort, grid
+
+**Files:**
+- Modify: `src/components/PluginsPage.tsx`
+- Create: `src/components/PluginsPage.test.tsx`
+
+**What this task delivers:** The actual browseable page. Search box on top, marketplace multi-select pills, "installed only" toggle, sort dropdown, grid of `PluginCard`s.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/components/PluginsPage.test.tsx`:
+
+```tsx
+import { describe, test, expect, vi } from 'vitest'
+import { render, fireEvent, waitFor } from '@solidjs/testing-library'
+import { PluginsPage } from './PluginsPage'
+
+vi.mock('../store/plugins', () => {
+  const { createStore } = require('solid-js/store')
+  const [catalog] = createStore({
+    installed: [{ id: 'asana@claude-plugins-official', scope: 'user', enabled: true }],
+    available: [
+      { pluginId: 'asana@claude-plugins-official', name: 'asana', description: 'Asana stuff', marketplaceName: 'claude-plugins-official', source: '', installCount: 100 },
+      { pluginId: 'amplitude@claude-plugins-official', name: 'amplitude', description: 'Analytics', marketplaceName: 'claude-plugins-official', source: '', installCount: 50 },
+      { pluginId: 'foo@other-mp', name: 'foo', description: 'A foo plugin', marketplaceName: 'other-mp', source: '', installCount: 999 },
+    ],
+  })
+  return {
+    catalog,
+    marketplaces: [
+      { name: 'claude-plugins-official' },
+      { name: 'other-mp' },
+    ],
+    isSupported: () => true,
+    isLoading: () => false,
+    isInstalled: (id: string) => id === 'asana@claude-plugins-official',
+    isPending: () => false,
+    loadCatalog: vi.fn().mockResolvedValue(undefined),
+    installPlugin: vi.fn(),
+    uninstallPlugin: vi.fn(),
+  }
+})
+vi.mock('../store/ui', () => ({ setShowPlugins: vi.fn(), addToast: vi.fn() }))
+
+describe('PluginsPage', () => {
+  test('renders all available plugins by default', async () => {
+    const { findByText } = render(() => <PluginsPage />)
+    expect(await findByText('asana')).toBeTruthy()
+    expect(await findByText('amplitude')).toBeTruthy()
+    expect(await findByText('foo')).toBeTruthy()
+  })
+
+  test('search filters by name', async () => {
+    const { findByPlaceholderText, queryByText, findByText } = render(() => <PluginsPage />)
+    const search = await findByPlaceholderText(/search/i)
+    fireEvent.input(search, { target: { value: 'amp' } })
+    await waitFor(() => {
+      expect(queryByText('asana')).toBeNull()
+      expect(queryByText('foo')).toBeNull()
+    })
+    expect(await findByText('amplitude')).toBeTruthy()
+  })
+
+  test('installed-only toggle hides un-installed', async () => {
+    const { findByLabelText, queryByText, findByText } = render(() => <PluginsPage />)
+    const toggle = await findByLabelText(/installed only/i)
+    fireEvent.click(toggle)
+    await waitFor(() => {
+      expect(queryByText('amplitude')).toBeNull()
+      expect(queryByText('foo')).toBeNull()
+    })
+    expect(await findByText('asana')).toBeTruthy()
+  })
+})
+```
+
+- [ ] **Step 2: Run it to verify fail**
+
+```bash
+pnpm test src/components/PluginsPage.test.tsx
+```
+
+Expected: FAIL — search box / toggle don't exist yet.
+
+- [ ] **Step 3: Replace PluginsPage with the full implementation**
+
+Overwrite `src/components/PluginsPage.tsx`:
+
+```tsx
+import { Component, For, Show, createMemo, createSignal, onMount } from 'solid-js'
+import { X, Search, RefreshCw } from 'lucide-solid'
+import { catalog, marketplaces, isSupported, isLoading, isInstalled, loadCatalog } from '../store/plugins'
+import { setShowPlugins } from '../store/ui'
+import { PluginCard } from './PluginCard'
+import { selectedProjectId } from '../store/ui'
+import { projects } from '../store/projects'
+
+type SortKey = 'installs' | 'name'
+
+export const PluginsPage: Component = () => {
+  const [query, setQuery] = createSignal('')
+  const [installedOnly, setInstalledOnly] = createSignal(false)
+  const [marketplaceFilter, setMarketplaceFilter] = createSignal<Set<string>>(new Set())
+  const [sortKey, setSortKey] = createSignal<SortKey>('installs')
+
+  onMount(() => { void loadCatalog() })
+
+  const cwd = createMemo(() => {
+    const pid = selectedProjectId()
+    if (pid) {
+      const proj = projects.find(p => p.id === pid)
+      if (proj) return proj.repoPath
+    }
+    // Fall back to home — claude reads/writes ~/.claude/settings.json regardless
+    // when --scope user, which is the default.
+    return '/'
+  })
+
+  const filtered = createMemo(() => {
+    const q = query().trim().toLowerCase()
+    const mpFilter = marketplaceFilter()
+    const onlyInstalled = installedOnly()
+    let list = catalog.available.filter(p => {
+      if (onlyInstalled && !isInstalled(p.pluginId)) return false
+      if (mpFilter.size > 0 && !mpFilter.has(p.marketplaceName)) return false
+      if (q && !p.name.toLowerCase().includes(q) && !p.description.toLowerCase().includes(q)) return false
+      return true
+    })
+    if (sortKey() === 'installs') {
+      list = [...list].sort((a, b) => (b.installCount ?? 0) - (a.installCount ?? 0))
+    } else {
+      list = [...list].sort((a, b) => a.name.localeCompare(b.name))
+    }
+    return list
+  })
+
+  const toggleMp = (name: string) => {
+    setMarketplaceFilter(prev => {
+      const next = new Set(prev)
+      if (next.has(name)) next.delete(name)
+      else next.add(name)
+      return next
+    })
+  }
+
+  return (
+    <div class="absolute inset-0 bg-bg z-20 flex flex-col">
+      <div class="flex items-center justify-between px-4 py-3 border-b-1 border-b-solid border-b-white/8">
+        <h1 class="text-lg font-medium">Plugins</h1>
+        <div class="flex items-center gap-2">
+          <button
+            class="p-1 rounded hover:bg-white/5"
+            onClick={() => loadCatalog()}
+            title="Refresh"
+            disabled={isLoading()}
+          >
+            <RefreshCw class={`w-4 h-4 ${isLoading() ? 'animate-spin' : ''}`} />
+          </button>
+          <button class="p-1 rounded hover:bg-white/5" onClick={() => setShowPlugins(false)} aria-label="Close">
+            <X class="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+
+      <Show when={isSupported() === false}>
+        <div class="p-8 text-center text-sm text-fg/60">
+          Update Claude Code to 2.0+ to use the plugin marketplace.
+        </div>
+      </Show>
+
+      <Show when={isSupported() !== false}>
+        <div class="px-4 py-3 flex items-center gap-3 flex-wrap border-b-1 border-b-solid border-b-white/8">
+          <div class="relative flex-1 min-w-60">
+            <Search class="w-4 h-4 absolute left-2 top-1/2 -translate-y-1/2 text-fg/40" />
+            <input
+              type="text"
+              placeholder="Search plugins…"
+              class="w-full pl-8 pr-3 py-1.5 rounded ring-1 ring-white/10 bg-bg text-sm focus:ring-accent focus:outline-none"
+              value={query()}
+              onInput={e => setQuery(e.currentTarget.value)}
+            />
+          </div>
+          <label class="flex items-center gap-1.5 text-sm text-fg/80">
+            <input
+              type="checkbox"
+              checked={installedOnly()}
+              onChange={e => setInstalledOnly(e.currentTarget.checked)}
+              aria-label="Installed only"
+            />
+            Installed only
+          </label>
+          <select
+            class="px-2 py-1.5 rounded ring-1 ring-white/10 bg-bg text-sm"
+            value={sortKey()}
+            onChange={e => setSortKey(e.currentTarget.value as SortKey)}
+          >
+            <option value="installs">Most installed</option>
+            <option value="name">Name</option>
+          </select>
+        </div>
+
+        <Show when={marketplaces.length > 1}>
+          <div class="px-4 py-2 flex items-center gap-2 flex-wrap border-b-1 border-b-solid border-b-white/8">
+            <span class="text-xs text-fg/50">Marketplaces:</span>
+            <For each={marketplaces}>
+              {mp => {
+                const active = () => marketplaceFilter().has(mp.name)
+                return (
+                  <button
+                    class={`px-2 py-0.5 rounded-full text-xs ring-1 ${active() ? 'ring-accent bg-accent/10 text-accent' : 'ring-white/10 hover:bg-white/5'}`}
+                    onClick={() => toggleMp(mp.name)}
+                  >
+                    {mp.name}
+                  </button>
+                )
+              }}
+            </For>
+          </div>
+        </Show>
+
+        <div class="flex-1 overflow-auto p-4">
+          <Show when={!isLoading() && filtered().length === 0}>
+            <p class="text-sm text-fg/60 text-center py-8">No plugins match your filters.</p>
+          </Show>
+          <div class="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-3">
+            <For each={filtered()}>
+              {p => <PluginCard plugin={p} cwd={cwd()} />}
+            </For>
+          </div>
+        </div>
+      </Show>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass + typecheck**
+
+```bash
+pnpm test src/components/PluginsPage.test.tsx
+pnpm check
+```
+
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/PluginsPage.tsx src/components/PluginsPage.test.tsx
+git commit -m "feat(plugins): plugin browser with search, filter, and sort"
+```
+
+---
+
+## Task 9: End-to-end manual verification
+
+**Files:** none (no code changes — just verifying the user-visible feature works in dev)
+
+- [ ] **Step 1: Run dev**
+
+```bash
+pnpm tauri dev --config src-tauri/tauri.dev.conf.json --features dev-notifications
+```
+
+- [ ] **Step 2: Walk the golden path**
+
+1. Click the Puzzle icon in the sidebar — Plugins page opens.
+2. The grid loads ~170 cards within ~1s (the catalog fetch).
+3. Type "amplitude" in the search box — only matching cards remain.
+4. Toggle "Installed only" — see just your 3 already-installed plugins.
+5. Click the marketplace pill `claude-plugins-official` — only that marketplace's plugins show.
+6. Click Install on a small plugin you don't already have (e.g. `agent-sdk-dev`). Spinner appears, then a success toast. Card flips to Uninstall.
+7. Click Uninstall on it. Spinner, toast, card flips back to Install.
+8. Click Refresh — spinner runs, list re-renders.
+9. Close the page with the X — back to the main view, no console errors.
+
+- [ ] **Step 3: Walk one error path**
+
+In a separate terminal: `mv ~/.local/bin/claude ~/.local/bin/claude.bak` (or rename whichever path `which claude` returns), then click Refresh in Verun. Expect: "Update Claude Code to 2.0+" empty state. Restore the binary.
+
+- [ ] **Step 4: Run the full project check**
+
+```bash
+make check
+```
+
+Expected: zero errors, zero clippy warnings, no TS errors.
+
+- [ ] **Step 5: Commit (no-op if no changes — this task is verification only)**
+
+If you made any small tweaks during manual testing:
+
+```bash
+git add -p
+git commit -m "fix(plugins): <whatever needed adjusting>"
+```
+
+---
+
+## Task 10: Docs
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `README.md`
+
+- [ ] **Step 1: Append to CHANGELOG.md under `## Unreleased`**
+
+```markdown
+- Plugins page lists every plugin from configured Claude Code marketplaces, with search, marketplace filter, sort by install count, and one-click install/uninstall into user / project / local scope. Backed by a thin Rust wrapper around `claude plugin list/install/uninstall` so the CLI remains the source of truth for what's installed.
+```
+
+- [ ] **Step 2: Add a feature bullet to README.md**
+
+Find the Features list and append:
+
+```markdown
+- **Plugin marketplace browser** - browse, search, and install Claude Code plugins from any configured marketplace without leaving Verun
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md README.md
+git commit -m "docs: changelog and readme entry for plugin marketplace"
+```
+
+---
+
+## Self-Review Notes
+
+**Spec coverage:**
+- "List all plugins" → Tasks 2 + 8 (catalog fetch + grid render).
+- "Filters" → Task 8 (marketplace pills, installed-only toggle).
+- "Search" → Task 8 (name + description match).
+- "Install with one click" → Task 7 (single button, default scope = user).
+- Out-of-scope items are listed at the top of the plan and intentionally not assigned tasks.
+
+**Naming consistency:**
+- `pluginId` (string) is used identically in Rust types, TS types, IPC commands, store keys, and component props.
+- `scope` is `'user' | 'project' | 'local'` everywhere — Rust accepts a `&str` and the TS type narrows it.
+
+**Risk notes for the engineer:**
+- `claude plugin install` may take up to ~30s on first install (git clone). The spinner in the card covers this; no timeout is set in our wrapper.
+- `cwd` for installs falls back to `/` when no project is selected. That's fine for `--scope user` (writes to `~/.claude/settings.json`), but `--scope project` / `--scope local` from that fallback directory would write to `/.claude/settings.json` — investigate before exposing those scopes when no project is active. If unsure, gate project/local on `selectedProjectId() != null` in `PluginCard.tsx` step 3 of Task 7.

--- a/src-tauri/src/agent/claude.rs
+++ b/src-tauri/src/agent/claude.rs
@@ -253,7 +253,10 @@ fn scan_installed_plugins(user_home: &Path) -> Vec<AgentSkill> {
         return Vec::new();
     };
     let mut skills = Vec::new();
-    for entries in plugins.values() {
+    for (key, entries) in plugins {
+        // Manifest keys look like `<plugin>@<marketplace>`. The plugin name is
+        // the prefix.
+        let plugin_name = key.split('@').next().unwrap_or(key.as_str());
         let Some(array) = entries.as_array() else {
             continue;
         };
@@ -262,8 +265,16 @@ fn scan_installed_plugins(user_home: &Path) -> Vec<AgentSkill> {
                 continue;
             };
             let base = Path::new(install_path);
+            // Skills aren't namespaced — they're addressed by their declared name.
             skills.extend(scan_skills_dir(&base.join("skills")));
-            skills.extend(scan_commands_dir(&base.join("commands")));
+            // Commands get the `<plugin>:<command>` prefix so Verun's slash
+            // command UI matches what `claude` autocomplete shows.
+            for cmd in scan_commands_dir(&base.join("commands")) {
+                skills.push(AgentSkill {
+                    name: format!("{plugin_name}:{}", cmd.name),
+                    description: cmd.description,
+                });
+            }
         }
     }
     skills
@@ -455,19 +466,25 @@ mod tests {
     }
 
     #[test]
-    fn discover_includes_plugin_commands() {
+    fn discover_namespaces_plugin_commands() {
+        // The CLI's autocomplete shows plugin commands as `<plugin>:<command>`
+        // (e.g. `/code-review:code-review`). Verun mirrors that so the slash
+        // command UI matches what users see in the terminal.
         let home = TempDir::new().unwrap();
         let install_path = home.path().join(".claude/plugins/cache/mp/plugin-x/1.0.0");
         write_command(
             &install_path.join("commands"),
             "plugin-cmd",
-            "---\nname: plugin-cmd\ndescription: from plugin\n---\n",
+            "---\ndescription: from plugin\n---\n",
         );
         write_installed_plugins(home.path(), &[&install_path]);
 
         let skills = Claude.discover_skills(None, home.path());
         let names: Vec<&str> = skills.iter().map(|s| s.name.as_str()).collect();
-        assert!(names.contains(&"plugin-cmd"));
+        // write_installed_plugins keys entries as `plugin-<i>@mp`, so the
+        // first plugin is named `plugin-0`.
+        assert!(names.contains(&"plugin-0:plugin-cmd"));
+        assert!(!names.contains(&"plugin-cmd"));
     }
 
     #[test]

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -3210,6 +3210,16 @@ pub async fn plugin_set_enabled(
     )
 }
 
+#[tauri::command]
+pub async fn plugin_read_manifest(
+    install_path: String,
+) -> Result<crate::plugin_marketplace::PluginManifest, String> {
+    flatten_join(
+        tokio::task::spawn_blocking(move || crate::plugin_marketplace::read_manifest(&install_path))
+            .await,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -3148,6 +3148,68 @@ pub async fn migrate_legacy_attachments(
     blob::migrate_legacy_attachments(pool.inner(), &app_data.0).await
 }
 
+// ---------------------------------------------------------------------------
+// Plugin marketplace
+// ---------------------------------------------------------------------------
+
+#[tauri::command]
+pub async fn plugin_is_supported() -> Result<bool, String> {
+    tokio::task::spawn_blocking(crate::plugin_marketplace::is_supported)
+        .await
+        .map_err(|e| format!("Task join error: {e}"))
+}
+
+#[tauri::command]
+pub async fn plugin_list_catalog() -> Result<crate::plugin_marketplace::PluginCatalog, String> {
+    flatten_join(tokio::task::spawn_blocking(crate::plugin_marketplace::list_catalog).await)
+}
+
+#[tauri::command]
+pub async fn plugin_list_marketplaces(
+) -> Result<Vec<crate::plugin_marketplace::MarketplaceInfo>, String> {
+    flatten_join(tokio::task::spawn_blocking(crate::plugin_marketplace::list_marketplaces).await)
+}
+
+#[tauri::command]
+pub async fn plugin_install(
+    plugin_id: String,
+    scope: String,
+    cwd: String,
+) -> Result<(), String> {
+    flatten_join(
+        tokio::task::spawn_blocking(move || {
+            crate::plugin_marketplace::install(&plugin_id, &scope, &cwd)
+        })
+        .await,
+    )
+}
+
+#[tauri::command]
+pub async fn plugin_uninstall(plugin_id: String, cwd: String) -> Result<(), String> {
+    flatten_join(
+        tokio::task::spawn_blocking(move || crate::plugin_marketplace::uninstall(&plugin_id, &cwd))
+            .await,
+    )
+}
+
+#[tauri::command]
+pub async fn plugin_set_enabled(
+    plugin_id: String,
+    enabled: bool,
+    cwd: String,
+) -> Result<(), String> {
+    flatten_join(
+        tokio::task::spawn_blocking(move || {
+            if enabled {
+                crate::plugin_marketplace::enable(&plugin_id, &cwd)
+            } else {
+                crate::plugin_marketplace::disable(&plugin_id, &cwd)
+            }
+        })
+        .await,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -410,6 +410,13 @@ pub fn run() {
             ipc::get_storage_stats,
             ipc::run_blob_gc,
             ipc::migrate_legacy_attachments,
+            // Plugin marketplace
+            ipc::plugin_is_supported,
+            ipc::plugin_list_catalog,
+            ipc::plugin_list_marketplaces,
+            ipc::plugin_install,
+            ipc::plugin_uninstall,
+            ipc::plugin_set_enabled,
         ])
         .build(tauri::generate_context!())
         .expect("error while building Verun")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -417,6 +417,7 @@ pub fn run() {
             ipc::plugin_install,
             ipc::plugin_uninstall,
             ipc::plugin_set_enabled,
+            ipc::plugin_read_manifest,
         ])
         .build(tauri::generate_context!())
         .expect("error while building Verun")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ mod github_remote;
 mod ipc;
 mod lsp;
 mod markdown_skills;
+mod plugin_marketplace;
 mod policy;
 mod pty;
 mod snapshots;

--- a/src-tauri/src/markdown_skills.rs
+++ b/src-tauri/src/markdown_skills.rs
@@ -51,6 +51,25 @@ fn unquote(s: &str) -> String {
     }
 }
 
+/// Reads a single field's value from a markdown file's YAML-ish frontmatter
+/// block. Returns `None` if there's no frontmatter or the field is absent.
+fn parse_frontmatter_field(text: &str, field: &str) -> Option<String> {
+    let rest = text
+        .strip_prefix("---\n")
+        .or_else(|| text.strip_prefix("---\r\n"))?;
+    let end = rest.find("\n---")?;
+    let block = &rest[..end];
+    for line in block.lines() {
+        let Some((key, value)) = line.split_once(':') else {
+            continue;
+        };
+        if key.trim() == field {
+            return Some(unquote(value.trim()));
+        }
+    }
+    None
+}
+
 /// Enumerates `<dir>/*/SKILL.md`, returning a skill for each subdirectory that
 /// has a parseable SKILL.md. Returns empty if the directory doesn't exist.
 pub fn scan_skills_dir(dir: &Path) -> Vec<AgentSkill> {
@@ -91,9 +110,19 @@ pub fn scan_commands_dir(dir: &Path) -> Vec<AgentSkill> {
         let Ok(text) = fs::read_to_string(&path) else {
             continue;
         };
-        if let Some(skill) = parse_skill_frontmatter(&text) {
-            skills.push(skill);
-        }
+        let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        // Filename is the canonical command name (matches how Claude Code's
+        // plugin spec resolves slash commands). Frontmatter `name:` is honoured
+        // when present so user-authored commands that set it explicitly still
+        // win, but it's no longer required — most plugin command files only
+        // declare `description:` and friends.
+        let name = parse_frontmatter_field(&text, "name")
+            .filter(|n| !n.is_empty())
+            .unwrap_or_else(|| stem.to_string());
+        let description = parse_frontmatter_field(&text, "description").unwrap_or_default();
+        skills.push(AgentSkill { name, description });
     }
     skills
 }
@@ -208,12 +237,29 @@ mod tests {
             "---\nname: ship\ndescription: Ship it\n---\n",
         );
         fs::write(tmp.path().join("readme.txt"), "nope").unwrap();
+        // No frontmatter — should still register, with name from filename.
         fs::write(tmp.path().join("stray.md"), "# no frontmatter\n").unwrap();
 
         let mut cmds = scan_commands_dir(tmp.path());
         cmds.sort_by(|a, b| a.name.cmp(&b.name));
         let names: Vec<&str> = cmds.iter().map(|s| s.name.as_str()).collect();
-        assert_eq!(names, vec!["bump-version", "ship"]);
+        assert_eq!(names, vec!["bump-version", "ship", "stray"]);
+    }
+
+    #[test]
+    fn scan_commands_dir_falls_back_to_filename_when_frontmatter_omits_name() {
+        let tmp = TempDir::new().unwrap();
+        // Anthropic plugin command shape: description-only frontmatter, no name.
+        write_command(
+            tmp.path(),
+            "code-review",
+            "---\nallowed-tools: Bash(gh pr view:*)\ndescription: Code review a pull request\n---\n",
+        );
+
+        let cmds = scan_commands_dir(tmp.path());
+        assert_eq!(cmds.len(), 1);
+        assert_eq!(cmds[0].name, "code-review");
+        assert_eq!(cmds[0].description, "Code review a pull request");
     }
 
     #[test]

--- a/src-tauri/src/plugin_marketplace.rs
+++ b/src-tauri/src/plugin_marketplace.rs
@@ -99,6 +99,51 @@ pub fn list_marketplaces() -> Result<Vec<MarketplaceInfo>, String> {
     serde_json::from_str(&out).map_err(|e| format!("parse marketplaces json: {e}"))
 }
 
+pub(crate) fn install_args<'a>(plugin_id: &'a str, scope: &'a str) -> Vec<&'a str> {
+    vec!["plugin", "install", plugin_id, "--scope", scope]
+}
+
+pub(crate) fn uninstall_args(plugin_id: &str) -> Vec<&str> {
+    vec!["plugin", "uninstall", plugin_id]
+}
+
+fn run_in(cwd: &str, args: &[&str]) -> Result<(), String> {
+    let output = Command::new("claude")
+        .current_dir(cwd)
+        .args(args)
+        .output()
+        .map_err(|e| format!("failed to spawn `claude {}`: {e}", args.join(" ")))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let detail = if !stderr.is_empty() { stderr } else { stdout };
+        return Err(detail);
+    }
+    Ok(())
+}
+
+/// `claude plugin install <pluginId> --scope user|project|local`.
+/// `cwd` is the directory the install runs from — required so project /
+/// local scopes write to the right `.claude/settings.json`.
+pub fn install(plugin_id: &str, scope: &str, cwd: &str) -> Result<(), String> {
+    run_in(cwd, &install_args(plugin_id, scope))
+}
+
+/// `claude plugin uninstall <pluginId>`.
+pub fn uninstall(plugin_id: &str, cwd: &str) -> Result<(), String> {
+    run_in(cwd, &uninstall_args(plugin_id))
+}
+
+/// `claude plugin enable <pluginId>`.
+pub fn enable(plugin_id: &str, cwd: &str) -> Result<(), String> {
+    run_in(cwd, &["plugin", "enable", plugin_id])
+}
+
+/// `claude plugin disable <pluginId>`.
+pub fn disable(plugin_id: &str, cwd: &str) -> Result<(), String> {
+    run_in(cwd, &["plugin", "disable", plugin_id])
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -163,6 +208,32 @@ mod tests {
         assert_eq!(
             list[0].repo.as_deref(),
             Some("anthropics/claude-plugins-official")
+        );
+    }
+
+    #[test]
+    fn install_args_compose_correctly() {
+        assert_eq!(
+            install_args("asana@claude-plugins-official", "user"),
+            vec![
+                "plugin",
+                "install",
+                "asana@claude-plugins-official",
+                "--scope",
+                "user"
+            ]
+        );
+        assert_eq!(
+            install_args("foo@bar", "project"),
+            vec!["plugin", "install", "foo@bar", "--scope", "project"]
+        );
+    }
+
+    #[test]
+    fn uninstall_args_compose_correctly() {
+        assert_eq!(
+            uninstall_args("asana@claude-plugins-official"),
+            vec!["plugin", "uninstall", "asana@claude-plugins-official"]
         );
     }
 }

--- a/src-tauri/src/plugin_marketplace.rs
+++ b/src-tauri/src/plugin_marketplace.rs
@@ -73,6 +73,32 @@ pub fn is_supported() -> bool {
         .unwrap_or(false)
 }
 
+fn run_capture(args: &[&str]) -> Result<String, String> {
+    let output = Command::new("claude")
+        .args(args)
+        .output()
+        .map_err(|e| format!("failed to spawn `claude {}`: {e}", args.join(" ")))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let detail = if !stderr.is_empty() { stderr } else { stdout };
+        return Err(format!("`claude {}` failed: {detail}", args.join(" ")));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// `claude plugin list --json --available`
+pub fn list_catalog() -> Result<PluginCatalog, String> {
+    let out = run_capture(&["plugin", "list", "--json", "--available"])?;
+    serde_json::from_str(&out).map_err(|e| format!("parse catalog json: {e}"))
+}
+
+/// `claude plugin marketplace list --json`
+pub fn list_marketplaces() -> Result<Vec<MarketplaceInfo>, String> {
+    let out = run_capture(&["plugin", "marketplace", "list", "--json"])?;
+    serde_json::from_str(&out).map_err(|e| format!("parse marketplaces json: {e}"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -82,5 +108,61 @@ mod tests {
         // Smoke test: function returns without panicking. We can't assert
         // true/false because CI may or may not have `claude` on PATH.
         let _ = is_supported();
+    }
+
+    #[test]
+    fn parses_catalog_json() {
+        let raw = r#"{
+          "installed": [{
+            "id": "superpowers@claude-plugins-official",
+            "version": "5.0.7",
+            "scope": "user",
+            "enabled": true,
+            "installPath": "/x/y/z",
+            "installedAt": "2026-05-01T00:00:00Z",
+            "lastUpdated": "2026-05-01T00:00:00Z"
+          }],
+          "available": [{
+            "pluginId": "asana@claude-plugins-official",
+            "name": "asana",
+            "description": "Asana integration",
+            "marketplaceName": "claude-plugins-official",
+            "source": "./external_plugins/asana",
+            "installCount": 8126
+          },{
+            "pluginId": "alloydb@claude-plugins-official",
+            "name": "alloydb",
+            "description": "AlloyDB",
+            "marketplaceName": "claude-plugins-official",
+            "source": {"source":"url","url":"https://example.com/x.git"}
+          }]
+        }"#;
+        let cat: PluginCatalog = serde_json::from_str(raw).unwrap();
+        assert_eq!(cat.installed.len(), 1);
+        assert_eq!(cat.installed[0].id, "superpowers@claude-plugins-official");
+        assert!(cat.installed[0].enabled);
+        assert_eq!(cat.available.len(), 2);
+        assert_eq!(cat.available[0].name, "asana");
+        assert_eq!(cat.available[0].install_count, Some(8126));
+        assert!(cat.available[0].source.is_string());
+        assert!(cat.available[1].source.is_object());
+    }
+
+    #[test]
+    fn parses_marketplaces_json() {
+        let raw = r#"[{
+          "name": "claude-plugins-official",
+          "source": "github",
+          "repo": "anthropics/claude-plugins-official",
+          "installLocation": "/Users/x/.claude/plugins/marketplaces/claude-plugins-official"
+        }]"#;
+        let list: Vec<MarketplaceInfo> = serde_json::from_str(raw).unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].name, "claude-plugins-official");
+        assert_eq!(list[0].source.as_deref(), Some("github"));
+        assert_eq!(
+            list[0].repo.as_deref(),
+            Some("anthropics/claude-plugins-official")
+        );
     }
 }

--- a/src-tauri/src/plugin_marketplace.rs
+++ b/src-tauri/src/plugin_marketplace.rs
@@ -1,0 +1,86 @@
+//! Wraps the `claude plugin ...` CLI to power Verun's in-app plugin
+//! marketplace browser. We deliberately avoid re-implementing install
+//! mechanics — the CLI is the source of truth for what's installed,
+//! enabled, and which marketplaces are configured.
+
+use serde::{Deserialize, Serialize};
+use std::process::Command;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AvailablePlugin {
+    pub plugin_id: String,
+    pub name: String,
+    #[serde(default)]
+    pub description: String,
+    pub marketplace_name: String,
+    /// `source` may be either an object or a bare string (e.g. "./plugins/foo")
+    /// in the CLI output. Kept as `serde_json::Value` so callers can render
+    /// whatever's available without losing data.
+    #[serde(default)]
+    pub source: serde_json::Value,
+    #[serde(default)]
+    pub version: Option<String>,
+    #[serde(default)]
+    pub install_count: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InstalledPlugin {
+    /// Format: "<name>@<marketplace>"
+    pub id: String,
+    #[serde(default)]
+    pub version: Option<String>,
+    pub scope: String,
+    pub enabled: bool,
+    #[serde(default)]
+    pub install_path: Option<String>,
+    #[serde(default)]
+    pub installed_at: Option<String>,
+    #[serde(default)]
+    pub last_updated: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginCatalog {
+    pub installed: Vec<InstalledPlugin>,
+    pub available: Vec<AvailablePlugin>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MarketplaceInfo {
+    pub name: String,
+    #[serde(default)]
+    pub source: Option<String>,
+    #[serde(default)]
+    pub repo: Option<String>,
+    #[serde(default)]
+    pub url: Option<String>,
+    #[serde(default)]
+    pub install_location: Option<String>,
+}
+
+/// Returns true if `claude plugin --help` exits 0 — i.e. the installed
+/// `claude` CLI is new enough to have the plugin subcommand.
+pub fn is_supported() -> bool {
+    Command::new("claude")
+        .args(["plugin", "--help"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_supported_returns_bool() {
+        // Smoke test: function returns without panicking. We can't assert
+        // true/false because CI may or may not have `claude` on PATH.
+        let _ = is_supported();
+    }
+}

--- a/src-tauri/src/plugin_marketplace.rs
+++ b/src-tauri/src/plugin_marketplace.rs
@@ -108,9 +108,15 @@ pub(crate) fn uninstall_args(plugin_id: &str) -> Vec<&str> {
 }
 
 fn run_in(cwd: &str, args: &[&str]) -> Result<(), String> {
-    let output = Command::new("claude")
-        .current_dir(cwd)
-        .args(args)
+    let mut cmd = Command::new("claude");
+    cmd.args(args);
+    // Skip current_dir when empty — Command::current_dir("") fails with
+    // "No such file or directory" on macOS. Inheriting the app's cwd is
+    // fine for `--scope user`, the only scope reachable without a project.
+    if !cwd.is_empty() {
+        cmd.current_dir(cwd);
+    }
+    let output = cmd
         .output()
         .map_err(|e| format!("failed to spawn `claude {}`: {e}", args.join(" ")))?;
     if !output.status.success() {
@@ -142,6 +148,108 @@ pub fn enable(plugin_id: &str, cwd: &str) -> Result<(), String> {
 /// `claude plugin disable <pluginId>`.
 pub fn disable(plugin_id: &str, cwd: &str) -> Result<(), String> {
     run_in(cwd, &["plugin", "disable", plugin_id])
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginManifest {
+    /// Raw `plugin.json` parsed as a tolerant JSON value (so unknown fields
+    /// pass through to the frontend without losing data).
+    pub manifest: serde_json::Value,
+    /// Enumerated component file paths discovered on disk, relative to the
+    /// install path. Frontend uses these to render component lists without
+    /// trusting plugin.json claims.
+    pub skills: Vec<String>,
+    pub commands: Vec<String>,
+    pub agents: Vec<String>,
+    pub has_hooks: bool,
+    pub has_mcp_config: bool,
+    pub has_lsp_config: bool,
+    pub has_readme: bool,
+}
+
+/// Reads `<install_path>/.claude-plugin/plugin.json` plus enumerates the
+/// directories Claude Code recognises (skills/, commands/, agents/) so we
+/// can render real component lists for installed plugins. All filesystem
+/// errors are non-fatal — missing files just produce empty entries.
+pub fn read_manifest(install_path: &str) -> Result<PluginManifest, String> {
+    use std::path::Path;
+    let root = Path::new(install_path);
+    if !root.exists() {
+        return Err(format!("install path not found: {install_path}"));
+    }
+
+    let manifest_path = root.join(".claude-plugin").join("plugin.json");
+    let manifest: serde_json::Value = match std::fs::read_to_string(&manifest_path) {
+        Ok(text) => serde_json::from_str(&text).unwrap_or(serde_json::Value::Null),
+        Err(_) => serde_json::Value::Null,
+    };
+
+    fn list_subdirs(dir: &std::path::Path) -> Vec<String> {
+        std::fs::read_dir(dir)
+            .ok()
+            .map(|it| {
+                it.flatten()
+                    .filter(|e| e.path().is_dir())
+                    .filter_map(|e| e.file_name().into_string().ok())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    fn list_md_files(dir: &std::path::Path) -> Vec<String> {
+        std::fs::read_dir(dir)
+            .ok()
+            .map(|it| {
+                it.flatten()
+                    .filter(|e| {
+                        let p = e.path();
+                        p.is_file()
+                            && p.extension().and_then(|s| s.to_str()) == Some("md")
+                    })
+                    .filter_map(|e| {
+                        e.path()
+                            .file_stem()
+                            .and_then(|s| s.to_str())
+                            .map(|s| s.to_string())
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    let skills = {
+        let mut s = list_subdirs(&root.join("skills"));
+        s.sort();
+        s
+    };
+    let commands = {
+        let mut c = list_md_files(&root.join("commands"));
+        c.sort();
+        c
+    };
+    let agents = {
+        let mut a = list_md_files(&root.join("agents"));
+        a.sort();
+        a
+    };
+    let has_hooks = root.join("hooks").join("hooks.json").exists();
+    let has_mcp_config = root.join(".mcp.json").exists();
+    let has_lsp_config = root.join(".lsp.json").exists();
+    let has_readme = ["README.md", "readme.md", "README"]
+        .iter()
+        .any(|f| root.join(f).exists());
+
+    Ok(PluginManifest {
+        manifest,
+        skills,
+        commands,
+        agents,
+        has_hooks,
+        has_mcp_config,
+        has_lsp_config,
+        has_readme,
+    })
 }
 
 #[cfg(test)]
@@ -235,5 +343,40 @@ mod tests {
             uninstall_args("asana@claude-plugins-official"),
             vec!["plugin", "uninstall", "asana@claude-plugins-official"]
         );
+    }
+
+    #[test]
+    fn read_manifest_enumerates_components() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join(".claude-plugin")).unwrap();
+        std::fs::write(
+            root.join(".claude-plugin/plugin.json"),
+            r#"{"name":"test","description":"a plugin","version":"1.0.0"}"#,
+        )
+        .unwrap();
+        std::fs::create_dir_all(root.join("skills/foo")).unwrap();
+        std::fs::create_dir_all(root.join("skills/bar")).unwrap();
+        std::fs::create_dir_all(root.join("commands")).unwrap();
+        std::fs::write(root.join("commands/run.md"), "x").unwrap();
+        std::fs::write(root.join(".mcp.json"), "{}").unwrap();
+        std::fs::write(root.join("README.md"), "hi").unwrap();
+
+        let m = read_manifest(root.to_str().unwrap()).unwrap();
+        assert_eq!(m.manifest["name"], "test");
+        assert_eq!(m.manifest["version"], "1.0.0");
+        assert_eq!(m.skills, vec!["bar", "foo"]);
+        assert_eq!(m.commands, vec!["run"]);
+        assert!(m.agents.is_empty());
+        assert!(!m.has_hooks);
+        assert!(m.has_mcp_config);
+        assert!(!m.has_lsp_config);
+        assert!(m.has_readme);
+    }
+
+    #[test]
+    fn read_manifest_handles_missing_install_path() {
+        let result = read_manifest("/nonexistent/path/that/should/not/exist");
+        assert!(result.is_err());
     }
 }

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -8,7 +8,7 @@ import { PluginsPage } from './PluginsPage'
 import { NewTaskDialog } from './NewTaskDialog'
 import { AddProjectDialog } from './AddProjectDialog'
 import { BtsBuilderDialog } from './BtsBuilderDialog'
-import { sidebarWidth, setSidebarWidth, showSettings, setShowSettings, showArchived, setShowArchived, showPlugins, toggleTerminal, showTerminal, setShowTerminal, newTaskProjectId, setNewTaskProjectId, requestNewTaskForProject, focusOrSelectTask, pickAndAddProject, addProjectPath, setAddProjectPath, showBtsBuilder, setShowBtsBuilder, setSelectedProjectId, siblingTaskInList, nextSessionIdInTask } from '../store/ui'
+import { sidebarWidth, setSidebarWidth, showSettings, setShowSettings, showArchived, setShowArchived, toggleTerminal, showTerminal, setShowTerminal, newTaskProjectId, setNewTaskProjectId, requestNewTaskForProject, focusOrSelectTask, pickAndAddProject, addProjectPath, setAddProjectPath, showBtsBuilder, setShowBtsBuilder, setSelectedProjectId, siblingTaskInList, nextSessionIdInTask } from '../store/ui'
 import * as ipc from '../lib/ipc'
 import { spawnTerminal, focusActiveTerminal, terminalsForTask, activeTerminalId, setActiveTerminalForTask, isStartCommandRunning, spawnStartCommand, stopStartCommand, hydrateTerminalsForTask } from '../store/terminals'
 import { activeTasksForProject, taskById } from '../store/tasks'
@@ -348,12 +348,10 @@ export const Layout: Component = () => {
         <Show when={showArchived() && !showSettings()}>
           <ArchivedPage />
         </Show>
-        <Show when={showPlugins() && !showSettings() && !showArchived()}>
-          <PluginsPage />
-        </Show>
-        <Show when={!showSettings() && !showArchived() && !showPlugins()}>
+        <Show when={!showSettings() && !showArchived()}>
           <TaskPanel />
         </Show>
+        <PluginsPage />
       </div>
 
       <NewTaskDialog

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -4,10 +4,11 @@ import { Sidebar } from './Sidebar'
 import { TaskPanel } from './TaskPanel'
 import { SettingsPage, selectSettingsSection, setSettingsSaveRequested } from './SettingsPage'
 import { ArchivedPage } from './ArchivedPage'
+import { PluginsPage } from './PluginsPage'
 import { NewTaskDialog } from './NewTaskDialog'
 import { AddProjectDialog } from './AddProjectDialog'
 import { BtsBuilderDialog } from './BtsBuilderDialog'
-import { sidebarWidth, setSidebarWidth, showSettings, setShowSettings, showArchived, setShowArchived, toggleTerminal, showTerminal, setShowTerminal, newTaskProjectId, setNewTaskProjectId, requestNewTaskForProject, focusOrSelectTask, pickAndAddProject, addProjectPath, setAddProjectPath, showBtsBuilder, setShowBtsBuilder, setSelectedProjectId, siblingTaskInList, nextSessionIdInTask } from '../store/ui'
+import { sidebarWidth, setSidebarWidth, showSettings, setShowSettings, showArchived, setShowArchived, showPlugins, toggleTerminal, showTerminal, setShowTerminal, newTaskProjectId, setNewTaskProjectId, requestNewTaskForProject, focusOrSelectTask, pickAndAddProject, addProjectPath, setAddProjectPath, showBtsBuilder, setShowBtsBuilder, setSelectedProjectId, siblingTaskInList, nextSessionIdInTask } from '../store/ui'
 import * as ipc from '../lib/ipc'
 import { spawnTerminal, focusActiveTerminal, terminalsForTask, activeTerminalId, setActiveTerminalForTask, isStartCommandRunning, spawnStartCommand, stopStartCommand, hydrateTerminalsForTask } from '../store/terminals'
 import { activeTasksForProject, taskById } from '../store/tasks'
@@ -347,7 +348,10 @@ export const Layout: Component = () => {
         <Show when={showArchived() && !showSettings()}>
           <ArchivedPage />
         </Show>
-        <Show when={!showSettings() && !showArchived()}>
+        <Show when={showPlugins() && !showSettings() && !showArchived()}>
+          <PluginsPage />
+        </Show>
+        <Show when={!showSettings() && !showArchived() && !showPlugins()}>
           <TaskPanel />
         </Show>
       </div>

--- a/src/components/PluginCard.test.tsx
+++ b/src/components/PluginCard.test.tsx
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   isPending: vi.fn(() => false),
   installPlugin: vi.fn().mockResolvedValue(undefined),
   uninstallPlugin: vi.fn().mockResolvedValue(undefined),
+  setSelectedPluginId: vi.fn(),
 }))
 
 vi.mock('../store/plugins', () => mocks)
@@ -35,7 +36,7 @@ describe('PluginCard', () => {
     const { getByText } = render(() => <PluginCard plugin={sample} cwd="/tmp" allowProjectScope={true} showMarketplace={true} />)
     expect(getByText('asana')).toBeTruthy()
     expect(getByText(/Asana integration/)).toBeTruthy()
-    expect(getByText(/8,126/)).toBeTruthy()
+    expect(getByText(/8\.1K/)).toBeTruthy()
   })
 
   test('clicking Install calls installPlugin with default scope user', () => {

--- a/src/components/PluginCard.test.tsx
+++ b/src/components/PluginCard.test.tsx
@@ -32,26 +32,31 @@ describe('PluginCard', () => {
   })
 
   test('renders name, description, and install count', () => {
-    const { getByText } = render(() => <PluginCard plugin={sample} cwd="/tmp" allowProjectScope={true} />)
+    const { getByText } = render(() => <PluginCard plugin={sample} cwd="/tmp" allowProjectScope={true} showMarketplace={true} />)
     expect(getByText('asana')).toBeTruthy()
     expect(getByText(/Asana integration/)).toBeTruthy()
     expect(getByText(/8,126/)).toBeTruthy()
   })
 
   test('clicking Install calls installPlugin with default scope user', () => {
-    const { getByText } = render(() => <PluginCard plugin={sample} cwd="/tmp" allowProjectScope={true} />)
+    const { getByText } = render(() => <PluginCard plugin={sample} cwd="/tmp" allowProjectScope={true} showMarketplace={true} />)
     fireEvent.click(getByText('Install'))
     expect(mocks.installPlugin).toHaveBeenCalledWith('asana@claude-plugins-official', 'user', '/tmp')
   })
 
   test('shows Uninstall when already installed', () => {
     mocks.isInstalled.mockReturnValue(true)
-    const { getByText } = render(() => <PluginCard plugin={sample} cwd="/tmp" allowProjectScope={true} />)
+    const { getByText } = render(() => <PluginCard plugin={sample} cwd="/tmp" allowProjectScope={true} showMarketplace={true} />)
     expect(getByText('Uninstall')).toBeTruthy()
   })
 
   test('hides scope picker when allowProjectScope is false', () => {
-    const { queryByTitle } = render(() => <PluginCard plugin={sample} cwd="/tmp" allowProjectScope={false} />)
+    const { queryByTitle } = render(() => <PluginCard plugin={sample} cwd="/tmp" allowProjectScope={false} showMarketplace={true} />)
     expect(queryByTitle('Install scope')).toBeNull()
+  })
+
+  test('hides marketplace badge when showMarketplace is false', () => {
+    const { queryByText } = render(() => <PluginCard plugin={sample} cwd="/tmp" allowProjectScope={true} showMarketplace={false} />)
+    expect(queryByText('claude-plugins-official')).toBeNull()
   })
 })

--- a/src/components/PluginCard.test.tsx
+++ b/src/components/PluginCard.test.tsx
@@ -1,0 +1,57 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { render, fireEvent, cleanup } from '@solidjs/testing-library'
+
+const mocks = vi.hoisted(() => ({
+  isInstalled: vi.fn(() => false),
+  isPending: vi.fn(() => false),
+  installPlugin: vi.fn().mockResolvedValue(undefined),
+  uninstallPlugin: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('../store/plugins', () => mocks)
+
+import { PluginCard } from './PluginCard'
+import type { AvailablePlugin } from '../types'
+
+const sample: AvailablePlugin = {
+  pluginId: 'asana@claude-plugins-official',
+  name: 'asana',
+  description: 'Asana integration',
+  marketplaceName: 'claude-plugins-official',
+  source: './external_plugins/asana',
+  installCount: 8126,
+}
+
+describe('PluginCard', () => {
+  beforeEach(() => {
+    cleanup()
+    mocks.isInstalled.mockReturnValue(false)
+    mocks.isPending.mockReturnValue(false)
+    mocks.installPlugin.mockClear()
+    mocks.uninstallPlugin.mockClear()
+  })
+
+  test('renders name, description, and install count', () => {
+    const { getByText } = render(() => <PluginCard plugin={sample} cwd="/tmp" allowProjectScope={true} />)
+    expect(getByText('asana')).toBeTruthy()
+    expect(getByText(/Asana integration/)).toBeTruthy()
+    expect(getByText(/8,126/)).toBeTruthy()
+  })
+
+  test('clicking Install calls installPlugin with default scope user', () => {
+    const { getByText } = render(() => <PluginCard plugin={sample} cwd="/tmp" allowProjectScope={true} />)
+    fireEvent.click(getByText('Install'))
+    expect(mocks.installPlugin).toHaveBeenCalledWith('asana@claude-plugins-official', 'user', '/tmp')
+  })
+
+  test('shows Uninstall when already installed', () => {
+    mocks.isInstalled.mockReturnValue(true)
+    const { getByText } = render(() => <PluginCard plugin={sample} cwd="/tmp" allowProjectScope={true} />)
+    expect(getByText('Uninstall')).toBeTruthy()
+  })
+
+  test('hides scope picker when allowProjectScope is false', () => {
+    const { queryByTitle } = render(() => <PluginCard plugin={sample} cwd="/tmp" allowProjectScope={false} />)
+    expect(queryByTitle('Install scope')).toBeNull()
+  })
+})

--- a/src/components/PluginCard.tsx
+++ b/src/components/PluginCard.tsx
@@ -26,7 +26,7 @@ export const PluginCard: Component<Props> = (props) => {
   return (
     <div class="ring-1 ring-white/8 rounded-lg p-4 flex flex-col gap-1 bg-white/2 hover:bg-white/4 transition-colors">
       <div class="flex items-baseline justify-between gap-3">
-        <h3 class="font-medium truncate min-w-0 flex-1 leading-tight">{props.plugin.name}</h3>
+        <h3 class="font-medium truncate min-w-0 flex-1 leading-tight m-0">{props.plugin.name}</h3>
         <div class="flex flex-col items-end gap-1 shrink-0 text-[11px] text-text-dim">
           <Show when={props.plugin.installCount != null}>
             <span>{props.plugin.installCount!.toLocaleString()} installs</span>

--- a/src/components/PluginCard.tsx
+++ b/src/components/PluginCard.tsx
@@ -24,9 +24,9 @@ export const PluginCard: Component<Props> = (props) => {
     props.allowProjectScope ? ['user', 'project', 'local'] : ['user']
 
   return (
-    <div class="ring-1 ring-white/8 rounded-lg p-4 flex flex-col gap-3 bg-white/2 hover:bg-white/4 transition-colors">
-      <div class="flex items-start justify-between gap-3">
-        <h3 class="font-medium truncate min-w-0 flex-1">{props.plugin.name}</h3>
+    <div class="ring-1 ring-white/8 rounded-lg p-4 flex flex-col gap-2 bg-white/2 hover:bg-white/4 transition-colors">
+      <div class="flex items-baseline justify-between gap-3">
+        <h3 class="font-medium truncate min-w-0 flex-1 leading-tight">{props.plugin.name}</h3>
         <div class="flex flex-col items-end gap-1 shrink-0 text-[11px] text-text-dim">
           <Show when={props.plugin.installCount != null}>
             <span>{props.plugin.installCount!.toLocaleString()} installs</span>

--- a/src/components/PluginCard.tsx
+++ b/src/components/PluginCard.tsx
@@ -56,7 +56,7 @@ export const PluginCard: Component<Props> = (props) => {
           }
         >
           <button
-            class="flex-1 px-3 py-1.5 rounded bg-accent text-white hover:bg-accent/90 text-sm flex items-center justify-center gap-1.5 disabled:opacity-50"
+            class="flex-1 px-3 py-1.5 rounded bg-accent text-accent-foreground hover:bg-accent-hover text-sm flex items-center justify-center gap-1.5 disabled:opacity-50"
             disabled={pending()}
             onClick={() => installPlugin(props.plugin.pluginId, scope(), props.cwd)}
           >

--- a/src/components/PluginCard.tsx
+++ b/src/components/PluginCard.tsx
@@ -1,0 +1,91 @@
+import { Component, Show, createSignal, For } from 'solid-js'
+import { Loader2, Download, Trash2, ChevronDown } from 'lucide-solid'
+import type { AvailablePlugin, PluginScope } from '../types'
+import { installPlugin, uninstallPlugin, isInstalled, isPending } from '../store/plugins'
+
+interface Props {
+  plugin: AvailablePlugin
+  cwd: string
+  /** When false, only `user` scope is offered (no project context). */
+  allowProjectScope: boolean
+}
+
+export const PluginCard: Component<Props> = (props) => {
+  const [scope, setScope] = createSignal<PluginScope>('user')
+  const [scopeOpen, setScopeOpen] = createSignal(false)
+
+  const installed = () => isInstalled(props.plugin.pluginId)
+  const pending = () => isPending(props.plugin.pluginId)
+  const scopes = (): PluginScope[] =>
+    props.allowProjectScope ? ['user', 'project', 'local'] : ['user']
+
+  return (
+    <div class="ring-1 ring-white/8 rounded-lg p-4 flex flex-col gap-3 bg-bg">
+      <div class="flex items-start justify-between gap-3">
+        <div class="min-w-0 flex-1">
+          <h3 class="font-medium truncate">{props.plugin.name}</h3>
+          <p class="text-xs text-fg/50 truncate">{props.plugin.marketplaceName}</p>
+        </div>
+        <Show when={props.plugin.installCount != null}>
+          <span class="text-xs text-fg/60 shrink-0">
+            {props.plugin.installCount!.toLocaleString()} installs
+          </span>
+        </Show>
+      </div>
+      <p class="text-sm text-fg/80 line-clamp-3">{props.plugin.description}</p>
+      <div class="flex items-center gap-2 mt-auto">
+        <Show
+          when={!installed()}
+          fallback={
+            <button
+              class="flex-1 px-3 py-1.5 rounded ring-1 ring-white/10 hover:bg-white/5 text-sm flex items-center justify-center gap-1.5"
+              disabled={pending()}
+              onClick={() => uninstallPlugin(props.plugin.pluginId, props.cwd)}
+            >
+              <Show when={pending()} fallback={<Trash2 class="w-3.5 h-3.5" />}>
+                <Loader2 class="w-3.5 h-3.5 animate-spin" />
+              </Show>
+              Uninstall
+            </button>
+          }
+        >
+          <button
+            class="flex-1 px-3 py-1.5 rounded bg-accent text-white hover:bg-accent/90 text-sm flex items-center justify-center gap-1.5 disabled:opacity-50"
+            disabled={pending()}
+            onClick={() => installPlugin(props.plugin.pluginId, scope(), props.cwd)}
+          >
+            <Show when={pending()} fallback={<Download class="w-3.5 h-3.5" />}>
+              <Loader2 class="w-3.5 h-3.5 animate-spin" />
+            </Show>
+            Install
+          </button>
+          <Show when={props.allowProjectScope}>
+            <div class="relative">
+              <button
+                class="px-2 py-1.5 rounded ring-1 ring-white/10 hover:bg-white/5 text-xs flex items-center gap-1"
+                onClick={() => setScopeOpen(o => !o)}
+                title="Install scope"
+              >
+                {scope()} <ChevronDown class="w-3 h-3" />
+              </button>
+              <Show when={scopeOpen()}>
+                <div class="absolute right-0 top-full mt-1 ring-1 ring-white/10 rounded bg-bg z-10 min-w-24">
+                  <For each={scopes()}>
+                    {s => (
+                      <button
+                        class="block w-full px-3 py-1.5 text-left text-xs hover:bg-white/5"
+                        onClick={() => { setScope(s); setScopeOpen(false) }}
+                      >
+                        {s}
+                      </button>
+                    )}
+                  </For>
+                </div>
+              </Show>
+            </div>
+          </Show>
+        </Show>
+      </div>
+    </div>
+  )
+}

--- a/src/components/PluginCard.tsx
+++ b/src/components/PluginCard.tsx
@@ -1,16 +1,17 @@
-import { Component, Show, createSignal, For } from 'solid-js'
-import { Loader2, Download, Trash2, ChevronDown } from 'lucide-solid'
+import { Component, Show, createSignal, For, createMemo } from 'solid-js'
+import { Loader2, Download, Trash2, ChevronDown, Check } from 'lucide-solid'
 import type { AvailablePlugin, PluginScope } from '../types'
-import { installPlugin, uninstallPlugin, isInstalled, isPending } from '../store/plugins'
+import { installPlugin, uninstallPlugin, isInstalled, isPending, setSelectedPluginId } from '../store/plugins'
+import { detectPluginType, pluginTypeLabel, formatCompactCount } from '../lib/pluginMeta'
 
 interface Props {
   plugin: AvailablePlugin
   cwd: string
   /** When false, only `user` scope is offered (no project context). */
   allowProjectScope: boolean
-  /** When true, render the marketplace name as a small badge near the install
-   * count. When false (single marketplace configured), it's hidden — every
-   * card would otherwise repeat the same string. */
+  /** When true, render the marketplace name in the footer row. When false
+   * (single marketplace configured), it's hidden — every card would
+   * otherwise repeat the same string. */
   showMarketplace: boolean
 }
 
@@ -20,77 +21,110 @@ export const PluginCard: Component<Props> = (props) => {
 
   const installed = () => isInstalled(props.plugin.pluginId)
   const pending = () => isPending(props.plugin.pluginId)
+  const type = createMemo(() => detectPluginType(props.plugin.description))
   const scopes = (): PluginScope[] =>
     props.allowProjectScope ? ['user', 'project', 'local'] : ['user']
 
   return (
-    <div class="ring-1 ring-white/8 rounded-lg p-4 flex flex-col gap-1 bg-white/2 hover:bg-white/4 transition-colors">
-      <div class="flex items-baseline justify-between gap-3">
-        <h3 class="font-medium truncate min-w-0 flex-1 leading-tight m-0">{props.plugin.name}</h3>
-        <div class="flex flex-col items-end gap-1 shrink-0 text-[11px] text-text-dim">
-          <Show when={props.plugin.installCount != null}>
-            <span>{props.plugin.installCount!.toLocaleString()} installs</span>
-          </Show>
-          <Show when={props.showMarketplace}>
-            <span class="px-1.5 py-0.5 rounded ring-1 ring-white/10 text-[10px]">
-              {props.plugin.marketplaceName}
-            </span>
-          </Show>
-        </div>
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={() => setSelectedPluginId(props.plugin.pluginId)}
+      onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setSelectedPluginId(props.plugin.pluginId) } }}
+      class={`group relative rounded-lg p-3 flex flex-col gap-1.5 transition-colors ring-1 cursor-pointer ${
+        installed()
+          ? 'ring-accent/25 bg-accent-muted/40 hover:bg-accent-muted/60'
+          : 'ring-outline/8 bg-outline/2 hover:bg-outline/4'
+      }`}
+    >
+      {/* Header: title + count */}
+      <div class="flex items-baseline justify-between gap-2">
+        <h3 class="m-0 truncate text-[13px] font-semibold leading-tight min-w-0 flex-1 text-text-primary">
+          {props.plugin.name}
+        </h3>
+        <Show when={props.plugin.installCount != null}>
+          <span class="text-[10px] text-text-dim tabular-nums shrink-0">
+            {formatCompactCount(props.plugin.installCount!)}
+          </span>
+        </Show>
       </div>
-      <p class="text-sm text-text-secondary line-clamp-4">{props.plugin.description}</p>
-      <div class="flex items-center gap-2 mt-auto">
-        <Show
-          when={!installed()}
-          fallback={
+
+      {/* Type chip — only when we can identify it confidently */}
+      <Show when={type()}>
+        <div>
+          <span class="text-[9px] uppercase tracking-wider font-semibold text-text-secondary px-1.5 py-0.5 rounded ring-1 ring-outline/10">
+            {pluginTypeLabel(type()!)}
+          </span>
+        </div>
+      </Show>
+
+      {/* Description */}
+      <p class="m-0 text-[11px] text-text-dim line-clamp-3 leading-relaxed">
+        {props.plugin.description}
+      </p>
+
+      {/* Footer: marketplace (left) + status/action (right) */}
+      <div class="flex items-center justify-between gap-2 mt-auto pt-1.5 min-h-[28px]">
+        <Show when={props.showMarketplace}>
+          <span class="text-[10px] text-text-dim truncate">
+            {props.plugin.marketplaceName}
+          </span>
+        </Show>
+        <div class="ml-auto flex items-center gap-1.5 shrink-0">
+          <Show when={installed()}>
+            {/* Resting: subtle 'Installed' indicator. Hover swaps in Uninstall. */}
+            <span class="text-[10px] text-accent flex items-center gap-1 group-hover:hidden">
+              <Check class="w-3 h-3" /> Installed
+            </span>
             <button
-              class="flex-1 px-3 py-1.5 rounded ring-1 ring-white/10 hover:bg-white/5 text-sm flex items-center justify-center gap-1.5"
+              class="hidden group-hover:flex px-2 py-0.5 rounded ring-1 ring-outline/10 hover:bg-outline/5 text-[10px] items-center gap-1 disabled:opacity-50"
               disabled={pending()}
-              onClick={() => uninstallPlugin(props.plugin.pluginId, props.cwd)}
+              onClick={(e) => { e.stopPropagation(); uninstallPlugin(props.plugin.pluginId, props.cwd) }}
             >
-              <Show when={pending()} fallback={<Trash2 class="w-3.5 h-3.5" />}>
-                <Loader2 class="w-3.5 h-3.5 animate-spin" />
+              <Show when={pending()} fallback={<Trash2 class="w-3 h-3" />}>
+                <Loader2 class="w-3 h-3 animate-spin" />
               </Show>
               Uninstall
             </button>
-          }
-        >
-          <button
-            class="flex-1 px-3 py-1.5 rounded bg-accent text-accent-foreground hover:bg-accent-hover text-sm flex items-center justify-center gap-1.5 disabled:opacity-50"
-            disabled={pending()}
-            onClick={() => installPlugin(props.plugin.pluginId, scope(), props.cwd)}
-          >
-            <Show when={pending()} fallback={<Download class="w-3.5 h-3.5" />}>
-              <Loader2 class="w-3.5 h-3.5 animate-spin" />
-            </Show>
-            Install
-          </button>
-          <Show when={props.allowProjectScope}>
-            <div class="relative">
-              <button
-                class="px-2 py-1.5 rounded ring-1 ring-white/10 hover:bg-white/5 text-xs flex items-center gap-1"
-                onClick={() => setScopeOpen(o => !o)}
-                title="Install scope"
-              >
-                {scope()} <ChevronDown class="w-3 h-3" />
-              </button>
-              <Show when={scopeOpen()}>
-                <div class="absolute right-0 top-full mt-1 ring-1 ring-white/10 rounded bg-surface-2 z-10 min-w-24">
-                  <For each={scopes()}>
-                    {s => (
-                      <button
-                        class="block w-full px-3 py-1.5 text-left text-xs hover:bg-white/5"
-                        onClick={() => { setScope(s); setScopeOpen(false) }}
-                      >
-                        {s}
-                      </button>
-                    )}
-                  </For>
-                </div>
-              </Show>
-            </div>
           </Show>
-        </Show>
+          <Show when={!installed()}>
+            <button
+              class="px-2 py-0.5 rounded ring-1 ring-accent/30 bg-accent-muted text-accent hover:bg-accent/15 text-[10px] flex items-center gap-1 disabled:opacity-50"
+              disabled={pending()}
+              onClick={(e) => { e.stopPropagation(); installPlugin(props.plugin.pluginId, scope(), props.cwd) }}
+            >
+              <Show when={pending()} fallback={<Download class="w-3 h-3" />}>
+                <Loader2 class="w-3 h-3 animate-spin" />
+              </Show>
+              Install
+            </button>
+            <Show when={props.allowProjectScope}>
+              <div class="relative">
+                <button
+                  class="px-1.5 py-0.5 rounded ring-1 ring-outline/10 hover:bg-outline/5 text-[10px] flex items-center gap-0.5"
+                  onClick={(e) => { e.stopPropagation(); setScopeOpen(o => !o) }}
+                  title="Install scope"
+                >
+                  {scope()} <ChevronDown class="w-2.5 h-2.5" />
+                </button>
+                <Show when={scopeOpen()}>
+                  <div class="absolute right-0 bottom-full mb-1 ring-1 ring-outline/10 rounded bg-surface-2 z-10 min-w-20 shadow-lg">
+                    <For each={scopes()}>
+                      {s => (
+                        <button
+                          class="block w-full px-2 py-1 text-left text-[10px] hover:bg-outline/5"
+                          onClick={(e) => { e.stopPropagation(); setScope(s); setScopeOpen(false) }}
+                        >
+                          {s}
+                        </button>
+                      )}
+                    </For>
+                  </div>
+                </Show>
+              </div>
+            </Show>
+          </Show>
+        </div>
       </div>
     </div>
   )

--- a/src/components/PluginCard.tsx
+++ b/src/components/PluginCard.tsx
@@ -24,7 +24,7 @@ export const PluginCard: Component<Props> = (props) => {
     props.allowProjectScope ? ['user', 'project', 'local'] : ['user']
 
   return (
-    <div class="ring-1 ring-white/8 rounded-lg p-4 flex flex-col gap-2 bg-white/2 hover:bg-white/4 transition-colors">
+    <div class="ring-1 ring-white/8 rounded-lg p-4 flex flex-col gap-1 bg-white/2 hover:bg-white/4 transition-colors">
       <div class="flex items-baseline justify-between gap-3">
         <h3 class="font-medium truncate min-w-0 flex-1 leading-tight">{props.plugin.name}</h3>
         <div class="flex flex-col items-end gap-1 shrink-0 text-[11px] text-text-dim">

--- a/src/components/PluginCard.tsx
+++ b/src/components/PluginCard.tsx
@@ -8,6 +8,10 @@ interface Props {
   cwd: string
   /** When false, only `user` scope is offered (no project context). */
   allowProjectScope: boolean
+  /** When true, render the marketplace name as a small badge near the install
+   * count. When false (single marketplace configured), it's hidden — every
+   * card would otherwise repeat the same string. */
+  showMarketplace: boolean
 }
 
 export const PluginCard: Component<Props> = (props) => {
@@ -20,19 +24,21 @@ export const PluginCard: Component<Props> = (props) => {
     props.allowProjectScope ? ['user', 'project', 'local'] : ['user']
 
   return (
-    <div class="ring-1 ring-white/8 rounded-lg p-4 flex flex-col gap-3 bg-bg">
+    <div class="ring-1 ring-white/8 rounded-lg p-4 flex flex-col gap-3 bg-white/2 hover:bg-white/4 transition-colors">
       <div class="flex items-start justify-between gap-3">
-        <div class="min-w-0 flex-1">
-          <h3 class="font-medium truncate">{props.plugin.name}</h3>
-          <p class="text-xs text-fg/50 truncate">{props.plugin.marketplaceName}</p>
+        <h3 class="font-medium truncate min-w-0 flex-1">{props.plugin.name}</h3>
+        <div class="flex flex-col items-end gap-1 shrink-0 text-[11px] text-text-dim">
+          <Show when={props.plugin.installCount != null}>
+            <span>{props.plugin.installCount!.toLocaleString()} installs</span>
+          </Show>
+          <Show when={props.showMarketplace}>
+            <span class="px-1.5 py-0.5 rounded ring-1 ring-white/10 text-[10px]">
+              {props.plugin.marketplaceName}
+            </span>
+          </Show>
         </div>
-        <Show when={props.plugin.installCount != null}>
-          <span class="text-xs text-fg/60 shrink-0">
-            {props.plugin.installCount!.toLocaleString()} installs
-          </span>
-        </Show>
       </div>
-      <p class="text-sm text-fg/80 line-clamp-3">{props.plugin.description}</p>
+      <p class="text-sm text-text-secondary line-clamp-4">{props.plugin.description}</p>
       <div class="flex items-center gap-2 mt-auto">
         <Show
           when={!installed()}
@@ -69,7 +75,7 @@ export const PluginCard: Component<Props> = (props) => {
                 {scope()} <ChevronDown class="w-3 h-3" />
               </button>
               <Show when={scopeOpen()}>
-                <div class="absolute right-0 top-full mt-1 ring-1 ring-white/10 rounded bg-bg z-10 min-w-24">
+                <div class="absolute right-0 top-full mt-1 ring-1 ring-white/10 rounded bg-surface-2 z-10 min-w-24">
                   <For each={scopes()}>
                     {s => (
                       <button

--- a/src/components/PluginDetailDrawer.tsx
+++ b/src/components/PluginDetailDrawer.tsx
@@ -1,0 +1,395 @@
+import { Component, Show, For, createMemo, createResource, createEffect, createSignal, onCleanup } from 'solid-js'
+import { X, ExternalLink, Download, Trash2, Loader2, Check } from 'lucide-solid'
+import { openUrl } from '@tauri-apps/plugin-opener'
+import type { AvailablePlugin, PluginScope } from '../types'
+import {
+  selectedPluginId, setSelectedPluginId,
+  catalog, marketplaces,
+  isInstalled, isPending, installedPluginById,
+  installPlugin, uninstallPlugin,
+} from '../store/plugins'
+import { selectedProjectId } from '../store/ui'
+import { projects } from '../store/projects'
+import * as ipc from '../lib/ipc'
+import { detectPluginType, pluginTypeLabel, formatCompactCount } from '../lib/pluginMeta'
+
+/** Best-effort source URL extraction. The CLI returns either a structured
+ * object or a bare string; we surface a clickable URL whenever we can.
+ * For plugins from Anthropic's official marketplace we link to the
+ * Anthropic-hosted plugin page instead of the underlying repo. */
+function sourceUrl(plugin: AvailablePlugin): string | null {
+  if (plugin.marketplaceName === 'claude-plugins-official') {
+    return `https://claude.com/plugins/${encodeURIComponent(plugin.name)}`
+  }
+  const s = plugin.source as unknown
+  if (!s) return null
+  if (typeof s === 'string') {
+    if (s.startsWith('http')) return s
+    const mp = marketplaces.find(m => m.name === plugin.marketplaceName)
+    if (mp?.url) return mp.url
+    if (mp?.repo) return `https://github.com/${mp.repo}`
+    return null
+  }
+  if (typeof s === 'object') {
+    const o = s as Record<string, unknown>
+    if (typeof o.url === 'string') return o.url
+    if (typeof o.repo === 'string') return `https://github.com/${o.repo}`
+  }
+  return null
+}
+
+export const PluginDetailDrawer: Component = () => {
+  const plugin = createMemo<AvailablePlugin | null>(() => {
+    const id = selectedPluginId()
+    if (!id) return null
+    const found = catalog.available.find(p => p.pluginId === id)
+    if (found) return found
+    // Synthesize from installed if not in available (matches PluginsPage behaviour).
+    const inst = catalog.installed.find(p => p.id === id)
+    if (!inst) return null
+    const at = inst.id.lastIndexOf('@')
+    return {
+      pluginId: inst.id,
+      name: at >= 0 ? inst.id.slice(0, at) : inst.id,
+      description: '',
+      marketplaceName: at >= 0 ? inst.id.slice(at + 1) : '',
+      source: '',
+      version: inst.version,
+    }
+  })
+
+  // Keep the last plugin around for ~200ms after close so the drawer can
+  // animate out with its content still visible. Without this, content would
+  // disappear instantly and the empty drawer would slide right.
+  const [displayPlugin, setDisplayPlugin] = createSignal<AvailablePlugin | null>(null)
+  createEffect(() => {
+    const p = plugin()
+    if (p) {
+      setDisplayPlugin(p)
+    } else {
+      const t = setTimeout(() => setDisplayPlugin(null), 200)
+      onCleanup(() => clearTimeout(t))
+    }
+  })
+  const isOpen = () => plugin() != null
+
+  const installedRecord = createMemo(() => {
+    const p = plugin()
+    return p ? installedPluginById(p.pluginId) : undefined
+  })
+
+  // Lazy-load the manifest only for installed plugins (we have the install path).
+  const [manifest] = createResource(installedRecord, async (rec) => {
+    if (!rec?.installPath) return null
+    try { return await ipc.pluginReadManifest(rec.installPath) } catch { return null }
+  })
+
+  const cwd = createMemo(() => {
+    const pid = selectedProjectId()
+    if (pid) {
+      const proj = projects.find(p => p.id === pid)
+      if (proj) return proj.repoPath
+    }
+    return ''
+  })
+  const allowProjectScope = () => selectedProjectId() != null
+
+  const close = () => setSelectedPluginId(null)
+
+  // Close on Escape
+  createEffect(() => {
+    if (!plugin()) return
+    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') close() }
+    window.addEventListener('keydown', handler)
+    onCleanup(() => window.removeEventListener('keydown', handler))
+  })
+
+  const type = createMemo(() => {
+    const p = plugin()
+    return p ? detectPluginType(p.description) : null
+  })
+
+  const installed = () => {
+    const p = plugin()
+    return p ? isInstalled(p.pluginId) : false
+  }
+  const pending = () => {
+    const p = plugin()
+    return p ? isPending(p.pluginId) : false
+  }
+
+  const handleInstall = (scope: PluginScope) => {
+    const p = plugin()
+    if (!p) return
+    void installPlugin(p.pluginId, scope, cwd())
+  }
+  const handleUninstall = () => {
+    const p = plugin()
+    if (!p) return
+    void uninstallPlugin(p.pluginId, cwd())
+  }
+
+  return (
+    <>
+      {/* Backdrop — always mounted, fades via opacity */}
+      <div
+        class={`fixed inset-0 z-50 bg-black/40 transition-opacity duration-200 ${
+          isOpen() ? 'opacity-100' : 'opacity-0 pointer-events-none'
+        }`}
+        onClick={close}
+      />
+      {/* Sheet — always mounted, slides via transform */}
+      <aside
+        class={`fixed right-0 top-0 bottom-0 z-50 w-[min(92vw,28rem)] bg-surface-2 border-l border-border shadow-2xl flex flex-col transform transition-transform duration-200 ease-out ${
+          isOpen() ? 'translate-x-0' : 'translate-x-full pointer-events-none'
+        }`}
+      >
+        <Show when={displayPlugin()}>
+          {(p) => (
+            <>
+            {/* Header */}
+            <div class="flex items-start gap-3 px-4 py-3 border-b border-border">
+              <div class="min-w-0 flex-1">
+                <div class="flex items-baseline gap-2">
+                  <h2 class="m-0 text-base font-semibold text-text-primary truncate">
+                    {p().name}
+                  </h2>
+                  <Show when={p().version}>
+                    <span class="text-[11px] text-text-dim tabular-nums shrink-0">v{p().version}</span>
+                  </Show>
+                </div>
+                <div class="flex items-center gap-2 mt-0.5">
+                  <Show when={type()}>
+                    <span class="text-[9px] uppercase tracking-wider font-semibold text-text-secondary px-1.5 py-0.5 rounded ring-1 ring-outline/10">
+                      {pluginTypeLabel(type()!)}
+                    </span>
+                  </Show>
+                  <Show when={p().installCount != null}>
+                    <span class="text-[11px] text-text-dim tabular-nums">{formatCompactCount(p().installCount!)} installs</span>
+                  </Show>
+                </div>
+              </div>
+              <button
+                class="p-1 rounded text-text-dim hover:text-text-secondary hover:bg-surface-3 transition-colors shrink-0"
+                onClick={close}
+                aria-label="Close"
+              >
+                <X class="w-4 h-4" />
+              </button>
+            </div>
+
+            {/* Body */}
+            <div class="flex-1 overflow-y-auto px-4 py-3 flex flex-col gap-4">
+              <Show when={p().description}>
+                <p class="m-0 text-[13px] text-text-secondary leading-relaxed whitespace-pre-wrap">
+                  {p().description}
+                </p>
+              </Show>
+
+              {/* Metadata */}
+              <dl class="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1.5 text-[12px]">
+                <dt class="text-text-dim">Marketplace</dt>
+                <dd class="m-0 text-text-secondary truncate">{p().marketplaceName || '—'}</dd>
+
+                <Show when={installedRecord()}>
+                  {(rec) => (
+                    <>
+                      <dt class="text-text-dim">Status</dt>
+                      <dd class="m-0 text-accent flex items-center gap-1">
+                        <Check class="w-3 h-3" /> Installed{rec().enabled ? '' : ' (disabled)'}
+                      </dd>
+                      <dt class="text-text-dim">Scope</dt>
+                      <dd class="m-0 text-text-secondary">{rec().scope}</dd>
+                      <Show when={rec().installedAt}>
+                        <dt class="text-text-dim">Installed</dt>
+                        <dd class="m-0 text-text-secondary">{new Date(rec().installedAt!).toLocaleString()}</dd>
+                      </Show>
+                      <Show when={rec().installPath}>
+                        <dt class="text-text-dim">Path</dt>
+                        <dd class="m-0 text-text-dim truncate" title={rec().installPath}>
+                          <code class="text-[11px]">{rec().installPath}</code>
+                        </dd>
+                      </Show>
+                    </>
+                  )}
+                </Show>
+              </dl>
+
+              {/* Components — installed only */}
+              <Show when={manifest()}>
+                {(m) => (
+                  <Show when={
+                    m().skills.length > 0 || m().commands.length > 0 || m().agents.length > 0 ||
+                    m().hasHooks || m().hasMcpConfig || m().hasLspConfig
+                  }>
+                    <div>
+                      <h3 class="m-0 text-[10px] font-semibold uppercase tracking-wider text-text-muted mb-2">
+                        What this plugin ships
+                      </h3>
+                      <div class="flex flex-col gap-2">
+                        <Show when={m().skills.length > 0}>
+                          <ComponentGroup label={`Skills (${m().skills.length})`} items={m().skills} />
+                        </Show>
+                        <Show when={m().commands.length > 0}>
+                          <ComponentGroup label={`Commands (${m().commands.length})`} items={m().commands.map(c => `/${c}`)} />
+                        </Show>
+                        <Show when={m().agents.length > 0}>
+                          <ComponentGroup label={`Agents (${m().agents.length})`} items={m().agents} />
+                        </Show>
+                        <Show when={m().hasHooks}>
+                          <ComponentBadge label="Hooks" />
+                        </Show>
+                        <Show when={m().hasMcpConfig}>
+                          <ComponentBadge label="MCP server" />
+                        </Show>
+                        <Show when={m().hasLspConfig}>
+                          <ComponentBadge label="LSP server" />
+                        </Show>
+                      </div>
+                    </div>
+                  </Show>
+                )}
+              </Show>
+
+              <Show when={!installed()}>
+                <p class="m-0 text-[11px] text-text-dim italic">
+                  Install to see the full list of skills, commands, agents and integrations this plugin ships.
+                </p>
+              </Show>
+            </div>
+
+            {/* Footer actions */}
+            <div class="px-4 py-3 border-t border-border flex items-center gap-2">
+              <Show when={sourceUrl(p())}>
+                {(url) => (
+                  <button
+                    class="flex items-center gap-1.5 px-2.5 py-1.5 rounded ring-1 ring-outline/10 hover:bg-outline/5 text-[12px] text-text-secondary"
+                    onClick={() => openUrl(url())}
+                  >
+                    <ExternalLink class="w-3.5 h-3.5" />
+                    View source
+                  </button>
+                )}
+              </Show>
+              <div class="ml-auto flex items-center gap-2">
+                <Show when={installed()}>
+                  <button
+                    class="flex items-center gap-1.5 px-3 py-1.5 rounded ring-1 ring-outline/10 hover:bg-outline/5 text-[12px] disabled:opacity-50"
+                    disabled={pending()}
+                    onClick={handleUninstall}
+                  >
+                    <Show when={pending()} fallback={<Trash2 class="w-3.5 h-3.5" />}>
+                      <Loader2 class="w-3.5 h-3.5 animate-spin" />
+                    </Show>
+                    Uninstall
+                  </button>
+                </Show>
+                <Show when={!installed()}>
+                  <ScopedInstallButton
+                    pending={pending()}
+                    allowProjectScope={allowProjectScope()}
+                    onInstall={handleInstall}
+                  />
+                </Show>
+              </div>
+            </div>
+            </>
+          )}
+        </Show>
+      </aside>
+    </>
+  )
+}
+
+const ComponentGroup: Component<{ label: string; items: string[] }> = (props) => (
+  <div>
+    <div class="text-[11px] text-text-dim mb-1">{props.label}</div>
+    <div class="flex flex-wrap gap-1">
+      <For each={props.items}>
+        {item => (
+          <code class="text-[11px] px-1.5 py-0.5 rounded ring-1 ring-outline/10 text-text-secondary bg-surface-1">
+            {item}
+          </code>
+        )}
+      </For>
+    </div>
+  </div>
+)
+
+const ComponentBadge: Component<{ label: string }> = (props) => (
+  <div class="text-[11px] text-text-secondary flex items-center gap-1.5">
+    <span class="w-1 h-1 rounded-full bg-accent" />
+    {props.label}
+  </div>
+)
+
+const ScopedInstallButton: Component<{
+  pending: boolean
+  allowProjectScope: boolean
+  onInstall: (scope: PluginScope) => void
+}> = (props) => {
+  return (
+    <div class="flex items-center gap-1.5">
+      <Show when={props.allowProjectScope}>
+        <ScopeMenu onPick={s => props.onInstall(s)} pending={props.pending} />
+      </Show>
+      <Show when={!props.allowProjectScope}>
+        <button
+          class="flex items-center gap-1.5 px-3 py-1.5 rounded ring-1 ring-accent/30 bg-accent-muted text-accent hover:bg-accent/15 text-[12px] disabled:opacity-50"
+          disabled={props.pending}
+          onClick={() => props.onInstall('user')}
+        >
+          <Show when={props.pending} fallback={<Download class="w-3.5 h-3.5" />}>
+            <Loader2 class="w-3.5 h-3.5 animate-spin" />
+          </Show>
+          Install
+        </button>
+      </Show>
+    </div>
+  )
+}
+
+const ScopeMenu: Component<{
+  onPick: (scope: PluginScope) => void
+  pending: boolean
+}> = (props) => {
+  const [open, setOpen] = createSignal(false)
+  const [scope, setScope] = createSignal<PluginScope>('user')
+  return (
+    <>
+      <button
+        class="flex items-center gap-1.5 px-3 py-1.5 rounded ring-1 ring-accent/30 bg-accent-muted text-accent hover:bg-accent/15 text-[12px] disabled:opacity-50"
+        disabled={props.pending}
+        onClick={() => props.onPick(scope())}
+      >
+        <Show when={props.pending} fallback={<Download class="w-3.5 h-3.5" />}>
+          <Loader2 class="w-3.5 h-3.5 animate-spin" />
+        </Show>
+        Install
+      </button>
+      <div class="relative">
+        <button
+          class="px-2 py-1.5 rounded ring-1 ring-outline/10 hover:bg-outline/5 text-[11px] flex items-center gap-1"
+          onClick={() => setOpen(o => !o)}
+          title="Install scope"
+        >
+          {scope()}
+        </button>
+        <Show when={open()}>
+          <div class="absolute right-0 bottom-full mb-1 ring-1 ring-outline/10 rounded bg-surface-2 z-10 min-w-24 shadow-lg">
+            <For each={['user', 'project', 'local'] as PluginScope[]}>
+              {s => (
+                <button
+                  class="block w-full px-3 py-1.5 text-left text-[11px] hover:bg-outline/5"
+                  onClick={() => { setScope(s); setOpen(false) }}
+                >
+                  {s}
+                </button>
+              )}
+            </For>
+          </div>
+        </Show>
+      </div>
+    </>
+  )
+}

--- a/src/components/PluginsPage.test.tsx
+++ b/src/components/PluginsPage.test.tsx
@@ -1,0 +1,85 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { render, fireEvent, cleanup, waitFor } from '@solidjs/testing-library'
+import { createStore } from 'solid-js/store'
+
+const { catalog, marketplaces, mocks } = vi.hoisted(() => {
+  const c = {
+    installed: [{ id: 'asana@claude-plugins-official', scope: 'user', enabled: true }],
+    available: [
+      { pluginId: 'asana@claude-plugins-official', name: 'asana', description: 'Asana stuff', marketplaceName: 'claude-plugins-official', source: '', installCount: 100 },
+      { pluginId: 'amplitude@claude-plugins-official', name: 'amplitude', description: 'Analytics', marketplaceName: 'claude-plugins-official', source: '', installCount: 50 },
+      { pluginId: 'foo@other-mp', name: 'foo', description: 'A foo plugin', marketplaceName: 'other-mp', source: '', installCount: 999 },
+    ],
+  }
+  const mp = [
+    { name: 'claude-plugins-official' },
+    { name: 'other-mp' },
+  ]
+  return {
+    catalog: c,
+    marketplaces: mp,
+    mocks: {
+      isSupported: vi.fn(() => true),
+      isLoading: vi.fn(() => false),
+      isInstalled: vi.fn((id: string) => id === 'asana@claude-plugins-official'),
+      isPending: vi.fn(() => false),
+      loadCatalog: vi.fn().mockResolvedValue(undefined),
+      installPlugin: vi.fn(),
+      uninstallPlugin: vi.fn(),
+    },
+  }
+})
+
+vi.mock('../store/plugins', () => {
+  const [cat] = createStore(catalog)
+  const [mps] = createStore(marketplaces)
+  return { catalog: cat, marketplaces: mps, ...mocks }
+})
+
+vi.mock('../store/ui', () => ({
+  setShowPlugins: vi.fn(),
+  selectedProjectId: () => null,
+  addToast: vi.fn(),
+}))
+
+vi.mock('../store/projects', () => {
+  const [projects] = createStore<unknown[]>([])
+  return { projects }
+})
+
+import { PluginsPage } from './PluginsPage'
+
+describe('PluginsPage', () => {
+  beforeEach(() => {
+    cleanup()
+  })
+
+  test('renders all available plugins by default', () => {
+    const { getByText } = render(() => <PluginsPage />)
+    expect(getByText('asana')).toBeTruthy()
+    expect(getByText('amplitude')).toBeTruthy()
+    expect(getByText('foo')).toBeTruthy()
+  })
+
+  test('search filters by name', async () => {
+    const { getByPlaceholderText, queryByText, getByText } = render(() => <PluginsPage />)
+    const search = getByPlaceholderText(/search/i)
+    fireEvent.input(search, { target: { value: 'amp' } })
+    await waitFor(() => {
+      expect(queryByText('asana')).toBeNull()
+      expect(queryByText('foo')).toBeNull()
+    })
+    expect(getByText('amplitude')).toBeTruthy()
+  })
+
+  test('installed-only toggle hides un-installed', async () => {
+    const { getByLabelText, queryByText, getByText } = render(() => <PluginsPage />)
+    const toggle = getByLabelText(/installed only/i)
+    fireEvent.click(toggle)
+    await waitFor(() => {
+      expect(queryByText('amplitude')).toBeNull()
+      expect(queryByText('foo')).toBeNull()
+    })
+    expect(getByText('asana')).toBeTruthy()
+  })
+})

--- a/src/components/PluginsPage.test.tsx
+++ b/src/components/PluginsPage.test.tsx
@@ -33,7 +33,14 @@ const { catalog, marketplaces, mocks } = vi.hoisted(() => {
 vi.mock('../store/plugins', () => {
   const [cat] = createStore(catalog)
   const [mps] = createStore(marketplaces)
-  return { catalog: cat, marketplaces: mps, ...mocks }
+  return {
+    catalog: cat,
+    marketplaces: mps,
+    selectedPluginId: () => null,
+    setSelectedPluginId: vi.fn(),
+    installedPluginById: () => undefined,
+    ...mocks,
+  }
 })
 
 vi.mock('../store/ui', () => ({
@@ -56,31 +63,31 @@ describe('PluginsPage', () => {
   })
 
   test('renders all available plugins by default', () => {
-    const { getByText } = render(() => <PluginsPage />)
-    expect(getByText('asana')).toBeTruthy()
-    expect(getByText('amplitude')).toBeTruthy()
-    expect(getByText('foo')).toBeTruthy()
+    const { getAllByText } = render(() => <PluginsPage />)
+    // Default stacks Installed / Popular / Browse, so plugins appear in
+    // multiple sections — assert at least one render per name.
+    expect(getAllByText('asana').length).toBeGreaterThan(0)
+    expect(getAllByText('amplitude').length).toBeGreaterThan(0)
+    expect(getAllByText('foo').length).toBeGreaterThan(0)
   })
 
-  test('search filters by name', async () => {
-    const { getByPlaceholderText, queryByText, getByText } = render(() => <PluginsPage />)
+  test('search filters the Browse all section but leaves Installed/Popular intact', async () => {
+    const { getByPlaceholderText, getAllByText } = render(() => <PluginsPage />)
+    // Baseline: with 3 plugins and cap=8, Popular renders all 3 once.
+    // asana also renders in Installed → 3 total. amplitude/foo: 2 each (Popular + Browse).
+    expect(getAllByText('asana').length).toBe(3)
+    expect(getAllByText('amplitude').length).toBe(2)
+    expect(getAllByText('foo').length).toBe(2)
+
     const search = getByPlaceholderText(/search/i)
     fireEvent.input(search, { target: { value: 'amp' } })
     await waitFor(() => {
-      expect(queryByText('asana')).toBeNull()
-      expect(queryByText('foo')).toBeNull()
+      // Only Browse responds: foo drops from 2 → 1, asana from 3 → 2.
+      expect(getAllByText('foo').length).toBe(1)
+      expect(getAllByText('asana').length).toBe(2)
     })
-    expect(getByText('amplitude')).toBeTruthy()
+    // amplitude still in both Popular and Browse.
+    expect(getAllByText('amplitude').length).toBe(2)
   })
 
-  test('installed-only toggle hides un-installed', async () => {
-    const { getByLabelText, queryByText, getByText } = render(() => <PluginsPage />)
-    const toggle = getByLabelText(/installed only/i)
-    fireEvent.click(toggle)
-    await waitFor(() => {
-      expect(queryByText('amplitude')).toBeNull()
-      expect(queryByText('foo')).toBeNull()
-    })
-    expect(getByText('asana')).toBeTruthy()
-  })
 })

--- a/src/components/PluginsPage.test.tsx
+++ b/src/components/PluginsPage.test.tsx
@@ -37,6 +37,7 @@ vi.mock('../store/plugins', () => {
 })
 
 vi.mock('../store/ui', () => ({
+  showPlugins: () => true,
   setShowPlugins: vi.fn(),
   selectedProjectId: () => null,
   addToast: vi.fn(),

--- a/src/components/PluginsPage.tsx
+++ b/src/components/PluginsPage.tsx
@@ -1,0 +1,26 @@
+import { Component, onMount, Show } from 'solid-js'
+import { loadCatalog, isLoading, isSupported } from '../store/plugins'
+import { setShowPlugins } from '../store/ui'
+import { X } from 'lucide-solid'
+
+export const PluginsPage: Component = () => {
+  onMount(() => { void loadCatalog() })
+  return (
+    <div class="absolute inset-0 bg-bg z-20 flex flex-col">
+      <div class="flex items-center justify-between px-4 py-3 border-b-1 border-b-solid border-b-white/8">
+        <h1 class="text-lg font-medium">Plugins</h1>
+        <button class="p-1 rounded hover:bg-white/5" onClick={() => setShowPlugins(false)} aria-label="Close">
+          <X class="w-4 h-4" />
+        </button>
+      </div>
+      <div class="flex-1 overflow-auto p-4">
+        <Show when={isSupported() === false}>
+          <p class="text-sm text-fg/60">Update Claude Code to 2.0+ to use the plugin marketplace.</p>
+        </Show>
+        <Show when={isLoading()}>
+          <p class="text-sm text-fg/60">Loading…</p>
+        </Show>
+      </div>
+    </div>
+  )
+}

--- a/src/components/PluginsPage.tsx
+++ b/src/components/PluginsPage.tsx
@@ -59,8 +59,8 @@ export const PluginsPage: Component = () => {
 
   return (
     <Dialog open={showPlugins()} onClose={() => setShowPlugins(false)} width="min(92vw, 80rem)">
-      <div class="flex flex-col" style={{ height: 'min(78vh, 720px)' }}>
-        <div class="flex items-center justify-between mb-4">
+      <div class="-m-5 flex flex-col" style={{ height: 'min(78vh, 720px)' }}>
+        <div class="flex items-center justify-between px-4 py-3 border-b border-border">
           <h2 class="text-sm font-semibold text-text-primary">Plugins</h2>
           <button
             class="p-1 rounded text-text-dim hover:text-text-secondary hover:bg-surface-3 transition-colors disabled:opacity-50"
@@ -74,7 +74,7 @@ export const PluginsPage: Component = () => {
 
         <div class="flex-1 grid grid-cols-[160px_1fr] min-h-0">
           {/* Agent rail — matches the app's main sidebar density */}
-          <nav class="flex flex-col gap-0.5 border-r border-border pr-2 -my-1 py-1 overflow-y-auto">
+          <nav class="flex flex-col gap-0.5 border-r border-border px-2 py-2 overflow-y-auto">
             <div class="text-[10px] font-semibold uppercase tracking-wider text-text-muted px-2 mb-1">
               Coding agent
             </div>
@@ -108,7 +108,7 @@ export const PluginsPage: Component = () => {
           </nav>
 
           {/* Right panel */}
-          <div class="flex flex-col min-h-0 min-w-0 pl-3">
+          <div class="flex flex-col min-h-0 min-w-0 px-4 py-3">
             <Show
               when={SUPPORTED_AGENTS.has(activeAgent())}
               fallback={<ComingSoon agent={activeAgent()} />}

--- a/src/components/PluginsPage.tsx
+++ b/src/components/PluginsPage.tsx
@@ -85,7 +85,7 @@ export const PluginsPage: Component = () => {
               title="Sort"
             >
               <option value="installs">Most installed</option>
-              <option value="name">A-Z</option>
+              <option value="name">Alphabetical</option>
             </select>
             <label class="flex items-center gap-1.5 text-[11px] text-text-secondary shrink-0 cursor-pointer">
               <input

--- a/src/components/PluginsPage.tsx
+++ b/src/components/PluginsPage.tsx
@@ -75,7 +75,7 @@ export const PluginsPage: Component = () => {
         <div class="flex-1 grid grid-cols-[160px_1fr] min-h-0">
           {/* Agent rail — matches the app's main sidebar density */}
           <nav class="flex flex-col gap-0.5 border-r border-border px-2 py-2 overflow-y-auto">
-            <div class="text-[10px] font-semibold uppercase tracking-wider text-text-muted px-2 mb-1">
+            <div class="text-[10px] font-semibold uppercase tracking-wider text-text-muted px-2.5 mb-1">
               Coding agent
             </div>
             <For each={AGENT_ORDER}>
@@ -84,7 +84,7 @@ export const PluginsPage: Component = () => {
                 const supported = SUPPORTED_AGENTS.has(agent)
                 return (
                   <button
-                    class={`relative flex items-center gap-2 px-2 py-1 rounded-md text-left transition-colors ${
+                    class={`relative flex items-center gap-2 px-2.5 py-1.5 rounded-md text-left transition-colors ${
                       active()
                         ? 'bg-accent-muted text-accent'
                         : 'text-text-secondary hover:bg-surface-3 hover:text-text-primary'
@@ -92,7 +92,7 @@ export const PluginsPage: Component = () => {
                     onClick={() => setActiveAgent(agent)}
                   >
                     <Show when={active()}>
-                      <span class="absolute left-0 top-1 bottom-1 w-0.5 rounded-r bg-accent" />
+                      <span class="absolute left-0 top-1.5 bottom-1.5 w-0.5 rounded-r bg-accent" />
                     </Show>
                     <SvgIcon svg={agentIcon(agent)} size={14} />
                     <span class="text-[12px] font-medium flex-1 truncate">{AGENT_DISPLAY_NAMES[agent]}</span>

--- a/src/components/PluginsPage.tsx
+++ b/src/components/PluginsPage.tsx
@@ -1,26 +1,147 @@
-import { Component, onMount, Show } from 'solid-js'
-import { loadCatalog, isLoading, isSupported } from '../store/plugins'
-import { setShowPlugins } from '../store/ui'
-import { X } from 'lucide-solid'
+import { Component, For, Show, createMemo, createSignal, onMount } from 'solid-js'
+import { X, Search, RefreshCw } from 'lucide-solid'
+import { catalog, marketplaces, isSupported, isLoading, isInstalled, loadCatalog } from '../store/plugins'
+import { setShowPlugins, selectedProjectId } from '../store/ui'
+import { projects } from '../store/projects'
+import { PluginCard } from './PluginCard'
+
+type SortKey = 'installs' | 'name'
 
 export const PluginsPage: Component = () => {
+  const [query, setQuery] = createSignal('')
+  const [installedOnly, setInstalledOnly] = createSignal(false)
+  const [marketplaceFilter, setMarketplaceFilter] = createSignal<Set<string>>(new Set())
+  const [sortKey, setSortKey] = createSignal<SortKey>('installs')
+
   onMount(() => { void loadCatalog() })
+
+  // When a project is selected we run installs from its worktree, which lets
+  // project / local scopes write to the right `.claude/settings.json`. With
+  // no project selected we restrict to user scope and run from the home dir
+  // so the CLI never falls back to writing into the wrong directory.
+  const cwd = createMemo(() => {
+    const pid = selectedProjectId()
+    if (pid) {
+      const proj = projects.find(p => p.id === pid)
+      if (proj) return proj.repoPath
+    }
+    return ''
+  })
+  const allowProjectScope = createMemo(() => selectedProjectId() != null)
+
+  const filtered = createMemo(() => {
+    const q = query().trim().toLowerCase()
+    const mpFilter = marketplaceFilter()
+    const onlyInstalled = installedOnly()
+    let list = catalog.available.filter(p => {
+      if (onlyInstalled && !isInstalled(p.pluginId)) return false
+      if (mpFilter.size > 0 && !mpFilter.has(p.marketplaceName)) return false
+      if (q && !p.name.toLowerCase().includes(q) && !p.description.toLowerCase().includes(q)) return false
+      return true
+    })
+    if (sortKey() === 'installs') {
+      list = [...list].sort((a, b) => (b.installCount ?? 0) - (a.installCount ?? 0))
+    } else {
+      list = [...list].sort((a, b) => a.name.localeCompare(b.name))
+    }
+    return list
+  })
+
+  const toggleMp = (name: string) => {
+    setMarketplaceFilter(prev => {
+      const next = new Set(prev)
+      if (next.has(name)) next.delete(name)
+      else next.add(name)
+      return next
+    })
+  }
+
   return (
     <div class="absolute inset-0 bg-bg z-20 flex flex-col">
       <div class="flex items-center justify-between px-4 py-3 border-b-1 border-b-solid border-b-white/8">
         <h1 class="text-lg font-medium">Plugins</h1>
-        <button class="p-1 rounded hover:bg-white/5" onClick={() => setShowPlugins(false)} aria-label="Close">
-          <X class="w-4 h-4" />
-        </button>
+        <div class="flex items-center gap-2">
+          <button
+            class="p-1 rounded hover:bg-white/5"
+            onClick={() => loadCatalog()}
+            title="Refresh"
+            disabled={isLoading()}
+          >
+            <RefreshCw class={`w-4 h-4 ${isLoading() ? 'animate-spin' : ''}`} />
+          </button>
+          <button class="p-1 rounded hover:bg-white/5" onClick={() => setShowPlugins(false)} aria-label="Close">
+            <X class="w-4 h-4" />
+          </button>
+        </div>
       </div>
-      <div class="flex-1 overflow-auto p-4">
-        <Show when={isSupported() === false}>
-          <p class="text-sm text-fg/60">Update Claude Code to 2.0+ to use the plugin marketplace.</p>
+
+      <Show when={isSupported() === false}>
+        <div class="p-8 text-center text-sm text-fg/60">
+          Update Claude Code to 2.0+ to use the plugin marketplace.
+        </div>
+      </Show>
+
+      <Show when={isSupported() !== false}>
+        <div class="px-4 py-3 flex items-center gap-3 flex-wrap border-b-1 border-b-solid border-b-white/8">
+          <div class="relative flex-1 min-w-60">
+            <Search class="w-4 h-4 absolute left-2 top-1/2 -translate-y-1/2 text-fg/40" />
+            <input
+              type="text"
+              placeholder="Search plugins…"
+              class="w-full pl-8 pr-3 py-1.5 rounded ring-1 ring-white/10 bg-bg text-sm focus:ring-accent focus:outline-none"
+              value={query()}
+              onInput={e => setQuery(e.currentTarget.value)}
+            />
+          </div>
+          <label class="flex items-center gap-1.5 text-sm text-fg/80">
+            <input
+              type="checkbox"
+              checked={installedOnly()}
+              onChange={e => setInstalledOnly(e.currentTarget.checked)}
+              aria-label="Installed only"
+            />
+            Installed only
+          </label>
+          <select
+            class="px-2 py-1.5 rounded ring-1 ring-white/10 bg-bg text-sm"
+            value={sortKey()}
+            onChange={e => setSortKey(e.currentTarget.value as SortKey)}
+          >
+            <option value="installs">Most installed</option>
+            <option value="name">Name</option>
+          </select>
+        </div>
+
+        <Show when={marketplaces.length > 1}>
+          <div class="px-4 py-2 flex items-center gap-2 flex-wrap border-b-1 border-b-solid border-b-white/8">
+            <span class="text-xs text-fg/50">Marketplaces:</span>
+            <For each={marketplaces}>
+              {mp => {
+                const active = () => marketplaceFilter().has(mp.name)
+                return (
+                  <button
+                    class={`px-2 py-0.5 rounded-full text-xs ring-1 ${active() ? 'ring-accent bg-accent/10 text-accent' : 'ring-white/10 hover:bg-white/5'}`}
+                    onClick={() => toggleMp(mp.name)}
+                  >
+                    {mp.name}
+                  </button>
+                )
+              }}
+            </For>
+          </div>
         </Show>
-        <Show when={isLoading()}>
-          <p class="text-sm text-fg/60">Loading…</p>
-        </Show>
-      </div>
+
+        <div class="flex-1 overflow-auto p-4">
+          <Show when={!isLoading() && filtered().length === 0}>
+            <p class="text-sm text-fg/60 text-center py-8">No plugins match your filters.</p>
+          </Show>
+          <div class="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-3">
+            <For each={filtered()}>
+              {p => <PluginCard plugin={p} cwd={cwd()} allowProjectScope={allowProjectScope()} />}
+            </For>
+          </div>
+        </div>
+      </Show>
     </div>
   )
 }

--- a/src/components/PluginsPage.tsx
+++ b/src/components/PluginsPage.tsx
@@ -1,7 +1,7 @@
 import { Component, For, Show, createMemo, createSignal, onMount } from 'solid-js'
-import { Search, RefreshCw, Sparkles } from 'lucide-solid'
+import { Search, X, Sparkles } from 'lucide-solid'
 import { openUrl } from '@tauri-apps/plugin-opener'
-import type { AgentType } from '../types'
+import type { AgentType, AvailablePlugin } from '../types'
 import { AGENT_DISPLAY_NAMES } from '../types'
 import { catalog, marketplaces, isSupported, isLoading, isInstalled, loadCatalog } from '../store/plugins'
 import { showPlugins, setShowPlugins, selectedProjectId } from '../store/ui'
@@ -9,6 +9,7 @@ import { projects } from '../store/projects'
 import { agentIcon } from '../lib/agents'
 import { Dialog } from './Dialog'
 import { PluginCard } from './PluginCard'
+import { PluginDetailDrawer } from './PluginDetailDrawer'
 import SvgIcon from './SvgIcon'
 
 type SortKey = 'installs' | 'name'
@@ -20,7 +21,6 @@ const SUPPORTED_AGENTS = new Set<AgentType>(['claude'])
 export const PluginsPage: Component = () => {
   const [activeAgent, setActiveAgent] = createSignal<AgentType>('claude')
   const [query, setQuery] = createSignal('')
-  const [installedOnly, setInstalledOnly] = createSignal(false)
   const [marketplaceFilter, setMarketplaceFilter] = createSignal<MarketplaceFilterValue>('all')
   const [sortKey, setSortKey] = createSignal<SortKey>('installs')
 
@@ -37,12 +37,46 @@ export const PluginsPage: Component = () => {
   const allowProjectScope = createMemo(() => selectedProjectId() != null)
   const showMarketplaceBadge = createMemo(() => marketplaces.length > 1)
 
-  const filtered = createMemo(() => {
+  // The CLI's --available list excludes already-installed plugins, so we
+  // synthesize entries for the installed-but-not-available case to make sure
+  // installed plugins still render as cards.
+  const allPlugins = createMemo<AvailablePlugin[]>(() => {
+    const availableIds = new Set(catalog.available.map(p => p.pluginId))
+    const synthesized: AvailablePlugin[] = catalog.installed
+      .filter(p => !availableIds.has(p.id))
+      .map(p => {
+        const at = p.id.lastIndexOf('@')
+        const name = at >= 0 ? p.id.slice(0, at) : p.id
+        const marketplaceName = at >= 0 ? p.id.slice(at + 1) : ''
+        return {
+          pluginId: p.id,
+          name,
+          description: '',
+          marketplaceName,
+          source: '',
+          version: p.version,
+        }
+      })
+    return [...catalog.available, ...synthesized]
+  })
+
+  const POPULAR_CAP = 8
+
+  const installedItems = createMemo(() =>
+    allPlugins().filter(p => isInstalled(p.pluginId))
+  )
+
+  const popularItems = createMemo(() =>
+    [...allPlugins()]
+      .sort((a, b) => (b.installCount ?? 0) - (a.installCount ?? 0))
+      .slice(0, POPULAR_CAP)
+  )
+
+  /** Browse-all is the only section that responds to the filter controls. */
+  const browseItems = createMemo(() => {
     const q = query().trim().toLowerCase()
     const mpFilter = marketplaceFilter()
-    const onlyInstalled = installedOnly()
-    let list = catalog.available.filter(p => {
-      if (onlyInstalled && !isInstalled(p.pluginId)) return false
+    let list = allPlugins().filter(p => {
       if (mpFilter !== 'all' && p.marketplaceName !== mpFilter) return false
       if (q && !p.name.toLowerCase().includes(q) && !p.description.toLowerCase().includes(q)) return false
       return true
@@ -64,12 +98,12 @@ export const PluginsPage: Component = () => {
         <div class="flex items-center justify-between px-4 py-2 border-b border-border">
           <h2 class="text-sm font-semibold text-text-primary">Plugins</h2>
           <button
-            class="p-1 rounded text-text-dim hover:text-text-secondary hover:bg-surface-3 transition-colors disabled:opacity-50"
-            onClick={() => loadCatalog()}
-            title="Refresh"
-            disabled={isLoading() || activeAgent() !== 'claude'}
+            class="p-1 rounded text-text-dim hover:text-text-secondary hover:bg-surface-3 transition-colors"
+            onClick={() => setShowPlugins(false)}
+            title="Close"
+            aria-label="Close"
           >
-            <RefreshCw class={`w-3.5 h-3.5 ${isLoading() ? 'animate-spin' : ''}`} />
+            <X class="w-3.5 h-3.5" />
           </button>
         </div>
 
@@ -86,7 +120,7 @@ export const PluginsPage: Component = () => {
                   <button
                     class={`relative flex items-center gap-2 px-2.5 py-1.5 rounded-md text-left transition-colors ${
                       active()
-                        ? 'bg-accent-muted text-accent'
+                        ? 'bg-surface-3 text-text-primary font-semibold'
                         : 'text-text-secondary hover:bg-surface-3 hover:text-text-primary'
                     }`}
                     onClick={() => setActiveAgent(agent)}
@@ -103,7 +137,7 @@ export const PluginsPage: Component = () => {
           </nav>
 
           {/* Right panel */}
-          <div class="flex flex-col min-h-0 min-w-0 px-4 pt-2 pb-3">
+          <div class="flex flex-col min-h-0 min-w-0">
             <Show
               when={SUPPORTED_AGENTS.has(activeAgent())}
               fallback={<ComingSoon agent={activeAgent()} />}
@@ -115,65 +149,90 @@ export const PluginsPage: Component = () => {
               </Show>
 
               <Show when={isSupported() !== false}>
-                <div class="flex items-center gap-2 mb-3">
-                  <div class="relative flex-1 min-w-0">
-                    <Search class="w-3.5 h-3.5 absolute left-2 top-1/2 -translate-y-1/2 text-text-dim" />
-                    <input
-                      type="text"
-                      placeholder="Search plugins…"
-                      class="w-full bg-surface-1 border border-border rounded-md pl-7 pr-3 py-1 text-[12px] text-text-primary outline-none focus:border-accent transition-colors"
-                      value={query()}
-                      onInput={e => setQuery(e.currentTarget.value)}
-                    />
-                  </div>
-                  <Show when={showMarketplaceBadge()}>
-                    <select
-                      class={selectClass}
-                      value={marketplaceFilter()}
-                      onChange={e => setMarketplaceFilter(e.currentTarget.value)}
-                      title="Filter by marketplace"
-                    >
-                      <option value="all">All marketplaces</option>
-                      <For each={marketplaces}>
-                        {mp => <option value={mp.name}>{mp.name}</option>}
-                      </For>
-                    </select>
-                  </Show>
-                  <select
-                    class={selectClass}
-                    value={sortKey()}
-                    onChange={e => setSortKey(e.currentTarget.value as SortKey)}
-                    title="Sort"
-                  >
-                    <option value="installs">Most installed</option>
-                    <option value="name">Alphabetical</option>
-                  </select>
-                  <label class="flex items-center gap-1.5 text-[11px] text-text-secondary shrink-0 cursor-pointer">
-                    <input
-                      type="checkbox"
-                      checked={installedOnly()}
-                      onChange={e => setInstalledOnly(e.currentTarget.checked)}
-                      aria-label="Installed only"
-                    />
-                    Installed only
-                  </label>
-                </div>
+                <div class="flex-1 overflow-y-auto px-4 pt-2 pb-3">
+                  <div class="flex flex-col gap-5">
+                    {/* Installed */}
+                    <Show when={installedItems().length > 0}>
+                      <section>
+                        <div class="flex items-baseline gap-2 mb-2">
+                          <h3 class="m-0 text-[10px] font-semibold uppercase tracking-wider text-text-muted">Installed</h3>
+                          <span class="text-[10px] text-text-dim tabular-nums">{installedItems().length}</span>
+                        </div>
+                        <div class="grid grid-cols-[repeat(auto-fill,minmax(240px,1fr))] gap-2">
+                          <For each={installedItems()}>
+                            {p => (
+                              <PluginCard plugin={p} cwd={cwd()} allowProjectScope={allowProjectScope()} showMarketplace={showMarketplaceBadge()} />
+                            )}
+                          </For>
+                        </div>
+                      </section>
+                    </Show>
 
-                <div class="flex-1 overflow-y-auto -mx-1 px-1">
-                  <Show when={!isLoading() && filtered().length === 0}>
-                    <p class="text-sm text-text-dim text-center py-8">No plugins match your filters.</p>
-                  </Show>
-                  <div class="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-3">
-                    <For each={filtered()}>
-                      {p => (
-                        <PluginCard
-                          plugin={p}
-                          cwd={cwd()}
-                          allowProjectScope={allowProjectScope()}
-                          showMarketplace={showMarketplaceBadge()}
-                        />
-                      )}
-                    </For>
+                    {/* Popular */}
+                    <section>
+                      <div class="flex items-baseline gap-2 mb-2">
+                        <h3 class="m-0 text-[10px] font-semibold uppercase tracking-wider text-text-muted">Popular</h3>
+                      </div>
+                      <div class="grid grid-cols-[repeat(auto-fill,minmax(240px,1fr))] gap-2">
+                        <For each={popularItems()}>
+                          {p => (
+                            <PluginCard plugin={p} cwd={cwd()} allowProjectScope={allowProjectScope()} showMarketplace={showMarketplaceBadge()} />
+                          )}
+                        </For>
+                      </div>
+                    </section>
+
+                    {/* Browse all — owns the filter controls */}
+                    <section>
+                      <div class="flex items-center gap-2 mb-2 flex-wrap">
+                        <h3 class="m-0 text-[10px] font-semibold uppercase tracking-wider text-text-muted shrink-0">Browse all</h3>
+                        <span class="text-[10px] text-text-dim tabular-nums shrink-0">{allPlugins().length}</span>
+                        <div class="ml-auto flex items-center gap-2 flex-wrap">
+                          <div class="relative w-56">
+                            <Search class="w-3.5 h-3.5 absolute left-2 top-1/2 -translate-y-1/2 text-text-dim" />
+                            <input
+                              type="text"
+                              placeholder="Search plugins…"
+                              class="w-full bg-surface-1 border border-border rounded-md pl-7 pr-3 py-1 text-[12px] text-text-primary outline-none focus:border-accent transition-colors"
+                              value={query()}
+                              onInput={e => setQuery(e.currentTarget.value)}
+                            />
+                          </div>
+                          <Show when={showMarketplaceBadge()}>
+                            <select
+                              class={selectClass}
+                              value={marketplaceFilter()}
+                              onChange={e => setMarketplaceFilter(e.currentTarget.value)}
+                              title="Filter by marketplace"
+                            >
+                              <option value="all">All marketplaces</option>
+                              <For each={marketplaces}>
+                                {mp => <option value={mp.name}>{mp.name}</option>}
+                              </For>
+                            </select>
+                          </Show>
+                          <select
+                            class={selectClass}
+                            value={sortKey()}
+                            onChange={e => setSortKey(e.currentTarget.value as SortKey)}
+                            title="Sort"
+                          >
+                            <option value="installs">Most installed</option>
+                            <option value="name">Alphabetical</option>
+                          </select>
+                        </div>
+                      </div>
+                      <Show when={!isLoading() && browseItems().length === 0}>
+                        <p class="text-sm text-text-dim text-center py-8">No plugins match your filters.</p>
+                      </Show>
+                      <div class="grid grid-cols-[repeat(auto-fill,minmax(240px,1fr))] gap-2">
+                        <For each={browseItems()}>
+                          {p => (
+                            <PluginCard plugin={p} cwd={cwd()} allowProjectScope={allowProjectScope()} showMarketplace={showMarketplaceBadge()} />
+                          )}
+                        </For>
+                      </div>
+                    </section>
                   </div>
                 </div>
               </Show>
@@ -181,6 +240,7 @@ export const PluginsPage: Component = () => {
           </div>
         </div>
       </div>
+      <PluginDetailDrawer />
     </Dialog>
   )
 }
@@ -192,7 +252,7 @@ const ComingSoon: Component<{ agent: AgentType }> = (props) => {
       <div class="max-w-md text-center">
         <div class="relative inline-flex mb-5">
           <div class="absolute inset-0 blur-2xl bg-accent/15 rounded-full" />
-          <div class="relative w-16 h-16 rounded-2xl bg-surface-1 ring-1 ring-white/8 flex items-center justify-center">
+          <div class="relative w-16 h-16 rounded-2xl bg-surface-1 ring-1 ring-outline/8 flex items-center justify-center">
             <SvgIcon svg={agentIcon(props.agent)} size={32} />
           </div>
         </div>

--- a/src/components/PluginsPage.tsx
+++ b/src/components/PluginsPage.tsx
@@ -59,7 +59,7 @@ export const PluginsPage: Component = () => {
 
   return (
     <Dialog open={showPlugins()} onClose={() => setShowPlugins(false)} width="min(92vw, 80rem)">
-      <div class="flex flex-col" style={{ 'min-height': '60vh', 'max-height': 'calc(100vh - 10rem)' }}>
+      <div class="flex flex-col" style={{ height: 'min(78vh, 720px)' }}>
         <div class="flex items-center justify-between mb-4">
           <h2 class="text-sm font-semibold text-text-primary">Plugins</h2>
           <button

--- a/src/components/PluginsPage.tsx
+++ b/src/components/PluginsPage.tsx
@@ -85,7 +85,7 @@ export const PluginsPage: Component = () => {
               title="Sort"
             >
               <option value="installs">Most installed</option>
-              <option value="name">Name</option>
+              <option value="name">A-Z</option>
             </select>
             <label class="flex items-center gap-1.5 text-[11px] text-text-secondary shrink-0 cursor-pointer">
               <input

--- a/src/components/PluginsPage.tsx
+++ b/src/components/PluginsPage.tsx
@@ -1,5 +1,5 @@
 import { Component, For, Show, createMemo, createSignal, onMount } from 'solid-js'
-import { Search, RefreshCw, Puzzle } from 'lucide-solid'
+import { Search, RefreshCw } from 'lucide-solid'
 import { catalog, marketplaces, isSupported, isLoading, isInstalled, loadCatalog } from '../store/plugins'
 import { showPlugins, setShowPlugins, selectedProjectId } from '../store/ui'
 import { projects } from '../store/projects'
@@ -7,11 +7,12 @@ import { Dialog } from './Dialog'
 import { PluginCard } from './PluginCard'
 
 type SortKey = 'installs' | 'name'
+type MarketplaceFilterValue = 'all' | string
 
 export const PluginsPage: Component = () => {
   const [query, setQuery] = createSignal('')
   const [installedOnly, setInstalledOnly] = createSignal(false)
-  const [marketplaceFilter, setMarketplaceFilter] = createSignal<Set<string>>(new Set())
+  const [marketplaceFilter, setMarketplaceFilter] = createSignal<MarketplaceFilterValue>('all')
   const [sortKey, setSortKey] = createSignal<SortKey>('installs')
 
   onMount(() => { void loadCatalog() })
@@ -33,7 +34,7 @@ export const PluginsPage: Component = () => {
     const onlyInstalled = installedOnly()
     let list = catalog.available.filter(p => {
       if (onlyInstalled && !isInstalled(p.pluginId)) return false
-      if (mpFilter.size > 0 && !mpFilter.has(p.marketplaceName)) return false
+      if (mpFilter !== 'all' && p.marketplaceName !== mpFilter) return false
       if (q && !p.name.toLowerCase().includes(q) && !p.description.toLowerCase().includes(q)) return false
       return true
     })
@@ -45,36 +46,48 @@ export const PluginsPage: Component = () => {
     return list
   })
 
-  const toggleMp = (name: string) => {
-    setMarketplaceFilter(prev => {
-      const next = new Set(prev)
-      if (next.has(name)) next.delete(name)
-      else next.add(name)
-      return next
-    })
-  }
+  const selectClass =
+    'bg-surface-1 border border-border rounded-md px-2 py-1 text-[11px] text-text-primary outline-none focus:border-accent transition-colors shrink-0'
 
   return (
     <Dialog open={showPlugins()} onClose={() => setShowPlugins(false)} width="min(92vw, 80rem)">
       <div class="flex flex-col" style={{ 'min-height': '60vh', 'max-height': 'calc(100vh - 10rem)' }}>
-        {/* Consolidated header: title + search + controls in one row */}
-        <div class="flex items-center gap-3 mb-4">
-          <div class="flex items-center gap-2 shrink-0">
-            <Puzzle size={16} class="text-accent" />
-            <h2 class="text-sm font-semibold text-text-primary">Plugins</h2>
-          </div>
+        <div class="flex items-center gap-2 mb-4">
+          <h2 class="text-sm font-semibold text-text-primary shrink-0 mr-1">Plugins</h2>
           <Show when={isSupported() !== false}>
             <div class="relative flex-1 min-w-0">
               <Search class="w-3.5 h-3.5 absolute left-2 top-1/2 -translate-y-1/2 text-text-dim" />
               <input
                 type="text"
                 placeholder="Search plugins…"
-                class="input-base w-full pl-7 pr-3 py-1 text-[12px]"
+                class="w-full bg-surface-1 border border-border rounded-md pl-7 pr-3 py-1 text-[12px] text-text-primary outline-none focus:border-accent transition-colors"
                 value={query()}
                 onInput={e => setQuery(e.currentTarget.value)}
               />
             </div>
-            <label class="flex items-center gap-1.5 text-[11px] text-text-secondary shrink-0">
+            <Show when={showMarketplaceBadge()}>
+              <select
+                class={selectClass}
+                value={marketplaceFilter()}
+                onChange={e => setMarketplaceFilter(e.currentTarget.value)}
+                title="Filter by marketplace"
+              >
+                <option value="all">All marketplaces</option>
+                <For each={marketplaces}>
+                  {mp => <option value={mp.name}>{mp.name}</option>}
+                </For>
+              </select>
+            </Show>
+            <select
+              class={selectClass}
+              value={sortKey()}
+              onChange={e => setSortKey(e.currentTarget.value as SortKey)}
+              title="Sort"
+            >
+              <option value="installs">Most installed</option>
+              <option value="name">Name</option>
+            </select>
+            <label class="flex items-center gap-1.5 text-[11px] text-text-secondary shrink-0 cursor-pointer">
               <input
                 type="checkbox"
                 checked={installedOnly()}
@@ -83,17 +96,9 @@ export const PluginsPage: Component = () => {
               />
               Installed only
             </label>
-            <select
-              class="input-base px-2 py-1 text-[11px] shrink-0"
-              value={sortKey()}
-              onChange={e => setSortKey(e.currentTarget.value as SortKey)}
-            >
-              <option value="installs">Most installed</option>
-              <option value="name">Name</option>
-            </select>
           </Show>
           <button
-            class="p-1 rounded text-text-dim hover:text-text-secondary hover:bg-surface-3 transition-colors"
+            class="p-1 rounded text-text-dim hover:text-text-secondary hover:bg-surface-3 transition-colors shrink-0"
             onClick={() => loadCatalog()}
             title="Refresh"
             disabled={isLoading()}
@@ -109,25 +114,6 @@ export const PluginsPage: Component = () => {
         </Show>
 
         <Show when={isSupported() !== false}>
-          <Show when={showMarketplaceBadge()}>
-            <div class="flex items-center gap-2 flex-wrap mb-3">
-              <span class="text-[10px] uppercase tracking-wider text-text-dim">Marketplaces</span>
-              <For each={marketplaces}>
-                {mp => {
-                  const active = () => marketplaceFilter().has(mp.name)
-                  return (
-                    <button
-                      class={`px-2 py-0.5 rounded-full text-[11px] ring-1 ${active() ? 'ring-accent bg-accent/10 text-accent' : 'ring-white/10 text-text-secondary hover:bg-white/5'}`}
-                      onClick={() => toggleMp(mp.name)}
-                    >
-                      {mp.name}
-                    </button>
-                  )
-                }}
-              </For>
-            </div>
-          </Show>
-
           <div class="flex-1 overflow-y-auto -mx-1 px-1">
             <Show when={!isLoading() && filtered().length === 0}>
               <p class="text-sm text-text-dim text-center py-8">No plugins match your filters.</p>

--- a/src/components/PluginsPage.tsx
+++ b/src/components/PluginsPage.tsx
@@ -81,7 +81,6 @@ export const PluginsPage: Component = () => {
             <For each={AGENT_ORDER}>
               {agent => {
                 const active = () => activeAgent() === agent
-                const supported = SUPPORTED_AGENTS.has(agent)
                 return (
                   <button
                     class={`relative flex items-center gap-2 px-2.5 py-1.5 rounded-md text-left transition-colors ${
@@ -96,11 +95,6 @@ export const PluginsPage: Component = () => {
                     </Show>
                     <SvgIcon svg={agentIcon(agent)} size={14} />
                     <span class="text-[12px] font-medium flex-1 truncate">{AGENT_DISPLAY_NAMES[agent]}</span>
-                    <Show when={!supported}>
-                      <span class="text-[9px] uppercase tracking-wider text-text-dim font-medium">
-                        soon
-                      </span>
-                    </Show>
                   </button>
                 )
               }}

--- a/src/components/PluginsPage.tsx
+++ b/src/components/PluginsPage.tsx
@@ -1,5 +1,6 @@
 import { Component, For, Show, createMemo, createSignal, onMount } from 'solid-js'
 import { Search, RefreshCw, Sparkles } from 'lucide-solid'
+import { openUrl } from '@tauri-apps/plugin-opener'
 import type { AgentType } from '../types'
 import { AGENT_DISPLAY_NAMES } from '../types'
 import { catalog, marketplaces, isSupported, isLoading, isInstalled, loadCatalog } from '../store/plugins'
@@ -202,10 +203,13 @@ const ComingSoon: Component<{ agent: AgentType }> = (props) => {
           Verun's plugin browser currently supports Claude Code only.
           {' '}{name()} support is on the roadmap.
         </p>
-        <div class="inline-flex items-center gap-1.5 text-[11px] text-accent bg-accent-muted px-2.5 py-1 rounded-full ring-1 ring-accent/20">
+        <button
+          class="inline-flex items-center gap-1.5 text-[11px] text-accent bg-accent-muted px-2.5 py-1 rounded-full ring-1 ring-accent/20 hover:bg-accent/15 transition-colors cursor-pointer"
+          onClick={() => openUrl('https://github.com/SoftwareSavants/verun/blob/main/ROADMAP.md')}
+        >
           <Sparkles class="w-3 h-3" />
           Track progress in our public roadmap
-        </div>
+        </button>
       </div>
     </div>
   )

--- a/src/components/PluginsPage.tsx
+++ b/src/components/PluginsPage.tsx
@@ -1,8 +1,9 @@
 import { Component, For, Show, createMemo, createSignal, onMount } from 'solid-js'
-import { X, Search, RefreshCw } from 'lucide-solid'
+import { Search, RefreshCw, Puzzle } from 'lucide-solid'
 import { catalog, marketplaces, isSupported, isLoading, isInstalled, loadCatalog } from '../store/plugins'
-import { setShowPlugins, selectedProjectId } from '../store/ui'
+import { showPlugins, setShowPlugins, selectedProjectId } from '../store/ui'
 import { projects } from '../store/projects'
+import { Dialog } from './Dialog'
 import { PluginCard } from './PluginCard'
 
 type SortKey = 'installs' | 'name'
@@ -15,10 +16,6 @@ export const PluginsPage: Component = () => {
 
   onMount(() => { void loadCatalog() })
 
-  // When a project is selected we run installs from its worktree, which lets
-  // project / local scopes write to the right `.claude/settings.json`. With
-  // no project selected we restrict to user scope and run from the home dir
-  // so the CLI never falls back to writing into the wrong directory.
   const cwd = createMemo(() => {
     const pid = selectedProjectId()
     if (pid) {
@@ -28,6 +25,7 @@ export const PluginsPage: Component = () => {
     return ''
   })
   const allowProjectScope = createMemo(() => selectedProjectId() != null)
+  const showMarketplaceBadge = createMemo(() => marketplaces.length > 1)
 
   const filtered = createMemo(() => {
     const q = query().trim().toLowerCase()
@@ -57,91 +55,98 @@ export const PluginsPage: Component = () => {
   }
 
   return (
-    <div class="absolute inset-0 bg-bg z-20 flex flex-col">
-      <div class="flex items-center justify-between px-4 py-3 border-b-1 border-b-solid border-b-white/8">
-        <h1 class="text-lg font-medium">Plugins</h1>
-        <div class="flex items-center gap-2">
+    <Dialog open={showPlugins()} onClose={() => setShowPlugins(false)} width="min(92vw, 80rem)">
+      <div class="flex flex-col" style={{ 'min-height': '60vh', 'max-height': 'calc(100vh - 10rem)' }}>
+        {/* Consolidated header: title + search + controls in one row */}
+        <div class="flex items-center gap-3 mb-4">
+          <div class="flex items-center gap-2 shrink-0">
+            <Puzzle size={16} class="text-accent" />
+            <h2 class="text-sm font-semibold text-text-primary">Plugins</h2>
+          </div>
+          <Show when={isSupported() !== false}>
+            <div class="relative flex-1 min-w-0">
+              <Search class="w-3.5 h-3.5 absolute left-2 top-1/2 -translate-y-1/2 text-text-dim" />
+              <input
+                type="text"
+                placeholder="Search plugins…"
+                class="input-base w-full pl-7 pr-3 py-1 text-[12px]"
+                value={query()}
+                onInput={e => setQuery(e.currentTarget.value)}
+              />
+            </div>
+            <label class="flex items-center gap-1.5 text-[11px] text-text-secondary shrink-0">
+              <input
+                type="checkbox"
+                checked={installedOnly()}
+                onChange={e => setInstalledOnly(e.currentTarget.checked)}
+                aria-label="Installed only"
+              />
+              Installed only
+            </label>
+            <select
+              class="input-base px-2 py-1 text-[11px] shrink-0"
+              value={sortKey()}
+              onChange={e => setSortKey(e.currentTarget.value as SortKey)}
+            >
+              <option value="installs">Most installed</option>
+              <option value="name">Name</option>
+            </select>
+          </Show>
           <button
-            class="p-1 rounded hover:bg-white/5"
+            class="p-1 rounded text-text-dim hover:text-text-secondary hover:bg-surface-3 transition-colors"
             onClick={() => loadCatalog()}
             title="Refresh"
             disabled={isLoading()}
           >
-            <RefreshCw class={`w-4 h-4 ${isLoading() ? 'animate-spin' : ''}`} />
-          </button>
-          <button class="p-1 rounded hover:bg-white/5" onClick={() => setShowPlugins(false)} aria-label="Close">
-            <X class="w-4 h-4" />
+            <RefreshCw class={`w-3.5 h-3.5 ${isLoading() ? 'animate-spin' : ''}`} />
           </button>
         </div>
-      </div>
 
-      <Show when={isSupported() === false}>
-        <div class="p-8 text-center text-sm text-fg/60">
-          Update Claude Code to 2.0+ to use the plugin marketplace.
-        </div>
-      </Show>
-
-      <Show when={isSupported() !== false}>
-        <div class="px-4 py-3 flex items-center gap-3 flex-wrap border-b-1 border-b-solid border-b-white/8">
-          <div class="relative flex-1 min-w-60">
-            <Search class="w-4 h-4 absolute left-2 top-1/2 -translate-y-1/2 text-fg/40" />
-            <input
-              type="text"
-              placeholder="Search plugins…"
-              class="w-full pl-8 pr-3 py-1.5 rounded ring-1 ring-white/10 bg-bg text-sm focus:ring-accent focus:outline-none"
-              value={query()}
-              onInput={e => setQuery(e.currentTarget.value)}
-            />
-          </div>
-          <label class="flex items-center gap-1.5 text-sm text-fg/80">
-            <input
-              type="checkbox"
-              checked={installedOnly()}
-              onChange={e => setInstalledOnly(e.currentTarget.checked)}
-              aria-label="Installed only"
-            />
-            Installed only
-          </label>
-          <select
-            class="px-2 py-1.5 rounded ring-1 ring-white/10 bg-bg text-sm"
-            value={sortKey()}
-            onChange={e => setSortKey(e.currentTarget.value as SortKey)}
-          >
-            <option value="installs">Most installed</option>
-            <option value="name">Name</option>
-          </select>
-        </div>
-
-        <Show when={marketplaces.length > 1}>
-          <div class="px-4 py-2 flex items-center gap-2 flex-wrap border-b-1 border-b-solid border-b-white/8">
-            <span class="text-xs text-fg/50">Marketplaces:</span>
-            <For each={marketplaces}>
-              {mp => {
-                const active = () => marketplaceFilter().has(mp.name)
-                return (
-                  <button
-                    class={`px-2 py-0.5 rounded-full text-xs ring-1 ${active() ? 'ring-accent bg-accent/10 text-accent' : 'ring-white/10 hover:bg-white/5'}`}
-                    onClick={() => toggleMp(mp.name)}
-                  >
-                    {mp.name}
-                  </button>
-                )
-              }}
-            </For>
+        <Show when={isSupported() === false}>
+          <div class="p-8 text-center text-sm text-text-dim">
+            Update Claude Code to 2.0+ to use the plugin marketplace.
           </div>
         </Show>
 
-        <div class="flex-1 overflow-auto p-4">
-          <Show when={!isLoading() && filtered().length === 0}>
-            <p class="text-sm text-fg/60 text-center py-8">No plugins match your filters.</p>
+        <Show when={isSupported() !== false}>
+          <Show when={showMarketplaceBadge()}>
+            <div class="flex items-center gap-2 flex-wrap mb-3">
+              <span class="text-[10px] uppercase tracking-wider text-text-dim">Marketplaces</span>
+              <For each={marketplaces}>
+                {mp => {
+                  const active = () => marketplaceFilter().has(mp.name)
+                  return (
+                    <button
+                      class={`px-2 py-0.5 rounded-full text-[11px] ring-1 ${active() ? 'ring-accent bg-accent/10 text-accent' : 'ring-white/10 text-text-secondary hover:bg-white/5'}`}
+                      onClick={() => toggleMp(mp.name)}
+                    >
+                      {mp.name}
+                    </button>
+                  )
+                }}
+              </For>
+            </div>
           </Show>
-          <div class="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-3">
-            <For each={filtered()}>
-              {p => <PluginCard plugin={p} cwd={cwd()} allowProjectScope={allowProjectScope()} />}
-            </For>
+
+          <div class="flex-1 overflow-y-auto -mx-1 px-1">
+            <Show when={!isLoading() && filtered().length === 0}>
+              <p class="text-sm text-text-dim text-center py-8">No plugins match your filters.</p>
+            </Show>
+            <div class="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-3">
+              <For each={filtered()}>
+                {p => (
+                  <PluginCard
+                    plugin={p}
+                    cwd={cwd()}
+                    allowProjectScope={allowProjectScope()}
+                    showMarketplace={showMarketplaceBadge()}
+                  />
+                )}
+              </For>
+            </div>
           </div>
-        </div>
-      </Show>
-    </div>
+        </Show>
+      </div>
+    </Dialog>
   )
 }

--- a/src/components/PluginsPage.tsx
+++ b/src/components/PluginsPage.tsx
@@ -1,15 +1,23 @@
 import { Component, For, Show, createMemo, createSignal, onMount } from 'solid-js'
-import { Search, RefreshCw } from 'lucide-solid'
+import { Search, RefreshCw, Sparkles } from 'lucide-solid'
+import type { AgentType } from '../types'
+import { AGENT_DISPLAY_NAMES } from '../types'
 import { catalog, marketplaces, isSupported, isLoading, isInstalled, loadCatalog } from '../store/plugins'
 import { showPlugins, setShowPlugins, selectedProjectId } from '../store/ui'
 import { projects } from '../store/projects'
+import { agentIcon } from '../lib/agents'
 import { Dialog } from './Dialog'
 import { PluginCard } from './PluginCard'
+import SvgIcon from './SvgIcon'
 
 type SortKey = 'installs' | 'name'
 type MarketplaceFilterValue = 'all' | string
 
+const AGENT_ORDER: AgentType[] = ['claude', 'codex', 'cursor', 'gemini', 'opencode']
+const SUPPORTED_AGENTS = new Set<AgentType>(['claude'])
+
 export const PluginsPage: Component = () => {
+  const [activeAgent, setActiveAgent] = createSignal<AgentType>('claude')
   const [query, setQuery] = createSignal('')
   const [installedOnly, setInstalledOnly] = createSignal(false)
   const [marketplaceFilter, setMarketplaceFilter] = createSignal<MarketplaceFilterValue>('all')
@@ -52,87 +60,155 @@ export const PluginsPage: Component = () => {
   return (
     <Dialog open={showPlugins()} onClose={() => setShowPlugins(false)} width="min(92vw, 80rem)">
       <div class="flex flex-col" style={{ 'min-height': '60vh', 'max-height': 'calc(100vh - 10rem)' }}>
-        <div class="flex items-center gap-2 mb-4">
-          <h2 class="text-sm font-semibold text-text-primary shrink-0 mr-1">Plugins</h2>
-          <Show when={isSupported() !== false}>
-            <div class="relative flex-1 min-w-0">
-              <Search class="w-3.5 h-3.5 absolute left-2 top-1/2 -translate-y-1/2 text-text-dim" />
-              <input
-                type="text"
-                placeholder="Search plugins…"
-                class="w-full bg-surface-1 border border-border rounded-md pl-7 pr-3 py-1 text-[12px] text-text-primary outline-none focus:border-accent transition-colors"
-                value={query()}
-                onInput={e => setQuery(e.currentTarget.value)}
-              />
-            </div>
-            <Show when={showMarketplaceBadge()}>
-              <select
-                class={selectClass}
-                value={marketplaceFilter()}
-                onChange={e => setMarketplaceFilter(e.currentTarget.value)}
-                title="Filter by marketplace"
-              >
-                <option value="all">All marketplaces</option>
-                <For each={marketplaces}>
-                  {mp => <option value={mp.name}>{mp.name}</option>}
-                </For>
-              </select>
-            </Show>
-            <select
-              class={selectClass}
-              value={sortKey()}
-              onChange={e => setSortKey(e.currentTarget.value as SortKey)}
-              title="Sort"
-            >
-              <option value="installs">Most installed</option>
-              <option value="name">Alphabetical</option>
-            </select>
-            <label class="flex items-center gap-1.5 text-[11px] text-text-secondary shrink-0 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={installedOnly()}
-                onChange={e => setInstalledOnly(e.currentTarget.checked)}
-                aria-label="Installed only"
-              />
-              Installed only
-            </label>
-          </Show>
+        <div class="flex items-center justify-between mb-4">
+          <h2 class="text-sm font-semibold text-text-primary">Plugins</h2>
           <button
-            class="p-1 rounded text-text-dim hover:text-text-secondary hover:bg-surface-3 transition-colors shrink-0"
+            class="p-1 rounded text-text-dim hover:text-text-secondary hover:bg-surface-3 transition-colors disabled:opacity-50"
             onClick={() => loadCatalog()}
             title="Refresh"
-            disabled={isLoading()}
+            disabled={isLoading() || activeAgent() !== 'claude'}
           >
             <RefreshCw class={`w-3.5 h-3.5 ${isLoading() ? 'animate-spin' : ''}`} />
           </button>
         </div>
 
-        <Show when={isSupported() === false}>
-          <div class="p-8 text-center text-sm text-text-dim">
-            Update Claude Code to 2.0+ to use the plugin marketplace.
-          </div>
-        </Show>
+        <div class="flex-1 grid grid-cols-[180px_1fr] gap-4 min-h-0">
+          {/* Agent rail */}
+          <nav class="flex flex-col gap-0.5">
+            <For each={AGENT_ORDER}>
+              {agent => {
+                const active = () => activeAgent() === agent
+                const supported = SUPPORTED_AGENTS.has(agent)
+                return (
+                  <button
+                    class={`group flex items-center gap-2.5 px-2.5 py-2 rounded-md text-left transition-colors ${
+                      active()
+                        ? 'bg-accent-muted text-accent ring-1 ring-accent/30'
+                        : 'text-text-secondary hover:bg-surface-3'
+                    }`}
+                    onClick={() => setActiveAgent(agent)}
+                  >
+                    <SvgIcon svg={agentIcon(agent)} size={16} />
+                    <span class="text-[12px] font-medium flex-1 truncate">{AGENT_DISPLAY_NAMES[agent]}</span>
+                    <Show when={!supported}>
+                      <span class={`text-[9px] uppercase tracking-wider px-1 py-0.5 rounded ring-1 ${
+                        active() ? 'ring-accent/30' : 'ring-white/10 text-text-dim'
+                      }`}>
+                        Soon
+                      </span>
+                    </Show>
+                  </button>
+                )
+              }}
+            </For>
+          </nav>
 
-        <Show when={isSupported() !== false}>
-          <div class="flex-1 overflow-y-auto -mx-1 px-1">
-            <Show when={!isLoading() && filtered().length === 0}>
-              <p class="text-sm text-text-dim text-center py-8">No plugins match your filters.</p>
+          {/* Right panel */}
+          <div class="flex flex-col min-h-0 min-w-0">
+            <Show
+              when={SUPPORTED_AGENTS.has(activeAgent())}
+              fallback={<ComingSoon agent={activeAgent()} />}
+            >
+              <Show when={isSupported() === false}>
+                <div class="p-8 text-center text-sm text-text-dim">
+                  Update Claude Code to 2.0+ to use the plugin marketplace.
+                </div>
+              </Show>
+
+              <Show when={isSupported() !== false}>
+                <div class="flex items-center gap-2 mb-3">
+                  <div class="relative flex-1 min-w-0">
+                    <Search class="w-3.5 h-3.5 absolute left-2 top-1/2 -translate-y-1/2 text-text-dim" />
+                    <input
+                      type="text"
+                      placeholder="Search plugins…"
+                      class="w-full bg-surface-1 border border-border rounded-md pl-7 pr-3 py-1 text-[12px] text-text-primary outline-none focus:border-accent transition-colors"
+                      value={query()}
+                      onInput={e => setQuery(e.currentTarget.value)}
+                    />
+                  </div>
+                  <Show when={showMarketplaceBadge()}>
+                    <select
+                      class={selectClass}
+                      value={marketplaceFilter()}
+                      onChange={e => setMarketplaceFilter(e.currentTarget.value)}
+                      title="Filter by marketplace"
+                    >
+                      <option value="all">All marketplaces</option>
+                      <For each={marketplaces}>
+                        {mp => <option value={mp.name}>{mp.name}</option>}
+                      </For>
+                    </select>
+                  </Show>
+                  <select
+                    class={selectClass}
+                    value={sortKey()}
+                    onChange={e => setSortKey(e.currentTarget.value as SortKey)}
+                    title="Sort"
+                  >
+                    <option value="installs">Most installed</option>
+                    <option value="name">Alphabetical</option>
+                  </select>
+                  <label class="flex items-center gap-1.5 text-[11px] text-text-secondary shrink-0 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={installedOnly()}
+                      onChange={e => setInstalledOnly(e.currentTarget.checked)}
+                      aria-label="Installed only"
+                    />
+                    Installed only
+                  </label>
+                </div>
+
+                <div class="flex-1 overflow-y-auto -mx-1 px-1">
+                  <Show when={!isLoading() && filtered().length === 0}>
+                    <p class="text-sm text-text-dim text-center py-8">No plugins match your filters.</p>
+                  </Show>
+                  <div class="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-3">
+                    <For each={filtered()}>
+                      {p => (
+                        <PluginCard
+                          plugin={p}
+                          cwd={cwd()}
+                          allowProjectScope={allowProjectScope()}
+                          showMarketplace={showMarketplaceBadge()}
+                        />
+                      )}
+                    </For>
+                  </div>
+                </div>
+              </Show>
             </Show>
-            <div class="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-3">
-              <For each={filtered()}>
-                {p => (
-                  <PluginCard
-                    plugin={p}
-                    cwd={cwd()}
-                    allowProjectScope={allowProjectScope()}
-                    showMarketplace={showMarketplaceBadge()}
-                  />
-                )}
-              </For>
-            </div>
           </div>
-        </Show>
+        </div>
       </div>
     </Dialog>
+  )
+}
+
+const ComingSoon: Component<{ agent: AgentType }> = (props) => {
+  const name = () => AGENT_DISPLAY_NAMES[props.agent]
+  return (
+    <div class="flex-1 flex items-center justify-center">
+      <div class="max-w-md text-center">
+        <div class="relative inline-flex mb-5">
+          <div class="absolute inset-0 blur-2xl bg-accent/15 rounded-full" />
+          <div class="relative w-16 h-16 rounded-2xl bg-surface-1 ring-1 ring-white/8 flex items-center justify-center">
+            <SvgIcon svg={agentIcon(props.agent)} size={32} />
+          </div>
+        </div>
+        <h3 class="text-base font-semibold text-text-primary mb-1.5">
+          {name()} plugins coming soon
+        </h3>
+        <p class="text-sm text-text-secondary leading-relaxed mb-4">
+          Verun's plugin browser currently supports Claude Code only.
+          {' '}{name()} support is on the roadmap.
+        </p>
+        <div class="inline-flex items-center gap-1.5 text-[11px] text-accent bg-accent-muted px-2.5 py-1 rounded-full ring-1 ring-accent/20">
+          <Sparkles class="w-3 h-3" />
+          Track progress in our public roadmap
+        </div>
+      </div>
+    </div>
   )
 }

--- a/src/components/PluginsPage.tsx
+++ b/src/components/PluginsPage.tsx
@@ -72,29 +72,33 @@ export const PluginsPage: Component = () => {
           </button>
         </div>
 
-        <div class="flex-1 grid grid-cols-[180px_1fr] gap-4 min-h-0">
+        <div class="flex-1 grid grid-cols-[160px_1fr] min-h-0">
           {/* Agent rail */}
-          <nav class="flex flex-col gap-0.5">
+          <nav class="flex flex-col gap-0.5 border-r border-border pr-3 -my-1 py-1 overflow-y-auto">
+            <div class="text-[10px] font-medium uppercase tracking-wider text-text-dim px-2.5 mb-1">
+              Coding agent
+            </div>
             <For each={AGENT_ORDER}>
               {agent => {
                 const active = () => activeAgent() === agent
                 const supported = SUPPORTED_AGENTS.has(agent)
                 return (
                   <button
-                    class={`group flex items-center gap-2.5 px-2.5 py-2 rounded-md text-left transition-colors ${
+                    class={`relative flex items-center gap-2 pl-2.5 pr-2 py-1.5 rounded-md text-left transition-colors ${
                       active()
-                        ? 'bg-accent-muted text-accent ring-1 ring-accent/30'
-                        : 'text-text-secondary hover:bg-surface-3'
+                        ? 'bg-accent-muted text-accent'
+                        : 'text-text-secondary hover:bg-surface-3 hover:text-text-primary'
                     }`}
                     onClick={() => setActiveAgent(agent)}
                   >
-                    <SvgIcon svg={agentIcon(agent)} size={16} />
+                    <Show when={active()}>
+                      <span class="absolute left-0 top-1.5 bottom-1.5 w-0.5 rounded-r bg-accent" />
+                    </Show>
+                    <SvgIcon svg={agentIcon(agent)} size={14} />
                     <span class="text-[12px] font-medium flex-1 truncate">{AGENT_DISPLAY_NAMES[agent]}</span>
                     <Show when={!supported}>
-                      <span class={`text-[9px] uppercase tracking-wider px-1 py-0.5 rounded ring-1 ${
-                        active() ? 'ring-accent/30' : 'ring-white/10 text-text-dim'
-                      }`}>
-                        Soon
+                      <span class="text-[9px] uppercase tracking-wider text-text-dim font-medium">
+                        soon
                       </span>
                     </Show>
                   </button>
@@ -104,7 +108,7 @@ export const PluginsPage: Component = () => {
           </nav>
 
           {/* Right panel */}
-          <div class="flex flex-col min-h-0 min-w-0">
+          <div class="flex flex-col min-h-0 min-w-0 pl-4">
             <Show
               when={SUPPORTED_AGENTS.has(activeAgent())}
               fallback={<ComingSoon agent={activeAgent()} />}

--- a/src/components/PluginsPage.tsx
+++ b/src/components/PluginsPage.tsx
@@ -73,9 +73,9 @@ export const PluginsPage: Component = () => {
         </div>
 
         <div class="flex-1 grid grid-cols-[160px_1fr] min-h-0">
-          {/* Agent rail */}
-          <nav class="flex flex-col gap-0.5 border-r border-border pr-3 -my-1 py-1 overflow-y-auto">
-            <div class="text-[10px] font-medium uppercase tracking-wider text-text-dim px-2.5 mb-1">
+          {/* Agent rail — matches the app's main sidebar density */}
+          <nav class="flex flex-col gap-0.5 border-r border-border pr-2 -my-1 py-1 overflow-y-auto">
+            <div class="text-[10px] font-semibold uppercase tracking-wider text-text-muted px-2 mb-1">
               Coding agent
             </div>
             <For each={AGENT_ORDER}>
@@ -84,7 +84,7 @@ export const PluginsPage: Component = () => {
                 const supported = SUPPORTED_AGENTS.has(agent)
                 return (
                   <button
-                    class={`relative flex items-center gap-2 pl-2.5 pr-2 py-1.5 rounded-md text-left transition-colors ${
+                    class={`relative flex items-center gap-2 px-2 py-1 rounded-md text-left transition-colors ${
                       active()
                         ? 'bg-accent-muted text-accent'
                         : 'text-text-secondary hover:bg-surface-3 hover:text-text-primary'
@@ -92,7 +92,7 @@ export const PluginsPage: Component = () => {
                     onClick={() => setActiveAgent(agent)}
                   >
                     <Show when={active()}>
-                      <span class="absolute left-0 top-1.5 bottom-1.5 w-0.5 rounded-r bg-accent" />
+                      <span class="absolute left-0 top-1 bottom-1 w-0.5 rounded-r bg-accent" />
                     </Show>
                     <SvgIcon svg={agentIcon(agent)} size={14} />
                     <span class="text-[12px] font-medium flex-1 truncate">{AGENT_DISPLAY_NAMES[agent]}</span>
@@ -108,7 +108,7 @@ export const PluginsPage: Component = () => {
           </nav>
 
           {/* Right panel */}
-          <div class="flex flex-col min-h-0 min-w-0 pl-4">
+          <div class="flex flex-col min-h-0 min-w-0 pl-3">
             <Show
               when={SUPPORTED_AGENTS.has(activeAgent())}
               fallback={<ComingSoon agent={activeAgent()} />}

--- a/src/components/PluginsPage.tsx
+++ b/src/components/PluginsPage.tsx
@@ -60,7 +60,7 @@ export const PluginsPage: Component = () => {
   return (
     <Dialog open={showPlugins()} onClose={() => setShowPlugins(false)} width="min(92vw, 80rem)">
       <div class="-m-5 flex flex-col" style={{ height: 'min(78vh, 720px)' }}>
-        <div class="flex items-center justify-between px-4 py-3 border-b border-border">
+        <div class="flex items-center justify-between px-4 py-2 border-b border-border">
           <h2 class="text-sm font-semibold text-text-primary">Plugins</h2>
           <button
             class="p-1 rounded text-text-dim hover:text-text-secondary hover:bg-surface-3 transition-colors disabled:opacity-50"
@@ -74,7 +74,7 @@ export const PluginsPage: Component = () => {
 
         <div class="flex-1 grid grid-cols-[160px_1fr] min-h-0">
           {/* Agent rail — matches the app's main sidebar density */}
-          <nav class="flex flex-col gap-0.5 border-r border-border px-2 py-2 overflow-y-auto">
+          <nav class="flex flex-col gap-0.5 border-r border-border px-2 pt-2 pb-2 overflow-y-auto">
             <div class="text-[10px] font-semibold uppercase tracking-wider text-text-muted px-2.5 mb-1">
               Coding agent
             </div>
@@ -108,7 +108,7 @@ export const PluginsPage: Component = () => {
           </nav>
 
           {/* Right panel */}
-          <div class="flex flex-col min-h-0 min-w-0 px-4 py-3">
+          <div class="flex flex-col min-h-0 min-w-0 px-4 pt-2 pb-3">
             <Show
               when={SUPPORTED_AGENTS.has(activeAgent())}
               fallback={<ComingSoon agent={activeAgent()} />}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -31,6 +31,8 @@ import {
   setShowSettings,
   showArchived,
   setShowArchived,
+  showPlugins,
+  setShowPlugins,
   isTaskUnread,
   isTaskAttention,
   clearTaskIndicators,
@@ -62,6 +64,7 @@ import {
   Archive,
   Settings,
   Play,
+  Puzzle,
 } from "lucide-solid";
 import { clsx } from "clsx";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
@@ -545,11 +548,27 @@ export const Sidebar: Component = () => {
             onClick={() => {
               const next = !showArchived()
               setShowArchived(next)
-              if (next) { setShowSettings(false); setSelectedTaskId(null) }
+              if (next) { setShowSettings(false); setShowPlugins(false); setSelectedTaskId(null) }
             }}
             title="Archived"
           >
             <Archive size={14} />
+          </button>
+          <button
+            class={clsx(
+              'p-1.5 rounded-md transition-colors',
+              showPlugins()
+                ? 'text-accent bg-accent-muted'
+                : 'text-text-dim hover:text-text-secondary hover:bg-surface-3'
+            )}
+            onClick={() => {
+              const next = !showPlugins()
+              setShowPlugins(next)
+              if (next) { setShowSettings(false); setShowArchived(false) }
+            }}
+            title="Plugins"
+          >
+            <Puzzle size={14} />
           </button>
           <button
             class={clsx(
@@ -561,7 +580,7 @@ export const Sidebar: Component = () => {
             onClick={() => {
               const next = !showSettings()
               setShowSettings(next)
-              if (next) setShowArchived(false)
+              if (next) { setShowArchived(false); setShowPlugins(false) }
             }}
             title="Settings"
           >

--- a/src/lib/ipc.test.ts
+++ b/src/lib/ipc.test.ts
@@ -45,6 +45,15 @@ describe('ipc', () => {
     expect(typeof ipc.openInFinder).toBe('function')
   })
 
+  test('all plugin functions are exported', () => {
+    expect(typeof ipc.pluginIsSupported).toBe('function')
+    expect(typeof ipc.pluginListCatalog).toBe('function')
+    expect(typeof ipc.pluginListMarketplaces).toBe('function')
+    expect(typeof ipc.pluginInstall).toBe('function')
+    expect(typeof ipc.pluginUninstall).toBe('function')
+    expect(typeof ipc.pluginSetEnabled).toBe('function')
+  })
+
   test('blob store wrappers are exported', () => {
     expect(typeof ipc.uploadAttachment).toBe('function')
     expect(typeof ipc.getBlob).toBe('function')

--- a/src/lib/ipc.test.ts
+++ b/src/lib/ipc.test.ts
@@ -52,6 +52,7 @@ describe('ipc', () => {
     expect(typeof ipc.pluginInstall).toBe('function')
     expect(typeof ipc.pluginUninstall).toBe('function')
     expect(typeof ipc.pluginSetEnabled).toBe('function')
+    expect(typeof ipc.pluginReadManifest).toBe('function')
   })
 
   test('blob store wrappers are exported', () => {

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -1,5 +1,5 @@
 import { invoke } from '@tauri-apps/api/core'
-import type { Project, Task, TaskWithSession, Session, OutputLine, RepoInfo, AttachmentRef, AgentSkill, AgentInfo, AgentType, GitStatus, FileDiff, DiffContents, BranchCommit, GitHubRepo, PrInfo, CiCheck, WorkflowRun, WorkflowJob, ToolApprovalRequest, TrustLevel, AuditEntry, PtySpawnResult, PtyListEntry, FileEntry, Step, BlobRef, StorageStats, GitHubOverviewSnapshot, GitHubActionsSnapshot, WorkflowJobsSnapshot, WorkflowLogSnapshot, RemoteFetchMode, PluginCatalog, MarketplaceInfo, PluginScope } from '../types'
+import type { Project, Task, TaskWithSession, Session, OutputLine, RepoInfo, AttachmentRef, AgentSkill, AgentInfo, AgentType, GitStatus, FileDiff, DiffContents, BranchCommit, GitHubRepo, PrInfo, CiCheck, WorkflowRun, WorkflowJob, ToolApprovalRequest, TrustLevel, AuditEntry, PtySpawnResult, PtyListEntry, FileEntry, Step, BlobRef, StorageStats, GitHubOverviewSnapshot, GitHubActionsSnapshot, WorkflowJobsSnapshot, WorkflowLogSnapshot, RemoteFetchMode, PluginCatalog, MarketplaceInfo, PluginScope, PluginManifest } from '../types'
 
 const DEMO = import.meta.env.VITE_DEMO_MODE === 'true'
 const seed = () => import('./seedData')
@@ -571,3 +571,6 @@ export const pluginUninstall = (pluginId: string, cwd: string) =>
 
 export const pluginSetEnabled = (pluginId: string, enabled: boolean, cwd: string) =>
   invoke<void>('plugin_set_enabled', { pluginId, enabled, cwd })
+
+export const pluginReadManifest = (installPath: string) =>
+  invoke<PluginManifest>('plugin_read_manifest', { installPath })

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -1,5 +1,5 @@
 import { invoke } from '@tauri-apps/api/core'
-import type { Project, Task, TaskWithSession, Session, OutputLine, RepoInfo, AttachmentRef, AgentSkill, AgentInfo, AgentType, GitStatus, FileDiff, DiffContents, BranchCommit, GitHubRepo, PrInfo, CiCheck, WorkflowRun, WorkflowJob, ToolApprovalRequest, TrustLevel, AuditEntry, PtySpawnResult, PtyListEntry, FileEntry, Step, BlobRef, StorageStats, GitHubOverviewSnapshot, GitHubActionsSnapshot, WorkflowJobsSnapshot, WorkflowLogSnapshot, RemoteFetchMode } from '../types'
+import type { Project, Task, TaskWithSession, Session, OutputLine, RepoInfo, AttachmentRef, AgentSkill, AgentInfo, AgentType, GitStatus, FileDiff, DiffContents, BranchCommit, GitHubRepo, PrInfo, CiCheck, WorkflowRun, WorkflowJob, ToolApprovalRequest, TrustLevel, AuditEntry, PtySpawnResult, PtyListEntry, FileEntry, Step, BlobRef, StorageStats, GitHubOverviewSnapshot, GitHubActionsSnapshot, WorkflowJobsSnapshot, WorkflowLogSnapshot, RemoteFetchMode, PluginCatalog, MarketplaceInfo, PluginScope } from '../types'
 
 const DEMO = import.meta.env.VITE_DEMO_MODE === 'true'
 const seed = () => import('./seedData')
@@ -552,3 +552,22 @@ export interface MigrationReport {
 
 export const migrateLegacyAttachments = (): Promise<MigrationReport> =>
   invoke<MigrationReport>('migrate_legacy_attachments')
+
+// Plugins
+export const pluginIsSupported = () =>
+  invoke<boolean>('plugin_is_supported')
+
+export const pluginListCatalog = () =>
+  invoke<PluginCatalog>('plugin_list_catalog')
+
+export const pluginListMarketplaces = () =>
+  invoke<MarketplaceInfo[]>('plugin_list_marketplaces')
+
+export const pluginInstall = (pluginId: string, scope: PluginScope, cwd: string) =>
+  invoke<void>('plugin_install', { pluginId, scope, cwd })
+
+export const pluginUninstall = (pluginId: string, cwd: string) =>
+  invoke<void>('plugin_uninstall', { pluginId, cwd })
+
+export const pluginSetEnabled = (pluginId: string, enabled: boolean, cwd: string) =>
+  invoke<void>('plugin_set_enabled', { pluginId, enabled, cwd })

--- a/src/lib/pluginMeta.test.ts
+++ b/src/lib/pluginMeta.test.ts
@@ -1,0 +1,36 @@
+import { describe, test, expect } from 'vitest'
+import { detectPluginType, formatCompactCount } from './pluginMeta'
+
+describe('detectPluginType', () => {
+  test('detects MCP server', () => {
+    expect(detectPluginType('Upstash Context7 MCP server for documentation')).toBe('mcp')
+    expect(detectPluginType('Implements the Model Context Protocol')).toBe('mcp')
+  })
+
+  test('detects LSP', () => {
+    expect(detectPluginType('TypeScript/JavaScript language server')).toBe('lsp')
+    expect(detectPluginType('rust-analyzer LSP server for Rust')).toBe('lsp')
+  })
+
+  test('returns null for ambiguous text', () => {
+    expect(detectPluginType('Create new skills, improve existing skills')).toBeNull()
+    expect(detectPluginType('Comprehensive feature development workflow with specialized agents')).toBeNull()
+    expect(detectPluginType('Tools for git commit workflows')).toBeNull()
+  })
+})
+
+describe('formatCompactCount', () => {
+  test('formats thousands', () => {
+    expect(formatCompactCount(8126)).toBe('8.1K')
+    expect(formatCompactCount(52559)).toBe('53K')
+    expect(formatCompactCount(299640)).toBe('300K')
+  })
+  test('formats millions', () => {
+    expect(formatCompactCount(1_500_000)).toBe('1.5M')
+    expect(formatCompactCount(12_345_678)).toBe('12M')
+  })
+  test('passes through small numbers', () => {
+    expect(formatCompactCount(8)).toBe('8')
+    expect(formatCompactCount(123)).toBe('123')
+  })
+})

--- a/src/lib/pluginMeta.ts
+++ b/src/lib/pluginMeta.ts
@@ -1,0 +1,33 @@
+export type PluginType = 'mcp' | 'lsp'
+
+const TYPE_LABELS: Record<PluginType, string> = {
+  mcp: 'MCP',
+  lsp: 'LSP',
+}
+
+// Conservative: only flag types we can identify with very high precision from
+// the description text. Other types (skill / agent / commands / hooks) leak
+// false positives because plugins frequently mention them in passing without
+// being one. Better to show no chip than the wrong chip.
+export function detectPluginType(description: string): PluginType | null {
+  const text = description.toLowerCase()
+  if (/\bmcp\s+server|model context protocol/.test(text)) return 'mcp'
+  if (/\blanguage\s+server\b|\blsp\s+(server|integration)/.test(text)) return 'lsp'
+  return null
+}
+
+export function pluginTypeLabel(type: PluginType): string {
+  return TYPE_LABELS[type]
+}
+
+export function formatCompactCount(n: number): string {
+  if (n >= 1_000_000) {
+    const v = n / 1_000_000
+    return `${v < 10 ? v.toFixed(1).replace(/\.0$/, '') : Math.round(v)}M`
+  }
+  if (n >= 1_000) {
+    const v = n / 1_000
+    return `${v < 10 ? v.toFixed(1).replace(/\.0$/, '') : Math.round(v)}K`
+  }
+  return String(n)
+}

--- a/src/store/plugins.ts
+++ b/src/store/plugins.ts
@@ -9,6 +9,7 @@ export const [marketplaces, setMarketplaces] = createStore<MarketplaceInfo[]>([]
 export const [isSupported, setIsSupported] = createSignal<boolean | null>(null)
 export const [isLoading, setIsLoading] = createSignal(false)
 export const [pending, setPending] = createStore<Record<string, true>>({})
+export const [selectedPluginId, setSelectedPluginId] = createSignal<string | null>(null)
 
 export function isPending(pluginId: string): boolean {
   return !!pending[pluginId]
@@ -16,6 +17,10 @@ export function isPending(pluginId: string): boolean {
 
 export function isInstalled(pluginId: string): boolean {
   return catalog.installed.some(p => p.id === pluginId)
+}
+
+export function installedPluginById(pluginId: string) {
+  return catalog.installed.find(p => p.id === pluginId)
 }
 
 export async function loadCatalog() {

--- a/src/store/plugins.ts
+++ b/src/store/plugins.ts
@@ -1,0 +1,64 @@
+import { createStore } from 'solid-js/store'
+import { createSignal } from 'solid-js'
+import type { PluginCatalog, MarketplaceInfo, PluginScope } from '../types'
+import * as ipc from '../lib/ipc'
+import { addToast } from './ui'
+
+export const [catalog, setCatalog] = createStore<PluginCatalog>({ installed: [], available: [] })
+export const [marketplaces, setMarketplaces] = createStore<MarketplaceInfo[]>([])
+export const [isSupported, setIsSupported] = createSignal<boolean | null>(null)
+export const [isLoading, setIsLoading] = createSignal(false)
+export const [pending, setPending] = createStore<Record<string, true>>({})
+
+export function isPending(pluginId: string): boolean {
+  return !!pending[pluginId]
+}
+
+export function isInstalled(pluginId: string): boolean {
+  return catalog.installed.some(p => p.id === pluginId)
+}
+
+export async function loadCatalog() {
+  setIsLoading(true)
+  try {
+    const supported = await ipc.pluginIsSupported()
+    setIsSupported(supported)
+    if (!supported) return
+    const [cat, mps] = await Promise.all([
+      ipc.pluginListCatalog(),
+      ipc.pluginListMarketplaces(),
+    ])
+    setCatalog(cat)
+    setMarketplaces(mps)
+  } catch (e) {
+    addToast(`Failed to load plugin catalog: ${e}`, 'error')
+  } finally {
+    setIsLoading(false)
+  }
+}
+
+export async function installPlugin(pluginId: string, scope: PluginScope, cwd: string) {
+  setPending(pluginId, true)
+  try {
+    await ipc.pluginInstall(pluginId, scope, cwd)
+    await loadCatalog()
+    addToast(`Installed ${pluginId}`, 'success')
+  } catch (e) {
+    addToast(`Install failed: ${e}`, 'error')
+  } finally {
+    setPending(pluginId, undefined as unknown as true)
+  }
+}
+
+export async function uninstallPlugin(pluginId: string, cwd: string) {
+  setPending(pluginId, true)
+  try {
+    await ipc.pluginUninstall(pluginId, cwd)
+    await loadCatalog()
+    addToast(`Uninstalled ${pluginId}`, 'success')
+  } catch (e) {
+    addToast(`Uninstall failed: ${e}`, 'error')
+  } finally {
+    setPending(pluginId, undefined as unknown as true)
+  }
+}

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -158,6 +158,7 @@ export const [showBtsBuilder, setShowBtsBuilder] = createSignal(false)
 
 export const [showSettings, setShowSettings] = createSignal(false)
 export const [showArchived, setShowArchived] = createSignal(false)
+export const [showPlugins, setShowPlugins] = createSignal(false)
 export const [showQuickOpen, setShowQuickOpen] = createSignal(false)
 
 export function showTerminal(): boolean {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -525,3 +525,15 @@ export interface MarketplaceInfo {
   url?: string
   installLocation?: string
 }
+
+export interface PluginManifest {
+  /** Raw plugin.json contents (or null when missing). */
+  manifest: Record<string, unknown> | null
+  skills: string[]
+  commands: string[]
+  agents: string[]
+  hasHooks: boolean
+  hasMcpConfig: boolean
+  hasLspConfig: boolean
+  hasReadme: boolean
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -476,3 +476,52 @@ export interface Problem {
   code?: string | number
   source: string         // 'typescript', 'eslint', etc.
 }
+
+// ---------- Plugins ----------
+
+export type PluginScope = 'user' | 'project' | 'local'
+
+export interface PluginSourceObject {
+  source?: string
+  url?: string
+  repo?: string
+  path?: string
+  ref?: string
+  sha?: string
+}
+
+// Source can be either a structured object or a bare path string.
+export type PluginSource = PluginSourceObject | string
+
+export interface AvailablePlugin {
+  pluginId: string
+  name: string
+  description: string
+  marketplaceName: string
+  source: PluginSource
+  version?: string
+  installCount?: number
+}
+
+export interface InstalledPlugin {
+  id: string
+  version?: string
+  scope: PluginScope
+  enabled: boolean
+  installPath?: string
+  installedAt?: string
+  lastUpdated?: string
+}
+
+export interface PluginCatalog {
+  installed: InstalledPlugin[]
+  available: AvailablePlugin[]
+}
+
+export interface MarketplaceInfo {
+  name: string
+  source?: string
+  repo?: string
+  url?: string
+  installLocation?: string
+}


### PR DESCRIPTION
## Summary
- New Plugins dialog (sidebar puzzle icon) lists every Claude Code plugin from configured marketplaces; thin Rust wrapper over `claude plugin list/install/uninstall/marketplace` keeps the CLI as the source of truth
- Search across name + description, marketplace pill filter (only shown when 2+ marketplaces configured), "installed only" toggle, sort by install count or name; one-click install with scope picker (user / project / local)
- Scope picker is gated to user-only when no project is selected, so installs never write to the wrong `.claude/settings.json`

## Test plan
- [ ] Click Puzzle icon in sidebar - Plugins dialog opens, ~170 cards load
- [ ] Type `amplitude` in search - only matching cards remain
- [ ] Toggle "Installed only" - shows just the plugins already in `claude plugin list`
- [ ] With 2+ marketplaces, click a marketplace pill - filters to that marketplace; with 1 marketplace, the row is hidden
- [ ] Install a small plugin (e.g. `agent-sdk-dev`) - spinner, success toast, card flips to Uninstall
- [ ] Uninstall it - spinner, toast, card flips back
- [ ] Refresh button re-fetches the catalog
- [ ] With a project selected, scope picker shows user/project/local; with none selected, picker is hidden
- [ ] Click backdrop or press Escape - dialog closes
- [ ] If \`claude\` CLI is missing or pre-2.0, dialog shows "Update Claude Code to 2.0+" empty state