### PR TITLE
ci: drop MSI bundle target to fix Windows release build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 - Running terminals now repaint correctly when you flip dark ↔ light mode (xterm's WebGL renderer was caching the original palette)
 - Terminal panel chrome now tracks the active theme instead of staying black in light mode
 - Release builds no longer fail under pnpm 11, which removed `onlyBuiltDependencies` and now hard-errors (`ERR_PNPM_IGNORED_BUILDS`) on unapproved dependency build scripts; a `pnpm-workspace.yaml` now allows `esbuild`'s build script
+- Windows release builds no longer fail in WiX `light.exe`: the MSI bundle target is dropped (the release only ships the NSIS installer), so the bundled LSP `node_modules` tree no longer chokes the MSI packager
 
 ### Polish
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -37,7 +37,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": "all",
+    "targets": ["app", "dmg", "deb", "rpm", "appimage", "nsis"],
     "resources": [
       "resources/lsp/node_modules/**/*"
     ],


### PR DESCRIPTION
## Summary

- The Windows release job has been failing in WiX `light.exe` while bundling the MSI (`Verun_0.11.0_x64_en-US.msi`). Tauri swallows light's stderr, but the failure surfaced once 0.11.0 added the bundled LSP `node_modules` tree (`resources/lsp/node_modules/**/*`) + the MCP relay sidecar to `bundle.resources` - a node_modules-sized component set is the textbook trigger for `light.exe` blowing up during ICE validation. macOS/Linux use `"targets": "all"` too but their packagers don't choke on file count.
- The MSI is dead output: the release workflow only uploads `bundle/nsis/*.exe`, the updater config points at the NSIS `.exe`, and `msi` is referenced nowhere else in the repo.
- Fix: `bundle.targets` goes from `"all"` to `["app", "dmg", "deb", "rpm", "appimage", "nsis"]` (every "all" target except `msi`). macOS/Linux output is unchanged; Windows now builds NSIS only.

Failing run: https://github.com/SoftwareSavants/verun/actions/runs/25763028871/job/75668790538

\`check-version\` already reports \`should_release=true\` (no \`v0.11.0\` tag exists yet), so merging this re-triggers the 0.11.0 release.

## Test plan

- [ ] Release workflow's \`build-windows\` job goes green (no real local test surface - nothing in \`make check\` exercises \`tauri build\` bundle targets)
- [ ] \`release\` job publishes v0.11.0 with the NSIS installer + updater sig as before