### PR TITLE
feat(claude): /btw side questions for ephemeral mid-stream Q&A

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Side question (`/btw`) for Claude sessions: ask an ephemeral question without polluting the transcript. Type `/btw <question>` in the composer (auto-completes from the slash-command palette), or - while the agent is streaming and you've scrolled to the bottom of the chat - click the small "Ask sideways /btw" pill that takes the place of the scroll-to-bottom button (same screen real estate, swapped by context). Q/A are not persisted to `output_lines` and never re-enter conversation history on resume; `synthetic` fallbacks are badged distinctly. Wires through a new `ask_side_question` Tauri command on top of the existing control-request plumbing.
 - Cmd+Alt+Left/Right now cycles between sessions in the current task when viewing a session (wraps at edges). The shortcut still cycles editor tabs when a file is open, mirroring Ctrl+Tab's view-aware behavior
 - File edits detected by the worktree watcher now trigger a debounced local git refresh, so status/commits/branch state update automatically as you change code without hitting GitHub
 - Local git refresh now uses non-locking read-only git commands, so viewing status no longer rewrites `.git/index` and self-triggers endless `git-local-changed` watcher loops

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Pluggable agent backend with first-class support for Claude Code and Codex (plan
 ## Stay in control without babysitting
 
 - **Steps** - queue follow-up prompts while an agent is working; arm them to auto-send on idle, or fire manually
+- **Side question (`/btw`)** - type `/btw <question>` mid-stream (or click the "Ask sideways" button that appears in the corner of the chat while Claude is working) to ask an ephemeral question - the answer shows in a floating panel and never enters conversation history
 - **Fork from any message** - hover any past reply to rewind the conversation in place, or branch into a new task with the worktree restored to the code as it was at that exact turn. Verun takes a git snapshot at every turn, so you can undo an entire direction - not just a line of code
 - **Tool approval** - configurable trust levels per task: supervised, normal, or full auto
 - **UI / Terminal toggle for Claude** - flip any Claude session into a real PTY running `claude --resume` to use the unmodified TUI, while history, fork, and search keep working because Verun tails the on-disk transcript. The mode is sticky per session with an app-wide default in Settings

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -935,6 +935,20 @@ pub async fn get_session_context_usage(
     task::get_session_context_usage(active.inner(), pending_ctrl.inner(), &session_id).await
 }
 
+/// Ask Claude an ephemeral side question (`/btw`) while a turn is mid-stream.
+/// Q/A are not persisted and never enter the conversation transcript.
+/// Returns `Ok(None)` when the CLI couldn't answer (e.g. before the first
+/// turn completes on a resumed session).
+#[tauri::command]
+pub async fn ask_side_question(
+    active: State<'_, ActiveMap>,
+    pending_ctrl: State<'_, PendingControlResponses>,
+    session_id: String,
+    question: String,
+) -> Result<Option<task::SideQuestionResponse>, String> {
+    task::send_side_question(active.inner(), pending_ctrl.inner(), &session_id, &question).await
+}
+
 /// Return session IDs that currently have an active process
 #[tauri::command]
 pub async fn get_active_sessions(active: State<'_, ActiveMap>) -> Result<Vec<String>, String> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -285,6 +285,7 @@ pub fn run() {
             ipc::abort_message,
             ipc::interrupt_session,
             ipc::get_session_context_usage,
+            ipc::ask_side_question,
             ipc::get_active_sessions,
             ipc::respond_to_approval,
             ipc::get_pending_approvals,

--- a/src-tauri/src/task.rs
+++ b/src-tauri/src/task.rs
@@ -2955,6 +2955,91 @@ pub async fn get_session_context_usage(
     }
 }
 
+/// Response shape for an ephemeral `/btw` side question. `synthetic = true`
+/// signals a fallback canned reply (e.g. when the turn isn't far enough along
+/// to answer meaningfully).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SideQuestionResponse {
+    pub response: String,
+    pub synthetic: bool,
+}
+
+/// Build the inner `request` body for a `side_question` control_request.
+/// Pure (no I/O) so the wire shape can be asserted in unit tests.
+fn build_side_question_request(question: &str) -> serde_json::Value {
+    serde_json::json!({
+        "subtype": "side_question",
+        "question": question,
+    })
+}
+
+/// Parse the CLI's `control_response` payload for a `side_question` request.
+/// The Anthropic SDK envelope is `{"response": {"subtype": "success",
+/// "request_id": ..., "response": {"response": "...", "synthetic": false}}}`,
+/// but `stream.rs` already unwraps one `response` layer before resolving the
+/// oneshot, so what arrives here is the inner `{"response": ..., "synthetic": ...}`.
+/// `null` at `response` means the CLI couldn't answer (e.g. before the first
+/// turn completes on a resumed session): returns `Ok(None)`.
+fn parse_side_question_response(
+    value: &serde_json::Value,
+) -> Result<Option<SideQuestionResponse>, String> {
+    let response_field = value
+        .get("response")
+        .ok_or_else(|| "side_question reply missing `response` field".to_string())?;
+    if response_field.is_null() {
+        return Ok(None);
+    }
+    let response = response_field
+        .as_str()
+        .ok_or_else(|| "side_question reply `response` is not a string".to_string())?
+        .to_string();
+    let synthetic = value
+        .get("synthetic")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    Ok(Some(SideQuestionResponse {
+        response,
+        synthetic,
+    }))
+}
+
+/// Ask Claude an ephemeral side question while a turn is mid-stream. The Q/A
+/// is not added to conversation history and never persisted to `output_lines`.
+/// Returns `Ok(None)` when the CLI returned a null response (e.g. nothing to
+/// answer about yet on a freshly resumed session).
+pub async fn send_side_question(
+    active: &ActiveMap,
+    pending: &PendingControlResponses,
+    session_id: &str,
+    question: &str,
+) -> Result<Option<SideQuestionResponse>, String> {
+    let stdin = active
+        .get(session_id)
+        .map(|proc| proc.stdin.clone())
+        .ok_or_else(|| "No active session".to_string())?;
+
+    let (request_id, rx) = send_control_request(
+        &stdin,
+        Some(pending),
+        build_side_question_request(question),
+    )
+    .await?;
+    let rx = rx.expect("pending map provided");
+
+    let result = tokio::time::timeout(Duration::from_secs(60), rx).await;
+
+    if result.is_err() {
+        pending.remove(&request_id);
+    }
+
+    match result {
+        Ok(Ok(Ok(v))) => parse_side_question_response(&v),
+        Ok(Ok(Err(e))) => Err(e),
+        Ok(Err(_)) => Err("Session closed before responding".to_string()),
+        Err(_) => Err("Timed out waiting for CLI response".to_string()),
+    }
+}
+
 fn title_generation_args(prompt: &str) -> Vec<String> {
     vec![
         "-p".into(),
@@ -3660,5 +3745,77 @@ mod tests {
         assert!(args.iter().any(|a| a == "test prompt"));
         assert!(args.iter().any(|a| a == "--no-session-persistence"));
         assert!(args.iter().any(|a| a == "haiku"));
+    }
+
+    #[test]
+    fn side_question_request_has_correct_wire_shape() {
+        let body = build_side_question_request("what was that var name?");
+        assert_eq!(body["subtype"], "side_question");
+        assert_eq!(body["question"], "what was that var name?");
+        // No extra top-level fields.
+        let obj = body.as_object().expect("object");
+        assert_eq!(obj.len(), 2);
+    }
+
+    // Note on shape: stream.rs unwraps one `response` layer before resolving
+    // the oneshot, so what `parse_side_question_response` sees is the inner
+    // `{"response": "...", "synthetic": ...}` object - not the SDK's outer
+    // `{"response": {"response": ..., "synthetic": ...}}` envelope.
+
+    #[test]
+    fn side_question_response_parses_full_payload() {
+        let v = serde_json::json!({ "response": "it was foo", "synthetic": false });
+        let parsed = parse_side_question_response(&v).unwrap();
+        assert_eq!(
+            parsed,
+            Some(SideQuestionResponse {
+                response: "it was foo".to_string(),
+                synthetic: false
+            })
+        );
+    }
+
+    #[test]
+    fn side_question_response_parses_synthetic_true() {
+        let v = serde_json::json!({ "response": "fallback", "synthetic": true });
+        let parsed = parse_side_question_response(&v).unwrap().unwrap();
+        assert!(parsed.synthetic);
+        assert_eq!(parsed.response, "fallback");
+    }
+
+    #[test]
+    fn side_question_response_defaults_synthetic_to_false_when_missing() {
+        let v = serde_json::json!({ "response": "ok" });
+        let parsed = parse_side_question_response(&v).unwrap().unwrap();
+        assert!(!parsed.synthetic);
+    }
+
+    #[test]
+    fn side_question_response_null_response_returns_none() {
+        let v = serde_json::json!({ "response": null, "synthetic": false });
+        let parsed = parse_side_question_response(&v).unwrap();
+        assert_eq!(parsed, None);
+    }
+
+    #[test]
+    fn side_question_response_missing_response_field_errors() {
+        let v = serde_json::json!({ "synthetic": true });
+        assert!(parse_side_question_response(&v).is_err());
+    }
+
+    #[test]
+    fn side_question_response_non_string_response_errors() {
+        let v = serde_json::json!({ "response": 42 });
+        assert!(parse_side_question_response(&v).is_err());
+    }
+
+    #[tokio::test]
+    async fn send_side_question_errors_when_session_not_active() {
+        let active = new_active_map();
+        let pending = new_pending_control_responses();
+        let err = send_side_question(&active, &pending, "no-such-session", "hi")
+            .await
+            .unwrap_err();
+        assert!(err.contains("No active session"), "got: {err}");
     }
 }

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -3,13 +3,14 @@ import { createStore, produce, reconcile } from 'solid-js/store'
 import { clsx } from 'clsx'
 import { renderMarkdown, handleMarkdownLinkClick, getWorktreePath } from '../lib/markdown'
 import type { OutputItem, SessionStatus, AttachmentRef } from '../types'
-import { ChevronDown, ChevronRight, AlertTriangle, Copy, Check, ArrowUp, ArrowDown, X, GitBranch, RotateCw, Plus, ChevronUp } from 'lucide-solid'
+import { ChevronDown, ChevronRight, AlertTriangle, Copy, Check, ArrowUp, ArrowDown, X, GitBranch, RotateCw, Plus, ChevronUp, MessageCircleQuestion } from 'lucide-solid'
 import { FileMentionBadge } from './FileMentionBadge'
 import { ImageViewer } from './ImageViewer'
 import { BlobImage } from './BlobImage'
 import { Popover } from './Popover'
 import { parseMentions } from '../lib/mentions'
 import * as ipc from '../lib/ipc'
+import { openSideQuestion, sideQuestionPanel } from '../store/sideQuestion'
 import { addToast, setSelectedTaskId, setSelectedSessionIdForTask } from '../store/ui'
 import { setSessions, loadOutputLines, loadOlderOutputLines, hasMoreOutputLines, sendMessage, createSession } from '../store/sessions'
 import { planModeForSession, thinkingModeForSession, fastModeForSession } from '../store/sessionContext'
@@ -1286,15 +1287,64 @@ export const ChatView: Component<Props> = (props) => {
         </Show>
       </div>
       </div>
-      <Show when={!isAtBottom()}>
-        <button
-          class="absolute bottom-4 right-4 z-10 w-7 h-7 flex items-center justify-center rounded-full bg-surface-2 ring-1 ring-outline/10 shadow-lg text-text-dim hover:text-text-secondary hover:ring-outline/20 transition-colors"
-          onClick={scrollToBottom}
-          title="Scroll to bottom"
-        >
-          <ChevronDown size={15} />
-        </button>
-      </Show>
+      {(() => {
+        const hasAiTurn = () => props.output.some((i) => i.kind !== 'userMessage')
+        const showBtw = () =>
+          isAtBottom()
+          && props.agentType === 'claude'
+          && !!props.sessionId
+          && hasAiTurn()
+          && sideQuestionPanel()?.sessionId !== props.sessionId
+        const showScroll = () => !isAtBottom()
+        // Both buttons share the same bottom-right pivot so they appear to
+        // morph out of/into the same anchor point instead of cross-fading
+        // as two competing rectangles.
+        const morph =
+          'absolute bottom-0 right-0 origin-bottom-right will-change-[transform,opacity] '
+          + 'transition-[opacity,transform] duration-[260ms] '
+          + 'ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none'
+        return (
+          <div class="absolute bottom-4 right-4 z-10 pointer-events-none">
+            <button
+              class={clsx(
+                morph,
+                'w-7 h-7 flex items-center justify-center rounded-full bg-surface-2 ring-1 ring-outline/10 shadow-lg text-text-dim hover:text-text-secondary hover:ring-outline/20',
+                showScroll()
+                  ? 'opacity-100 scale-100 pointer-events-auto'
+                  : 'opacity-0 scale-75 pointer-events-none',
+              )}
+              onClick={scrollToBottom}
+              title="Scroll to bottom"
+              aria-hidden={!showScroll()}
+              tabindex={showScroll() ? 0 : -1}
+            >
+              <ChevronDown size={15} />
+            </button>
+            <button
+              class={clsx(
+                morph,
+                'h-7 px-2.5 flex items-center gap-1.5 whitespace-nowrap rounded-full bg-surface-2 ring-1 ring-outline/10 shadow-lg text-text-dim hover:text-text-secondary hover:ring-outline/20 text-[11px]',
+                showBtw()
+                  ? 'opacity-100 scale-100 pointer-events-auto'
+                  : 'opacity-0 scale-75 pointer-events-none',
+              )}
+              onClick={() => {
+                const sid = props.sessionId
+                if (sid) openSideQuestion(sid)
+              }}
+              title="Ask Claude an ephemeral side question (does not enter conversation history)"
+              aria-hidden={!showBtw()}
+              tabindex={showBtw() ? 0 : -1}
+            >
+              <MessageCircleQuestion size={12} />
+              <span>
+                Ask sideways{' '}
+                <code class="ml-0.5 px-1 py-0.5 rounded bg-surface-3 text-text-dim text-[9px]">/btw</code>
+              </span>
+            </button>
+          </div>
+        )
+      })()}
       <Show when={viewerImage()}>
         {(img) => (
           <ImageViewer

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -21,6 +21,7 @@ import * as ipc from '../lib/ipc'
 import { Popover } from './Popover'
 import { ImageViewer } from './ImageViewer'
 import { BlobImage } from './BlobImage'
+import { openSideQuestion } from '../store/sideQuestion'
 import { serializeAttachments, deserializeAttachments, uploadAttachments } from '../lib/binary'
 import { formatCost as fmtCost, formatTokens as fmtTokens, formatDurationShort } from '../lib/format'
 
@@ -1001,18 +1002,33 @@ export const MessageInput: Component<Props> = (props) => {
         setPlanMode(!planMode())
         break
       }
+      case 'btw': {
+        const sid = props.sessionId
+        if (!sid) break
+        // Strip the `/btw ` prefix; whatever's left becomes the side question.
+        // Empty rest means "open the panel" - pass undefined so the panel
+        // restores the remembered Q/A instead of blanking it.
+        const rest = message().trim().replace(/^\/btw\s*/i, '')
+        openSideQuestion(sid, rest.length > 0 ? rest : undefined, rest.length > 0)
+        break
+      }
     }
     setMessage('')
     setShowPalette(false)
   }
 
   const handleCommandSelect = (cmd: Command) => {
-    if (cmd.category === 'app') {
+    // /btw is an app command but takes a free-form question, so insert the
+    // prefix and let the user type the question instead of firing immediately
+    // with empty text.
+    if (cmd.category === 'app' && cmd.name !== 'btw') {
       handleAppCommand(cmd)
     } else {
       setMessage(`/${cmd.name} `)
+      setInputContent(`/${cmd.name} `)
       setShowPalette(false)
       inputRef?.focus()
+      setCursorToEnd()
     }
   }
 
@@ -1308,7 +1324,7 @@ export const MessageInput: Component<Props> = (props) => {
       const msg = message().trim()
       if (msg.startsWith('/')) {
         const cmdName = msg.slice(1).split(/\s+/)[0]
-        const appCmds = ['new-session', 'clear', 'plan']
+        const appCmds = ['new-session', 'clear', 'plan', 'btw']
         if (appCmds.includes(cmdName)) {
           handleAppCommand({ name: cmdName, description: '', category: 'app' })
           return

--- a/src/components/SideQuestionPanel.tsx
+++ b/src/components/SideQuestionPanel.tsx
@@ -1,0 +1,229 @@
+import { Component, createSignal, createEffect, on, onMount, onCleanup, Show } from 'solid-js'
+import { Portal } from 'solid-js/web'
+import { X, Loader2, ArrowUp } from 'lucide-solid'
+import { clsx } from 'clsx'
+import { askSideQuestion } from '../lib/ipc'
+import { renderMarkdown, handleMarkdownLinkClick, getWorktreePath } from '../lib/markdown'
+import { registerDismissable } from '../lib/dismissable'
+import {
+  closeSideQuestion,
+  getRememberedSideQuestion,
+  rememberSideQuestion,
+} from '../store/sideQuestion'
+import type { SideQuestionResponse } from '../types'
+
+interface Props {
+  sessionId: string
+  taskId?: string
+  prefill?: string
+  autoSubmit?: boolean
+  /** Bumped on every `openSideQuestion` so we can re-seed even when other
+      props are unchanged (eg. user re-opens with the same session id). */
+  openId: number
+}
+
+export const SideQuestionPanel: Component<Props> = (props) => {
+  const [question, setQuestion] = createSignal('')
+  const [loading, setLoading] = createSignal(false)
+  const [answer, setAnswer] = createSignal<SideQuestionResponse | null | undefined>(undefined)
+  const [error, setError] = createSignal<string | null>(null)
+  let inputRef: HTMLTextAreaElement | undefined
+
+  const seed = (prefill: string | undefined, sessionId: string) => {
+    if (prefill !== undefined) {
+      setQuestion(prefill)
+      setAnswer(undefined)
+      setError(null)
+      return
+    }
+    const mem = getRememberedSideQuestion(sessionId)
+    if (mem) {
+      setQuestion(mem.question)
+      setAnswer(mem.answer ?? undefined)
+      setError(mem.error ?? null)
+    } else {
+      setQuestion('')
+      setAnswer(undefined)
+      setError(null)
+    }
+  }
+
+  // Initial seed (synchronous so first paint has the right values).
+  seed(props.prefill, props.sessionId)
+
+  const persist = () => {
+    rememberSideQuestion(props.sessionId, {
+      question: question(),
+      answer: answer() ?? null,
+      error: error(),
+    })
+  }
+
+  const focusAndSelectAll = () => {
+    if (!inputRef) return
+    const active = document.activeElement
+    const safe = active === null || active === document.body || active === inputRef
+    if (!safe) return
+    inputRef.focus()
+    inputRef.select()
+  }
+
+  const submit = async () => {
+    const q = question().trim()
+    if (!q || loading()) return
+    setError(null)
+    setAnswer(undefined)
+    setLoading(true)
+    // Keep the question highlighted while the request is in flight so the
+    // user can see what they asked and instantly retype to replace.
+    inputRef?.focus()
+    inputRef?.select()
+    try {
+      const result = await askSideQuestion(props.sessionId, q)
+      setAnswer(result)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setLoading(false)
+      persist()
+      focusAndSelectAll()
+    }
+  }
+
+  const onKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      submit()
+    }
+  }
+
+  onMount(() => {
+    inputRef?.focus()
+    if (question().length > 0) {
+      inputRef?.select()
+    }
+    const unregister = registerDismissable(closeSideQuestion)
+    onCleanup(() => {
+      unregister()
+      persist()
+    })
+    if (props.autoSubmit && question().trim()) {
+      submit()
+    }
+  })
+
+  // Re-seed when openId changes (re-open while still mounted, eg. user typed
+  // /btw on the same already-open session).
+  createEffect(on(
+    () => props.openId,
+    (_id, prev) => {
+      if (prev === undefined) return
+      seed(props.prefill, props.sessionId)
+      requestAnimationFrame(() => {
+        inputRef?.focus()
+        if (question().length > 0) inputRef?.select()
+      })
+      if (props.autoSubmit && question().trim()) {
+        submit()
+      }
+    },
+  ))
+
+  const hasAnswerArea = () => loading() || answer() !== undefined || error()
+  const canSend = () => question().trim().length > 0 && !loading()
+
+  return (
+    <Portal>
+      <div
+        class="fixed bottom-6 right-6 z-50 w-96 max-w-[calc(100vw-3rem)] rounded-xl bg-surface-1 ring-1 ring-outline/15 shadow-2xl flex flex-col side-question-enter"
+        role="dialog"
+        aria-label="Ask a side question"
+      >
+        {/* Header */}
+        <div class="flex items-center gap-2 px-3 py-2 border-b-1 border-b-solid border-b-border-subtle">
+          <span class="text-xs font-medium text-text-primary">Side question</span>
+          <span class="text-[10px] text-text-dim">ephemeral, not saved</span>
+          <button
+            class="ml-auto w-6 h-6 flex items-center justify-center rounded-md text-text-dim hover:text-text-muted hover:bg-surface-2 transition-colors"
+            onClick={closeSideQuestion}
+            title="Dismiss (Esc)"
+            aria-label="Dismiss"
+          >
+            <X size={14} />
+          </button>
+        </div>
+
+        {/* Answer area (above the composer, like the chat) */}
+        <Show when={hasAnswerArea()}>
+          <div class="px-3 py-2.5 max-h-80 overflow-y-auto border-b-1 border-b-solid border-b-border-subtle">
+            <Show when={loading()}>
+              <div class="text-xs text-text-dim flex items-center gap-2">
+                <Loader2 size={12} class="animate-spin" /> Asking Claude...
+              </div>
+            </Show>
+            <Show when={!loading() && error()}>
+              <div class="text-xs text-status-error">{error()}</div>
+            </Show>
+            <Show when={!loading() && answer() === null}>
+              <div class="text-xs text-text-dim italic">
+                Claude couldn't answer this side question right now.
+              </div>
+            </Show>
+            <Show when={!loading() && answer()}>
+              {(a) => (
+                <div>
+                  <Show when={a().synthetic}>
+                    <span class="inline-block text-[9px] uppercase tracking-wider px-1.5 py-0.5 mb-1.5 rounded-sm bg-amber-500/15 text-amber-500 font-semibold">
+                      synthetic
+                    </span>
+                  </Show>
+                  <div
+                    class="text-sm text-text-primary leading-relaxed prose-verun select-text break-words overflow-hidden"
+                    innerHTML={renderMarkdown(a().response, getWorktreePath(props.taskId))}
+                    onClick={(e) => handleMarkdownLinkClick(e, props.taskId)}
+                  />
+                </div>
+              )}
+            </Show>
+          </div>
+        </Show>
+
+        {/* Composer pinned to the bottom; send button overlaid in the
+            textarea's bottom-right corner so it reads as one input. */}
+        <div class="px-3 py-2.5">
+          <div class="relative">
+            <textarea
+              ref={inputRef}
+              value={question()}
+              onInput={(e) => setQuestion(e.currentTarget.value)}
+              onKeyDown={onKeyDown}
+              placeholder="Ask about the current turn..."
+              rows={2}
+              // `readonly` (not `disabled`) so the text stays at full opacity
+              // and the selection highlight remains visible while the request
+              // is in flight. Submit is gated on `loading()` separately.
+              readonly={loading()}
+              class="w-full bg-surface-2 ring-1 ring-outline/15 rounded-md pl-2 pr-10 py-1.5 text-sm text-text-primary placeholder:text-text-dim resize-none focus:outline-none focus:ring-outline/30"
+            />
+            <button
+              class={clsx(
+                'absolute bottom-1.5 right-1.5 w-7 h-7 flex items-center justify-center rounded-md transition-colors',
+                canSend()
+                  ? 'text-text-primary bg-surface-3 hover:bg-surface-4'
+                  : 'text-text-dim/40',
+              )}
+              onClick={submit}
+              disabled={!canSend()}
+              title="Ask (Enter)"
+              aria-label="Ask"
+            >
+              <Show when={!loading()} fallback={<Loader2 size={14} class="animate-spin" />}>
+                <ArrowUp size={14} />
+              </Show>
+            </button>
+          </div>
+        </div>
+      </div>
+    </Portal>
+  )
+}

--- a/src/components/TaskPanel.tsx
+++ b/src/components/TaskPanel.tsx
@@ -11,6 +11,8 @@ import { MessageInput } from './MessageInput'
 import { ChatView } from './ChatView'
 import { SessionTerminal } from './SessionTerminal'
 import { ClaudeViewToggle } from './ClaudeViewToggle'
+import { SideQuestionPanel } from './SideQuestionPanel'
+import { sideQuestionPanelData } from '../store/sideQuestion'
 import { sessionViewMode } from '../store/sessionViewMode'
 import { canUseTerminalView } from '../lib/terminalMode'
 import { RightPanel } from './RightPanel'
@@ -814,6 +816,17 @@ export const TaskPanel: Component = () => {
         }}
       </Show>
       <QuickOpen />
+      <Show when={sideQuestionPanelData()} keyed>
+        {(p) => (
+          <SideQuestionPanel
+            sessionId={p.sessionId}
+            taskId={sessionById(p.sessionId)?.taskId}
+            prefill={p.prefill}
+            autoSubmit={p.autoSubmit}
+            openId={p.openId}
+          />
+        )}
+      </Show>
     </div>
   )
 }

--- a/src/lib/ipc.test.ts
+++ b/src/lib/ipc.test.ts
@@ -1,7 +1,17 @@
-import { describe, test, expect } from 'vitest'
+import { describe, test, expect, vi, beforeEach } from 'vitest'
 import * as ipc from './ipc'
 
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}))
+
+import { invoke } from '@tauri-apps/api/core'
+
 describe('ipc', () => {
+  beforeEach(() => {
+    vi.mocked(invoke).mockReset()
+  })
+
   test('all project functions are exported', () => {
     expect(typeof ipc.addProject).toBe('function')
     expect(typeof ipc.listProjects).toBe('function')
@@ -49,5 +59,25 @@ describe('ipc', () => {
     expect(typeof ipc.uploadAttachment).toBe('function')
     expect(typeof ipc.getBlob).toBe('function')
     expect(typeof ipc.getStorageStats).toBe('function')
+  })
+
+  describe('askSideQuestion', () => {
+    test('forwards camelCase args to ask_side_question and resolves to typed object', async () => {
+      vi.mocked(invoke).mockResolvedValueOnce({ response: 'ok', synthetic: false })
+      const result = await ipc.askSideQuestion('s1', 'q?')
+      expect(invoke).toHaveBeenCalledWith('ask_side_question', { sessionId: 's1', question: 'q?' })
+      expect(result).toEqual({ response: 'ok', synthetic: false })
+    })
+
+    test('resolves to null when CLI cannot answer', async () => {
+      vi.mocked(invoke).mockResolvedValueOnce(null)
+      const result = await ipc.askSideQuestion('s1', 'q?')
+      expect(result).toBeNull()
+    })
+
+    test('rejects when invoke throws', async () => {
+      vi.mocked(invoke).mockRejectedValueOnce(new Error('No active session'))
+      await expect(ipc.askSideQuestion('s1', 'q?')).rejects.toThrow('No active session')
+    })
   })
 })

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -1,5 +1,5 @@
 import { invoke } from '@tauri-apps/api/core'
-import type { Project, Task, TaskWithSession, Session, OutputLine, RepoInfo, AttachmentRef, AgentSkill, AgentInfo, AgentType, GitStatus, FileDiff, DiffContents, BranchCommit, GitHubRepo, PrInfo, CiCheck, WorkflowRun, WorkflowJob, ToolApprovalRequest, TrustLevel, AuditEntry, PtySpawnResult, PtyListEntry, FileEntry, Step, BlobRef, StorageStats, GitHubOverviewSnapshot, GitHubActionsSnapshot, WorkflowJobsSnapshot, WorkflowLogSnapshot, RemoteFetchMode } from '../types'
+import type { Project, Task, TaskWithSession, Session, OutputLine, RepoInfo, AttachmentRef, AgentSkill, AgentInfo, AgentType, GitStatus, FileDiff, DiffContents, BranchCommit, GitHubRepo, PrInfo, CiCheck, WorkflowRun, WorkflowJob, ToolApprovalRequest, TrustLevel, AuditEntry, PtySpawnResult, PtyListEntry, FileEntry, Step, BlobRef, StorageStats, GitHubOverviewSnapshot, GitHubActionsSnapshot, WorkflowJobsSnapshot, WorkflowLogSnapshot, RemoteFetchMode, SideQuestionResponse } from '../types'
 
 const DEMO = import.meta.env.VITE_DEMO_MODE === 'true'
 const seed = () => import('./seedData')
@@ -95,6 +95,11 @@ export const interruptSession = (sessionId: string) =>
 
 export const getSessionContextUsage = (sessionId: string) =>
   invoke<unknown>('get_session_context_usage', { sessionId })
+
+// Ephemeral side question (`/btw`). Resolves to `null` when the CLI cannot
+// answer (e.g. on a freshly resumed session before the first turn completes).
+export const askSideQuestion = (sessionId: string, question: string) =>
+  invoke<SideQuestionResponse | null>('ask_side_question', { sessionId, question })
 
 export const getActiveSessions = (): Promise<string[]> =>
   DEMO ? Promise.resolve([]) : invoke<string[]>('get_active_sessions')

--- a/src/store/commands.ts
+++ b/src/store/commands.ts
@@ -23,6 +23,7 @@ export const APP_COMMANDS: Command[] = [
   { name: 'new-session', description: 'Create a new session on the current task', category: 'app' },
   { name: 'clear', description: 'Clear the current session output', category: 'app' },
   { name: 'plan', description: 'Toggle plan mode', category: 'app' },
+  { name: 'btw', description: 'Ask an ephemeral side question (not added to history)', category: 'app' },
 ]
 
 const byKey = new Map<string, AgentSkill[]>()

--- a/src/store/sideQuestion.ts
+++ b/src/store/sideQuestion.ts
@@ -1,0 +1,55 @@
+import { createSignal } from 'solid-js'
+import type { SideQuestionResponse } from '../types'
+
+interface PanelData {
+  sessionId: string
+  prefill?: string
+  autoSubmit?: boolean
+  /** Bumped on every open so the panel can detect re-opens with the same
+      sessionId/prefill (forces re-seed via createEffect). */
+  openId: number
+}
+
+export interface RememberedSideQuestion {
+  question: string
+  answer?: SideQuestionResponse | null
+  error?: string | null
+}
+
+const [panel, setPanel] = createSignal<PanelData | null>(null)
+const memory = new Map<string, RememberedSideQuestion>()
+let openCounter = 0
+
+/** Current panel data, or null when no panel is open. Drives both the
+    `<Show>` mount in TaskPanel and the bubble visibility in ChatView. */
+export const sideQuestionPanel = panel
+export const sideQuestionPanelData = panel
+
+export function openSideQuestion(sessionId: string, prefill?: string, autoSubmit = false) {
+  openCounter += 1
+  setPanel({ sessionId, prefill, autoSubmit, openId: openCounter })
+}
+
+export function toggleSideQuestion(sessionId: string) {
+  if (panel()?.sessionId === sessionId) {
+    closeSideQuestion()
+  } else {
+    openSideQuestion(sessionId)
+  }
+}
+
+export function closeSideQuestion() {
+  setPanel(null)
+}
+
+export function getRememberedSideQuestion(sessionId: string): RememberedSideQuestion | undefined {
+  return memory.get(sessionId)
+}
+
+export function rememberSideQuestion(sessionId: string, state: RememberedSideQuestion) {
+  memory.set(sessionId, state)
+}
+
+export function forgetSideQuestion(sessionId: string) {
+  memory.delete(sessionId)
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -476,3 +476,10 @@ export interface Problem {
   code?: string | number
   source: string         // 'typescript', 'eslint', etc.
 }
+
+// Side question (/btw) - ephemeral Q/A while a turn is mid-stream.
+// Q/A never enters conversation history nor `output_lines`.
+export interface SideQuestionResponse {
+  response: string
+  synthetic: boolean
+}

--- a/uno.config.ts
+++ b/uno.config.ts
@@ -209,6 +209,18 @@ export default defineConfig({
           box-shadow: inset 2px 0 0 rgba(96, 165, 250, 0.65);
         }
 
+        /* Side question panel enter animation - one-shot keyframe that fires
+           on mount, no JS state needed. Anchored to bottom-right so it grows
+           out of the corner it's pinned to. */
+        @keyframes sideQuestionEnter {
+          from { opacity: 0; transform: scale(0.95) translateY(0.5rem); }
+          to   { opacity: 1; transform: scale(1) translateY(0); }
+        }
+        .side-question-enter {
+          animation: sideQuestionEnter 220ms cubic-bezier(0.22, 1, 0.36, 1);
+          transform-origin: bottom right;
+        }
+
         /* Hide scrollbar but keep scrolling */
         .scrollbar-hide::-webkit-scrollbar { display: none; }
         .scrollbar-hide { scrollbar-width: none; }


### PR DESCRIPTION
## Summary

- Adds `/btw <question>` (and an "Ask sideways" corner button) that lets you ask Claude an ephemeral question while a turn is mid-stream — answer renders in a floating panel, nothing enters the conversation history.
- Backend routes the question via a Claude control request with a 60s timeout (`send_side_question` in `task.rs`, `ask_side_question` IPC command).
- Floating panel (`SideQuestionPanel.tsx`) has its own composer + answer area; per-session last Q/A is remembered so close + reopen restores state.

## UX details

- Corner button appears only when: agent is Claude, session is active, there's an AI turn, and the user is scrolled to the bottom — replaces the scroll-to-bottom button in that spot so it stays discoverable but unobtrusive.
- Composer stays focused with the question text selected during the request, so users can instantly retype to replace.
- Synthetic responses get an amber badge.

## Test plan

- [ ] `pnpm test` (frontend, including new `askSideQuestion` IPC tests)
- [ ] `cargo test` (backend, including `send_side_question` tests)
- [ ] Manual: type `/btw what's in this file?` mid-turn → answer renders without polluting history
- [ ] Manual: close panel and re-open via corner button → last Q/A is restored
- [ ] Manual: open panel, dismiss with Esc, re-open via `/btw` → composer is focused and seeded