### PR TITLE
fix(notifications): prefer session name over task name when set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - "Ask sideways" pill no longer overlaps the last user bubble when the agent is idle and the user's message is the most recent one (e.g. after an interrupt) - the chat reserves extra bottom space in that case so the pill sits below the message
 - Side question requests now keep running in the background if the panel is closed mid-flight. The "Ask sideways" pill shows a spinner ("Asking sideways...") while a request is in progress, then switches to an "Answer ready" state (accent ring + sparkle icon) when the answer arrives while the panel is closed. Click the pill to reopen and view the answer, or the inline X to dismiss the notification without opening
+- Desktop notifications (task completed/failed, approval needed, question from task) now use the session name when set, falling back to the task name - gives precise context when a task has multiple named sessions (#247)
 
 ## 0.11.0 — 2026-05-12
 

--- a/src/store/sessions.test.ts
+++ b/src/store/sessions.test.ts
@@ -30,8 +30,27 @@ vi.mock('../lib/notifications', () => ({
 
 import { sessions, setSessions, outputItems, setOutputItems, sessionsForTask, sessionById, initSessionListeners, initSessionWindowFocusRefresh, loadSessions, loadOutputLines, loadOlderOutputLines, hasMoreOutputLines, clearOutputItems, closeSession, createSession, reopenSession, clearSessionContextsForTask, sessionCosts, setSessionCosts, sessionTokens, setSessionTokens, INITIAL_OUTPUT_LINES_LIMIT, OLDER_OUTPUT_PAGE_SIZE } from './sessions'
 import * as ipc from '../lib/ipc'
+import { setTasks } from './tasks'
+import { notify } from '../lib/notifications'
 import { setPlanFilePathForSession, planFilePathForSession, sessionContexts, setSessionContexts } from './sessionContext'
-import type { Session, OutputItem } from '../types'
+import type { Session, OutputItem, Task, ToolApprovalRequest } from '../types'
+
+const makeTask = (overrides: Partial<Task> = {}): Task => ({
+  id: 't-001',
+  projectId: 'p-001',
+  name: null,
+  worktreePath: '/tmp/wt',
+  branch: 'feature',
+  createdAt: 1000,
+  mergeBaseSha: null,
+  portOffset: 0,
+  archived: false,
+  archivedAt: null,
+  lastCommitMessage: null,
+  parentTaskId: null,
+  agentType: 'claude' as const,
+  ...overrides,
+})
 
 const makeSession = (overrides: Partial<Session> = {}): Session => ({
   id: 's-001',
@@ -592,5 +611,71 @@ describe('reopenSession', () => {
     })
     await reopenSession('s-race-reopen')
     expect(sessions.filter(x => x.id === 's-race-reopen').length).toBe(1)
+  })
+})
+
+// Issue #247 — notifications must prefer the session name over the task name
+// when the session has one, so a multi-session task gives precise context.
+describe('notification name selection', () => {
+  beforeAll(async () => {
+    await initSessionListeners()
+  })
+
+  beforeEach(() => {
+    setSessions([])
+    setTasks([])
+    vi.mocked(notify).mockClear()
+  })
+
+  test('session-status uses the session name when set', () => {
+    setTasks([makeTask({ id: 't-1', name: 'Refactor auth' })])
+    setSessions([makeSession({ id: 's-1', taskId: 't-1', name: 'Fix login retry', status: 'running' })])
+
+    listenCallbacks.get('session-status')!({ payload: { sessionId: 's-1', status: 'idle' } })
+
+    expect(notify).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(notify).mock.calls[0][0].body).toBe('Fix login retry')
+  })
+
+  test('session-status falls back to the task name when the session has no name', () => {
+    setTasks([makeTask({ id: 't-2', name: 'Refactor auth' })])
+    setSessions([makeSession({ id: 's-2', taskId: 't-2', name: null, status: 'running' })])
+
+    listenCallbacks.get('session-status')!({ payload: { sessionId: 's-2', status: 'idle' } })
+
+    expect(notify).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(notify).mock.calls[0][0].body).toBe('Refactor auth')
+  })
+
+  test('tool-approval-request uses the session name when set', () => {
+    setTasks([makeTask({ id: 't-3', name: 'Refactor auth' })])
+    setSessions([makeSession({ id: 's-3', taskId: 't-3', name: 'Fix login retry' })])
+    const req: ToolApprovalRequest = {
+      sessionId: 's-3',
+      requestId: 'r-1',
+      toolName: 'Bash',
+      toolInput: {},
+    }
+
+    listenCallbacks.get('tool-approval-request')!({ payload: req })
+
+    expect(notify).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(notify).mock.calls[0][0].body).toBe('Fix login retry: Bash')
+  })
+
+  test('tool-approval-request falls back to task name when session has no name', () => {
+    setTasks([makeTask({ id: 't-4', name: 'Refactor auth' })])
+    setSessions([makeSession({ id: 's-4', taskId: 't-4', name: null })])
+    const req: ToolApprovalRequest = {
+      sessionId: 's-4',
+      requestId: 'r-2',
+      toolName: 'Bash',
+      toolInput: {},
+    }
+
+    listenCallbacks.get('tool-approval-request')!({ payload: req })
+
+    expect(notify).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(notify).mock.calls[0][0].body).toBe('Refactor auth: Bash')
   })
 })

--- a/src/store/sessions.ts
+++ b/src/store/sessions.ts
@@ -464,10 +464,10 @@ export async function initSessionListeners() {
     if (wasRunning && (status === 'idle' || status === 'error') && prevSession) {
       markTaskUnread(prevSession.taskId)
       markSessionUnread(sessionId)
-      const taskName = taskById(prevSession.taskId)?.name || 'Task'
+      const displayName = prevSession.name || taskById(prevSession.taskId)?.name || 'Task'
       notify({
         title: status === 'error' ? 'Task failed' : 'Task completed',
-        body: taskName,
+        body: displayName,
         taskId: prevSession.taskId,
         sessionId,
       })
@@ -488,13 +488,13 @@ export async function initSessionListeners() {
     const session = sessions.find(s => s.id === req.sessionId)
     if (session) {
       markTaskAttention(session.taskId)
-      const taskName = taskById(session.taskId)?.name || 'Task'
+      const displayName = session.name || taskById(session.taskId)?.name || 'Task'
       const isQuestion = req.toolName === 'AskUserQuestion'
       notify({
         title: isQuestion ? 'Question from task' : 'Approval needed',
         body: isQuestion
-          ? `${taskName}: ${(req.toolInput?.question as string)?.slice(0, 100) || 'has a question'}`
-          : `${taskName}: ${req.toolName}`,
+          ? `${displayName}: ${(req.toolInput?.question as string)?.slice(0, 100) || 'has a question'}`
+          : `${displayName}: ${req.toolName}`,
         taskId: session.taskId,
         sessionId: req.sessionId,
       })


### PR DESCRIPTION
## Summary

- Desktop notifications (task completed/failed, approval needed, question from task) now use the session name when set, falling back to the task name.
- Multi-session tasks now get precise context per session instead of every session sharing the same task-name body.
- Both notification paths in `src/store/sessions.ts` (`session-status` and `tool-approval-request` listeners) updated.

Closes #247

## Test plan

- [x] `pnpm vitest run src/store/sessions.test.ts` - 39 passed
- [x] `pnpm check` - clean
- [x] TDD: 4 new tests cover both notification paths and both code paths (session name set / session name null → task-name fallback). Watched the two "session name set" tests fail with `received 'Refactor auth', expected 'Fix login retry'` before the fix.