### PR TITLE
feat(side-question): background requests + loading/unread pill states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- "Ask sideways" pill no longer overlaps the last user bubble when the agent is idle and the user's message is the most recent one (e.g. after an interrupt) - the chat reserves extra bottom space in that case so the pill sits below the message
+- Side question requests now keep running in the background if the panel is closed mid-flight. The "Ask sideways" pill shows a spinner ("Asking sideways...") while a request is in progress, then switches to an "Answer ready" state (accent ring + sparkle icon) when the answer arrives while the panel is closed. Click the pill to reopen and view the answer, or the inline X to dismiss the notification without opening
+
 ## 0.11.0 — 2026-05-12
 
 ### Activity monitor

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -3,14 +3,19 @@ import { createStore, produce, reconcile } from 'solid-js/store'
 import { clsx } from 'clsx'
 import { renderMarkdown, handleMarkdownLinkClick, getWorktreePath } from '../lib/markdown'
 import type { OutputItem, SessionStatus, AttachmentRef } from '../types'
-import { ChevronDown, ChevronRight, AlertTriangle, Copy, Check, ArrowUp, ArrowDown, X, GitBranch, RotateCw, Plus, ChevronUp, MessageCircleQuestion } from 'lucide-solid'
+import { ChevronDown, ChevronRight, AlertTriangle, Copy, Check, ArrowUp, ArrowDown, X, GitBranch, RotateCw, Plus, ChevronUp, MessageCircleQuestion, Loader2, Sparkles } from 'lucide-solid'
 import { FileMentionBadge } from './FileMentionBadge'
 import { ImageViewer } from './ImageViewer'
 import { BlobImage } from './BlobImage'
 import { Popover } from './Popover'
 import { parseMentions } from '../lib/mentions'
 import * as ipc from '../lib/ipc'
-import { openSideQuestion, sideQuestionPanel } from '../store/sideQuestion'
+import {
+  dismissSideQuestionUnread,
+  openSideQuestion,
+  sideQuestionPanel,
+  sideQuestionState,
+} from '../store/sideQuestion'
 import { addToast, setSelectedTaskId, setSelectedSessionIdForTask } from '../store/ui'
 import { setSessions, loadOutputLines, loadOlderOutputLines, hasMoreOutputLines, sendMessage, createSession } from '../store/sessions'
 import { planModeForSession, thinkingModeForSession, fastModeForSession } from '../store/sessionContext'
