### PR TITLE
Fix release builds failing under pnpm 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 
-- Add `pnpm-workspace.yaml` with `allowBuilds: { esbuild: true }` so CI release builds work under pnpm 11, which removed `onlyBuiltDependencies` and now hard-errors (`ERR_PNPM_IGNORED_BUILDS`) on unapproved dependency build scripts
-
 ## 0.11.0 — 2026-05-12
 
 ### Activity monitor
@@ -51,6 +49,7 @@
 - Fixed garbled text in all PTY views (Claude terminal, shell terminals, bootstrap log): multi-byte glyphs (😄, —, …) that spanned a read boundary were being split into replacement characters. The reader now buffers partial UTF-8 across reads so glyphs stay intact
 - Running terminals now repaint correctly when you flip dark ↔ light mode (xterm's WebGL renderer was caching the original palette)
 - Terminal panel chrome now tracks the active theme instead of staying black in light mode
+- Release builds no longer fail under pnpm 11, which removed `onlyBuiltDependencies` and now hard-errors (`ERR_PNPM_IGNORED_BUILDS`) on unapproved dependency build scripts; a `pnpm-workspace.yaml` now allows `esbuild`'s build script
 
 ### Polish
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `pnpm-workspace.yaml` with `allowBuilds: { esbuild: true }` so CI release builds work under pnpm 11, which removed `onlyBuiltDependencies` and now hard-errors (`ERR_PNPM_IGNORED_BUILDS`) on unapproved dependency build scripts
+
 ## 0.11.0 — 2026-05-12
 
 ### Activity monitor

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
## Why

The [Release workflow run](https://github.com/SoftwareSavants/verun/actions/runs/25744139038) failed: every `build-*` job died at **Install frontend dependencies** with

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: esbuild@0.25.12
Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
##[error]Process completed with exit code 1.
```

so no artifacts were produced and the `release` job was skipped.

**Root cause:** `release.yml` uses `pnpm/action-setup@v4` with `version: latest`, which now resolves to **pnpm 11.1.1**. pnpm 11 removed `onlyBuiltDependencies` and friends and now *hard-errors* (`ERR_PNPM_IGNORED_BUILDS`, exit 1) on any dependency with an unapproved build/lifecycle script. `esbuild@0.25.12` ships a `postinstall` (`node install.js`) and was never on an allowlist, so `pnpm install --frozen-lockfile` fails. Nothing in our code changed; pnpm shipped a major version.

## Fix

Add a `pnpm-workspace.yaml` with the pnpm 10.26+/11 replacement config:

```yaml
allowBuilds:
  esbuild: true
```

`esbuild` is the only package in the dependency tree with an install lifecycle script, so the allowlist is complete. `package.json` and `pnpm-lock.yaml` are untouched (`allowBuilds` is not written to the lockfile), so `--frozen-lockfile` stays happy.

The `version: latest` pin in the workflow is left as-is; the goal here was to make pnpm 11 work, not to freeze the toolchain.

## Verification

- Clean `pnpm install --frozen-lockfile` under **pnpm 11.1.1** (CI's version): exit 0, `esbuild postinstall: Done`, no `ERR_PNPM_IGNORED_BUILDS`.
- Same under local **pnpm 10.33.2**: exit 0.
- `make check`: 570 frontend tests pass, Rust tests pass, clippy clean.

## Notes

The changelog note is filed under the existing `## 0.11.0` section (not `## Unreleased`) on purpose: this lands in the re-run of the 0.11.0 release once merged.

No related open issues.