@@ -841,6 +846,32 @@ export const ChatView: Component<Props> = (props) => {
   // Scroll to bottom button visibility
   const [isAtBottom, setIsAtBottom] = createSignal(true)
 
+  const hasAiTurn = () => props.output.some((i) => i.kind !== 'userMessage')
+  const btwState = () => props.sessionId ? sideQuestionState(props.sessionId) : undefined
+  // The pill is "sticky" (visible regardless of scroll position) when there's
+  // a side question in flight or an unread answer for this session - those are
+  // notification states the user shouldn't miss by scrolling away.
+  const btwSticky = () => !!btwState()?.loading || !!btwState()?.unread
+  const btwMode = (): 'idle' | 'loading' | 'unread' => {
+    const s = btwState()
+    if (s?.loading) return 'loading'
+    if (s?.unread) return 'unread'
+    return 'idle'
+  }
+  const showBtw = () =>
+    props.agentType === 'claude'
+    && !!props.sessionId
+    && sideQuestionPanel()?.sessionId !== props.sessionId
+    && (btwSticky() || (isAtBottom() && hasAiTurn()))
+  // Reserve extra bottom space only when the pill would otherwise sit on top
+  // of the user's last message: agent isn't streaming and the last rendered
+  // block is user-authored (e.g. user interrupted a turn). Checking the last
+  // *block* (not raw output) ignores trailing turnEnd/turnSnapshot items.
+  const needsBtwPad = () =>
+    showBtw()
+    && props.sessionStatus !== 'running'
+    && blocks[blocks.length - 1]?.type === 'user'
+
   // Search state
   const [showSearch, setShowSearch] = createSignal(false)
   const [searchQuery, setSearchQuery] = createSignal('')
@@ -1124,7 +1155,10 @@ export const ChatView: Component<Props> = (props) => {
         onScroll={handleScroll}
         onClick={handleLinkClick}
       >
-      <div ref={contentRef} class="flex flex-col gap-2 pt-4 pb-6">
+      <div
+        ref={contentRef}
+        class={clsx('flex flex-col gap-2 pt-4', needsBtwPad() ? 'pb-16' : 'pb-6')}
+      >
         <For each={blocks}>
           {(block) => (
             <Switch>
@@ -1316,21 +1350,22 @@ export const ChatView: Component<Props> = (props) => {
       </div>
       </div>
       {(() => {
-        const hasAiTurn = () => props.output.some((i) => i.kind !== 'userMessage')
-        const showBtw = () =>
-          isAtBottom()
-          && props.agentType === 'claude'
-          && !!props.sessionId
-          && hasAiTurn()
-          && sideQuestionPanel()?.sessionId !== props.sessionId
-        const showScroll = () => !isAtBottom()
-        // Both buttons share the same bottom-right pivot so they appear to
-        // morph out of/into the same anchor point instead of cross-fading
-        // as two competing rectangles.
+        // Scroll-down chevron hides when the pill is "sticky" (loading/unread)
+        // so the two never stack in the same anchor point.
+        const showScroll = () => !isAtBottom() && !btwSticky()
         const morph =
           'absolute bottom-0 right-0 origin-bottom-right will-change-[transform,opacity] '
           + 'transition-[opacity,transform] duration-[260ms] '
           + 'ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none'
+        const onPillClick = () => {
+          const sid = props.sessionId
+          if (sid) openSideQuestion(sid)
+        }
+        const onDismissUnread = (e: MouseEvent) => {
+          e.stopPropagation()
+          const sid = props.sessionId
+          if (sid) dismissSideQuestionUnread(sid)
+        }
         return (
           <div class="absolute bottom-4 right-4 z-10 pointer-events-none">
             <button
@@ -1348,28 +1383,67 @@ export const ChatView: Component<Props> = (props) => {
             >
               <ChevronDown size={15} />
             </button>
-            <button
+            <div
               class={clsx(
                 morph,
-                'h-7 px-2.5 flex items-center gap-1.5 whitespace-nowrap rounded-full bg-surface-2 ring-1 ring-outline/10 shadow-lg text-text-dim hover:text-text-secondary hover:ring-outline/20 text-[11px]',
+                'h-7 flex items-stretch whitespace-nowrap rounded-full bg-surface-2 ring-1 shadow-lg text-[11px]',
+                btwMode() === 'unread'
+                  ? 'ring-accent/40 text-text-primary'
+                  : 'ring-outline/10 text-text-dim',
                 showBtw()
                   ? 'opacity-100 scale-100 pointer-events-auto'
                   : 'opacity-0 scale-75 pointer-events-none',
               )}
-              onClick={() => {
-                const sid = props.sessionId
-                if (sid) openSideQuestion(sid)
-              }}
-              title="Ask Claude an ephemeral side question (does not enter conversation history)"
               aria-hidden={!showBtw()}
-              tabindex={showBtw() ? 0 : -1}
             >
-              <MessageCircleQuestion size={12} />
-              <span>
-                Ask sideways{' '}
-                <code class="ml-0.5 px-1 py-0.5 rounded bg-surface-3 text-text-dim text-[9px]">/btw</code>
-              </span>
-            </button>
+              <button
+                class={clsx(
+                  'h-full px-2.5 flex items-center gap-1.5 rounded-l-full',
+                  btwMode() === 'unread' ? 'rounded-r-none' : 'rounded-r-full',
+                  btwMode() === 'unread'
+                    ? 'hover:bg-accent/10'
+                    : 'hover:text-text-secondary hover:ring-outline/20',
+                )}
+                onClick={onPillClick}
+                title={
+                  btwMode() === 'loading'
+                    ? 'Side question in progress - click to reopen'
+                    : btwMode() === 'unread'
+                      ? 'Answer ready - click to view'
+                      : 'Ask Claude an ephemeral side question (does not enter conversation history)'
+                }
+                tabindex={showBtw() ? 0 : -1}
+              >
+                <Switch>
+                  <Match when={btwMode() === 'loading'}>
+                    <Loader2 size={12} class="animate-spin" />
+                    <span>Asking sideways...</span>
+                  </Match>
+                  <Match when={btwMode() === 'unread'}>
+                    <Sparkles size={12} class="text-accent" />
+                    <span>Answer ready</span>
+                  </Match>
+                  <Match when={btwMode() === 'idle'}>
+                    <MessageCircleQuestion size={12} />
+                    <span>
+                      Ask sideways{' '}
+                      <code class="ml-0.5 px-1 py-0.5 rounded bg-surface-3 text-text-dim text-[9px]">/btw</code>
+                    </span>
+                  </Match>
+                </Switch>
+              </button>
+              <Show when={btwMode() === 'unread'}>
+                <button
+                  class="px-2 flex items-center text-text-dim hover:text-text-primary border-l-1 border-l-solid border-l-outline/15 rounded-r-full"
+                  onClick={onDismissUnread}
+                  title="Dismiss"
+                  aria-label="Dismiss answer notification"
+                  tabindex={showBtw() ? 0 : -1}
+                >
+                  <X size={12} />
+                </button>
+              </Show>
+            </div>
           </div>
         )
       })()}

--- a/src/components/SideQuestionPanel.tsx
+++ b/src/components/SideQuestionPanel.tsx
@@ -2,15 +2,14 @@ import { Component, createSignal, createEffect, on, onMount, onCleanup, Show } f
 import { Portal } from 'solid-js/web'
 import { X, Loader2, ArrowUp } from 'lucide-solid'
 import { clsx } from 'clsx'
-import { askSideQuestion } from '../lib/ipc'
 import { renderMarkdown, handleMarkdownLinkClick, getWorktreePath } from '../lib/markdown'
 import { registerDismissable } from '../lib/dismissable'
 import {
   closeSideQuestion,
-  getRememberedSideQuestion,
   rememberSideQuestion,
+  sideQuestionState,
+  submitSideQuestion,
 } from '../store/sideQuestion'
-import type { SideQuestionResponse } from '../types'
 
 interface Props {
   sessionId: string
@@ -24,40 +23,24 @@ interface Props {
 
 export const SideQuestionPanel: Component<Props> = (props) => {
   const [question, setQuestion] = createSignal('')
-  const [loading, setLoading] = createSignal(false)
-  const [answer, setAnswer] = createSignal<SideQuestionResponse | null | undefined>(undefined)
-  const [error, setError] = createSignal<string | null>(null)
   let inputRef: HTMLTextAreaElement | undefined
+
+  const stored = () => sideQuestionState(props.sessionId)
+  const loading = () => stored()?.loading ?? false
+  const answer = () => stored()?.answer
+  const error = () => stored()?.error ?? null
 
   const seed = (prefill: string | undefined, sessionId: string) => {
     if (prefill !== undefined) {
       setQuestion(prefill)
-      setAnswer(undefined)
-      setError(null)
       return
     }
-    const mem = getRememberedSideQuestion(sessionId)
-    if (mem) {
-      setQuestion(mem.question)
-      setAnswer(mem.answer ?? undefined)
-      setError(mem.error ?? null)
-    } else {
-      setQuestion('')
-      setAnswer(undefined)
-      setError(null)
-    }
+    const mem = sideQuestionState(sessionId)
+    setQuestion(mem?.question ?? '')
   }
 
   // Initial seed (synchronous so first paint has the right values).
   seed(props.prefill, props.sessionId)
-
-  const persist = () => {
-    rememberSideQuestion(props.sessionId, {
-      question: question(),
-      answer: answer() ?? null,
-      error: error(),
-    })
-  }
 
   const focusAndSelectAll = () => {
     if (!inputRef) return
@@ -71,23 +54,12 @@ export const SideQuestionPanel: Component<Props> = (props) => {
   const submit = async () => {
     const q = question().trim()
     if (!q || loading()) return
-    setError(null)
-    setAnswer(undefined)
-    setLoading(true)
     // Keep the question highlighted while the request is in flight so the
     // user can see what they asked and instantly retype to replace.
     inputRef?.focus()
     inputRef?.select()
-    try {
-      const result = await askSideQuestion(props.sessionId, q)
-      setAnswer(result)
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e))
-    } finally {
-      setLoading(false)
-      persist()
-      focusAndSelectAll()
-    }
+    await submitSideQuestion(props.sessionId, q)
+    focusAndSelectAll()
   }
 
   const onKeyDown = (e: KeyboardEvent) => {
@@ -105,7 +77,9 @@ export const SideQuestionPanel: Component<Props> = (props) => {
     const unregister = registerDismissable(closeSideQuestion)
     onCleanup(() => {
       unregister()
-      persist()
+      // Persist the question text so re-opening shows what the user typed.
+      // Loading/answer/error/unread are owned by the store, not us.
+      rememberSideQuestion(props.sessionId, { question: question() })
     })
     if (props.autoSubmit && question().trim()) {
       submit()

--- a/src/store/sideQuestion.test.ts
+++ b/src/store/sideQuestion.test.ts
@@ -1,0 +1,144 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+import { createRoot } from 'solid-js'
+
+// Resolver-controlled mock so we can observe in-flight state. `vi.hoisted`
+// is required because `vi.mock` factories are hoisted above module-level
+// code — using a closure variable directly would hit a TDZ error.
+const mocks = vi.hoisted(() => {
+  const state: {
+    pendingResolve: ((v: import('../types').SideQuestionResponse | null) => void) | null
+    pendingReject: ((e: unknown) => void) | null
+  } = { pendingResolve: null, pendingReject: null }
+  return {
+    state,
+    askSideQuestion: vi.fn(() =>
+      new Promise<import('../types').SideQuestionResponse | null>((resolve, reject) => {
+        state.pendingResolve = resolve
+        state.pendingReject = reject
+      }),
+    ),
+  }
+})
+
+vi.mock('../lib/ipc', () => ({
+  askSideQuestion: mocks.askSideQuestion,
+}))
+
+// Import after the mock is registered.
+import {
+  closeSideQuestion,
+  dismissSideQuestionUnread,
+  getRememberedSideQuestion,
+  openSideQuestion,
+  sideQuestionState,
+  submitSideQuestion,
+} from './sideQuestion'
+
+function nextTick() {
+  return new Promise(resolve => setTimeout(resolve, 0))
+}
+
+describe('sideQuestion store', () => {
+  beforeEach(() => {
+    mocks.state.pendingResolve = null
+    mocks.state.pendingReject = null
+    mocks.askSideQuestion.mockClear()
+    closeSideQuestion()
+  })
+
+  test('submitSideQuestion sets loading=true synchronously and clears unread', () => {
+    const sid = `s-${Math.random()}`
+    submitSideQuestion(sid, 'hi')
+    expect(sideQuestionState(sid)?.loading).toBe(true)
+    expect(sideQuestionState(sid)?.question).toBe('hi')
+    expect(sideQuestionState(sid)?.unread).toBe(false)
+    expect(sideQuestionState(sid)?.answer).toBeUndefined()
+  })
+
+  test('loading persists past closeSideQuestion (background request continues)', () => {
+    const sid = `s-${Math.random()}`
+    openSideQuestion(sid)
+    submitSideQuestion(sid, 'hi')
+    closeSideQuestion()
+    expect(sideQuestionState(sid)?.loading).toBe(true)
+  })
+
+  test('answer while panel closed marks unread=true and loading=false', async () => {
+    const sid = `s-${Math.random()}`
+    submitSideQuestion(sid, 'q')
+    // Panel never opened for this session — answer arrives "while closed".
+    mocks.state.pendingResolve!({ response: 'A', synthetic: false })
+    await nextTick()
+    const s = sideQuestionState(sid)
+    expect(s?.loading).toBe(false)
+    expect(s?.answer).toEqual({ response: 'A', synthetic: false })
+    expect(s?.unread).toBe(true)
+  })
+
+  test('answer while panel open for this session does NOT mark unread', async () => {
+    const sid = `s-${Math.random()}`
+    openSideQuestion(sid)
+    submitSideQuestion(sid, 'q')
+    mocks.state.pendingResolve!({ response: 'A', synthetic: false })
+    await nextTick()
+    expect(sideQuestionState(sid)?.unread).toBe(false)
+  })
+
+  test('error while panel closed also marks unread=true', async () => {
+    const sid = `s-${Math.random()}`
+    submitSideQuestion(sid, 'q')
+    mocks.state.pendingReject!(new Error('boom'))
+    await nextTick()
+    const s = sideQuestionState(sid)
+    expect(s?.loading).toBe(false)
+    expect(s?.error).toBe('boom')
+    expect(s?.unread).toBe(true)
+  })
+
+  test('dismissSideQuestionUnread clears unread but keeps answer', async () => {
+    const sid = `s-${Math.random()}`
+    submitSideQuestion(sid, 'q')
+    mocks.state.pendingResolve!({ response: 'A', synthetic: false })
+    await nextTick()
+    expect(sideQuestionState(sid)?.unread).toBe(true)
+    dismissSideQuestionUnread(sid)
+    expect(sideQuestionState(sid)?.unread).toBe(false)
+    expect(sideQuestionState(sid)?.answer).toEqual({ response: 'A', synthetic: false })
+  })
+
+  test('opening panel for an unread session clears unread', async () => {
+    const sid = `s-${Math.random()}`
+    submitSideQuestion(sid, 'q')
+    mocks.state.pendingResolve!({ response: 'A', synthetic: false })
+    await nextTick()
+    expect(sideQuestionState(sid)?.unread).toBe(true)
+    openSideQuestion(sid)
+    expect(sideQuestionState(sid)?.unread).toBe(false)
+  })
+
+  test('sideQuestionState reads are reactive inside createRoot', async () => {
+    const sid = `s-${Math.random()}`
+    const seen: (boolean | undefined)[] = []
+    createRoot(dispose => {
+      // Touch the field; createMemo/createEffect would track this. Using a
+      // bare read inside createRoot is enough to register a dependency when
+      // wrapped in an effect — but we just want to confirm transitions are
+      // observable without errors.
+      seen.push(sideQuestionState(sid)?.loading)
+      submitSideQuestion(sid, 'q')
+      seen.push(sideQuestionState(sid)?.loading)
+      dispose()
+    })
+    expect(seen[0]).toBeUndefined()
+    expect(seen[1]).toBe(true)
+  })
+
+  test('getRememberedSideQuestion is backward-compatible with existing callers', async () => {
+    const sid = `s-${Math.random()}`
+    submitSideQuestion(sid, 'hello')
+    expect(getRememberedSideQuestion(sid)?.question).toBe('hello')
+    mocks.state.pendingResolve!({ response: 'world', synthetic: false })
+    await nextTick()
+    expect(getRememberedSideQuestion(sid)?.answer).toEqual({ response: 'world', synthetic: false })
+  })
+})

--- a/src/store/sideQuestion.ts
+++ b/src/store/sideQuestion.ts
@@ -1,5 +1,7 @@
 import { createSignal } from 'solid-js'
+import { createStore, produce } from 'solid-js/store'
 import type { SideQuestionResponse } from '../types'
+import { askSideQuestion } from '../lib/ipc'
 
 interface PanelData {
   sessionId: string
@@ -14,10 +16,14 @@ export interface RememberedSideQuestion {
   question: string
   answer?: SideQuestionResponse | null
   error?: string | null
+  /** A request is in flight for this session, possibly with the panel closed. */
+  loading: boolean
+  /** An answer (or error) arrived while the panel was closed for this session. */
+  unread: boolean
 }
 
 const [panel, setPanel] = createSignal<PanelData | null>(null)
-const memory = new Map<string, RememberedSideQuestion>()
+const [memory, setMemory] = createStore<Record<string, RememberedSideQuestion>>({})
 let openCounter = 0
 
 /** Current panel data, or null when no panel is open. Drives both the
@@ -25,8 +31,19 @@ let openCounter = 0
 export const sideQuestionPanel = panel
 export const sideQuestionPanelData = panel
 
+/** Reactive accessor for a single session's side-question state. */
+export const sideQuestionState = (sessionId: string): RememberedSideQuestion | undefined =>
+  memory[sessionId]
+
+function blankState(question = ''): RememberedSideQuestion {
+  return { question, answer: undefined, error: null, loading: false, unread: false }
+}
+
 export function openSideQuestion(sessionId: string, prefill?: string, autoSubmit = false) {
   openCounter += 1
+  if (memory[sessionId]?.unread) {
+    setMemory(sessionId, 'unread', false)
+  }
   setPanel({ sessionId, prefill, autoSubmit, openId: openCounter })
 }
 
@@ -43,13 +60,48 @@ export function closeSideQuestion() {
 }
 
 export function getRememberedSideQuestion(sessionId: string): RememberedSideQuestion | undefined {
-  return memory.get(sessionId)
+  return memory[sessionId]
 }
 
-export function rememberSideQuestion(sessionId: string, state: RememberedSideQuestion) {
-  memory.set(sessionId, state)
+export function rememberSideQuestion(
+  sessionId: string,
+  partial: Partial<RememberedSideQuestion>,
+) {
+  setMemory(sessionId, prev => ({ ...(prev ?? blankState()), ...partial }))
 }
 
 export function forgetSideQuestion(sessionId: string) {
-  memory.delete(sessionId)
+  setMemory(produce(store => { delete store[sessionId] }))
+}
+
+export function dismissSideQuestionUnread(sessionId: string) {
+  if (memory[sessionId]) {
+    setMemory(sessionId, 'unread', false)
+  }
+}
+
+/** Kicks off a side question. Resolves when the request settles; safe to
+    ignore — the store tracks loading/answer/error/unread on its own so the
+    panel can unmount mid-flight and the pill can read the live state. */
+export async function submitSideQuestion(sessionId: string, question: string): Promise<void> {
+  setMemory(sessionId, { ...blankState(question), loading: true })
+  try {
+    const result = await askSideQuestion(sessionId, question)
+    const stillOpen = panel()?.sessionId === sessionId
+    setMemory(sessionId, prev => ({
+      ...(prev ?? blankState(question)),
+      loading: false,
+      answer: result,
+      error: null,
+      unread: !stillOpen,
+    }))
+  } catch (e) {
+    const stillOpen = panel()?.sessionId === sessionId
+    setMemory(sessionId, prev => ({
+      ...(prev ?? blankState(question)),
+      loading: false,
+      error: e instanceof Error ? e.message : String(e),
+      unread: !stillOpen,
+    }))
+  }
 }


### PR DESCRIPTION
- Store owns the in-flight request and per-session state via submitSideQuestion; closing the panel mid-flight no longer cancels the request
- Pill switches between idle / "Asking sideways..." / "Answer ready" modes, with an inline X to dismiss the unread notification without opening the panel
- Pill becomes sticky in loading/unread modes so notifications aren't hidden by scroll position; scroll-down chevron suppresses when sticky to avoid overlap
- Also: don't overlap the last user bubble when the agent is idle and the last rendered block is user-authored (e.g. after an interrupt)

## What does this PR do?

<!-- A brief description of the change and why it's needed. -->

## How to test

<!-- Steps for the reviewer to verify the change works. -->

## Checklist

- [ ] `make check` passes with zero errors and zero warnings
- [ ] Tested the feature end-to-end in `make dev`
- [ ] Updated CHANGELOG.md (if user-facing)
- [ ] Updated README.md (if a new feature or significant change)
